### PR TITLE
Change generated gwblocks.pvlist file to be more selective

### DIFF
--- a/BlockServer/block_server.py
+++ b/BlockServer/block_server.py
@@ -210,7 +210,7 @@ class BlockServer(Driver):
             ca_server (CAServer) : The CA server used for generating PVs on the fly
         """
         super(BlockServer, self).__init__()
-        self._gateway = Gateway(GATEWAY_PREFIX, BLOCK_PREFIX, PVLIST_FILE)
+        self._gateway = Gateway(GATEWAY_PREFIX, BLOCK_PREFIX, PVLIST_FILE, MACROS["$(MYPVPREFIX)"])
         self._active_configserver = None
         self._status = "INITIALISING"
         self._ioc_control = IocControl(MACROS["$(MYPVPREFIX)"])

--- a/BlockServer/epics/gateway.py
+++ b/BlockServer/epics/gateway.py
@@ -54,7 +54,7 @@ EVALUATION ORDER DENY, ALLOW
 %sCS:GATEWAY:BLOCKSERVER:.*    				    ALLOW	ANYBODY	    1
 ## allow anybody to generate gateway reports 
 %sCS:GATEWAY:BLOCKSERVER:report[1-9]Flag		ALLOW	ANYBODY		1
-""" % ( self._pv_prefix, self._pv_prefix )
+""" % (self._pv_prefix, self._pv_prefix)
         f.write(header)
         if blocks is not None:
             for name, value in blocks.iteritems():
@@ -76,37 +76,46 @@ EVALUATION ORDER DENY, ALLOW
             lines.append("## The block points at a :SP, so it needs an optional group as genie_python will append an additional :SP\n")
             if local:
                 # Pattern match is for picking up any extras like :RBV or .EGU
-                lines.append('%s%s%s\(:SP\)?    ALIAS    %s%s\n' % (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv))
-                lines.append('%s%s%s\(:SP\)?\([.:].*\)    ALIAS    %s%s\\2\n' % (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv))
+                lines.append('%s%s%s\(:SP\)?    ALIAS    %s%s\n' %
+                             (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv))
+                lines.append('%s%s%s\(:SP\)?\([.:].*\)    ALIAS    %s%s\\2\n' % (self._pv_prefix, self._block_prefix,
+                                                                                 blockname, self._pv_prefix, pv))
             else:
                 # pv_prefix is hard-coded for non-local PVs
                 # Pattern match is for picking up any extras like :RBV or .EGU
                 lines.append('%s%s%s\(:SP\)?    ALIAS    %s\n' % (self._pv_prefix, self._block_prefix, blockname, pv))
-                lines.append('%s%s%s\(:SP\)?\([.:].*\)    ALIAS    %s\\2\n' % (self._pv_prefix, self._block_prefix, blockname, pv))
+                lines.append('%s%s%s\(:SP\)?\([.:].*\)    ALIAS    %s\\2\n' % (self._pv_prefix, self._block_prefix,
+                                                                               blockname, pv))
         elif pv.endswith(".RBV"):
             # The block points at a readback value (most likely for a motor)
             lines.append("## The block points at a .RBV, so it needs entries for both reading the RBV and for the rest\n")
             if local:
                 # Pattern match is for picking up any extras like :RBV or .EGU
-                lines.append('%s%s%s    ALIAS    %s%s\n' % (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv))
-                lines.append('%s%s%s\([.:].*\)    ALIAS    %s%s\\1\n' % (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv.rstrip(".RBV")))
+                lines.append('%s%s%s    ALIAS    %s%s\n' % (self._pv_prefix, self._block_prefix, blockname,
+                                                            self._pv_prefix, pv))
+                lines.append('%s%s%s\([.:].*\)    ALIAS    %s%s\\1\n' % (self._pv_prefix, self._block_prefix, blockname,
+                                                                         self._pv_prefix, pv.rstrip(".RBV")))
             else:
                 # pv_prefix is hard-coded for non-local PVs
                 # Pattern match is for picking up any extras like :RBV or .EGU
                 lines.append('%s%s%s    ALIAS    %s\n' % (self._pv_prefix, self._block_prefix, blockname, pv))
-                lines.append('%s%s%s\([.:].*\)    ALIAS    %s\\1\n' % (self._pv_prefix, self._block_prefix, blockname, pv.rstrip(".RBV")))
+                lines.append('%s%s%s\([.:].*\)    ALIAS    %s\\1\n' % (self._pv_prefix, self._block_prefix, blockname,
+                                                                       pv.rstrip(".RBV")))
         else:
             # Standard case
             lines.append("## Standard block with entries for matching :SP and :SP:RBV as well as .EGU\n")
             if local:
                 # Pattern match is for picking up any any SP or SP:RBV
-                lines.append('%s%s%s    ALIAS    %s%s\n' % (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv))
-                lines.append('%s%s%s\([.:].*\)    ALIAS    %s%s\\1\n' % (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv))
+                lines.append('%s%s%s    ALIAS    %s%s\n' % (self._pv_prefix, self._block_prefix, blockname,
+                                                            self._pv_prefix, pv))
+                lines.append('%s%s%s\([.:].*\)    ALIAS    %s%s\\1\n' % (self._pv_prefix, self._block_prefix, blockname,
+                                                                         self._pv_prefix, pv))
             else:
                 # pv_prefix is hard-coded for non-local PVs
                 # Pattern match is for picking up any any SP or SP:RBV
                 lines.append('%s%s%s    ALIAS    %s\n' % (self._pv_prefix, self._block_prefix, blockname, pv))
-                lines.append('%s%s%s\([.:].*\)    ALIAS    %s\\1\n' % (self._pv_prefix, self._block_prefix, blockname, pv))
+                lines.append('%s%s%s\([.:].*\)    ALIAS    %s\\1\n' % (self._pv_prefix, self._block_prefix, blockname,
+                                                                       pv))
         return lines
 
     def set_new_aliases(self, blocks):

--- a/BlockServer/epics/gateway.py
+++ b/BlockServer/epics/gateway.py
@@ -2,21 +2,22 @@ import time
 from server_common.channel_access import caget, caput
 from server_common.utilities import print_and_log
 
-
 class Gateway(object):
     """A class for interacting with the EPICS gateway that creates the aliases used for implementing blocks"""
 
-    def __init__(self, prefix, block_prefix, pvlist_file):
+    def __init__(self, prefix, block_prefix, pvlist_file, pv_prefix):
         """Constructor.
 
         Args:
             prefix (string) : The prefix for the gateway
             block_prefix (string) : The block prefix
             pvlist_file (string) : Where to write the gateway file
+            pv_prefix (string) : Prefix for instrument PVs
         """
         self._prefix = prefix
         self._block_prefix = block_prefix
         self._pvlist_file = pvlist_file
+        self._pv_prefix = pv_prefix
 
     def exists(self):
         """Checks the gateway exists by querying on of the PVs.
@@ -44,65 +45,69 @@ class Gateway(object):
     def _generate_alias_file(self, blocks=None):
         # Generate blocks.pvlist for gateway
         f = open(self._pvlist_file, 'w')
+        header = """\
+## Make ALLOW rules override DENY rules
+EVALUATION ORDER DENY, ALLOW
+## serve nothing by default, this is to avoid gateway loops
+.*												DENY
+## serve blockserver internal variables, including Flag variables needed by blockserver process to restart gateway
+%sCS:GATEWAY:BLOCKSERVER:.*    				    ALLOW	ANYBODY	    1
+## allow anybody to generate gateway reports 
+%sCS:GATEWAY:BLOCKSERVER:report[1-9]Flag		ALLOW	ANYBODY		1
+""" % ( self._pv_prefix, self._pv_prefix )
+        f.write(header)
         if blocks is not None:
             for name, value in blocks.iteritems():
                 lines = self._generate_alias(value.name, value.pv, value.local)
                 for l in lines:
                     f.write(l)
-        # Allow the gateway diagnostic PVs through
-        # f.write(self._gateway_prefix + '.* ALLOW \n')
-        f.write('.*:CS:GATEWAY:.*    ALLOW\n')
         # Add a blank line at the end!
         f.write("\n")
         f.close()
 
     def _generate_alias(self, blockname, pv, local):
         print("Creating block: %s for %s" % (blockname, pv))
+        lines = list()
         if pv.endswith(".VAL"):
             # Strip off the .VAL
             pv = pv.rstrip(".VAL")
         if pv.endswith(":SP"):
             # The block points at a setpoint
-            lines = list()
-            lines.append("# The block points at a :SP, so it needs an optional group as genie_python will append an additional :SP\n")
+            lines.append("## The block points at a :SP, so it needs an optional group as genie_python will append an additional :SP\n")
             if local:
-                # First pattern match is used for getting the prefix (e.g. MYPVPREFIX)
-                # The 2nd is for picking up any extras like :RBV or .EGU
-                lines.append('\(.*\)%s%s\(:SP\)?\(.*\)    ALIAS    \\1%s\\3\n' % (self._block_prefix, blockname, pv))
-                return lines
+                # Pattern match is for picking up any extras like :RBV or .EGU
+                lines.append('%s%s%s\(:SP\)?    ALIAS    %s%s\n' % (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv))
+                lines.append('%s%s%s\(:SP\)?\([.:].*\)    ALIAS    %s%s\\2\n' % (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv))
             else:
-                # First pattern match is ignored as the prefix is hard-coded for non-local PVs
-                # The 2nd is for picking up any extras like :RBV or .EGU
-                lines.append('\(.*\)%s%s\(:SP\)?\(.*\)    ALIAS    %s\\3\n' % (self._block_prefix, blockname, pv))
-                return lines
+                # pv_prefix is hard-coded for non-local PVs
+                # Pattern match is for picking up any extras like :RBV or .EGU
+                lines.append('%s%s%s\(:SP\)?    ALIAS    %s\n' % (self._pv_prefix, self._block_prefix, blockname, pv))
+                lines.append('%s%s%s\(:SP\)?\([.:].*\)    ALIAS    %s\\2\n' % (self._pv_prefix, self._block_prefix, blockname, pv))
         elif pv.endswith(".RBV"):
             # The block points at a readback value (most likely for a motor)
-            lines = list()
-            lines.append("# The block points at a .RBV, so it needs two entries one for reading the RBV and one for the rest\n")
+            lines.append("## The block points at a .RBV, so it needs entries for both reading the RBV and for the rest\n")
             if local:
-                # First pattern match is used for getting the prefix (e.g. MYPVPREFIX)
-                # The 2nd is for picking up any extras like .EGU
-                lines.append('\(.*\)%s%s    ALIAS    \\1%s\n' % (self._block_prefix, blockname, pv))
-                lines.append('\(.*\)%s%s\(.+\)    ALIAS    \\1%s\\2\n' % (self._block_prefix, blockname,
-                                                                          pv.rstrip(".RBV")))
-                return lines
+                # Pattern match is for picking up any extras like :RBV or .EGU
+                lines.append('%s%s%s    ALIAS    %s%s\n' % (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv))
+                lines.append('%s%s%s\([.:].*\)    ALIAS    %s%s\\1\n' % (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv.rstrip(".RBV")))
             else:
-                # First pattern match is ignored as the prefix is hard-coded for non-local PVs
-                # The 2nd is for picking up any extras like :RBV or .EGU
-                lines.append('\(.*\)%s%s    ALIAS    %s\n' % (self._block_prefix, blockname, pv))
-                lines.append('\(.*\)%s%s\(.+\)    ALIAS    %s\\2\n' % (self._block_prefix, blockname,
-                                                                       pv.rstrip(".RBV")))
-                return lines
+                # pv_prefix is hard-coded for non-local PVs
+                # Pattern match is for picking up any extras like :RBV or .EGU
+                lines.append('%s%s%s    ALIAS    %s\n' % (self._pv_prefix, self._block_prefix, blockname, pv))
+                lines.append('%s%s%s\([.:].*\)    ALIAS    %s\\1\n' % (self._pv_prefix, self._block_prefix, blockname, pv.rstrip(".RBV")))
         else:
             # Standard case
+            lines.append("## Standard block with entries for matching :SP and :SP:RBV as well as .EGU\n")
             if local:
-                # First pattern match is used for getting the prefix (e.g. MYPVPREFIX)
-                # The 2nd is for picking up any SP or SP:RBV
-                return ['\(.*\)%s%s\(.*\)    ALIAS    \\1%s\\2\n' % (self._block_prefix, blockname, pv)]
+                # Pattern match is for picking up any any SP or SP:RBV
+                lines.append('%s%s%s    ALIAS    %s%s\n' % (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv))
+                lines.append('%s%s%s\([.:].*\)    ALIAS    %s%s\\1\n' % (self._pv_prefix, self._block_prefix, blockname, self._pv_prefix, pv))
             else:
-                # First pattern match is ignored as the prefix is hard-coded for non-local PVs
-                # The 2nd is for picking up any SP or SP:RBV
-                return ['\(.*\)%s%s\(.*\)    ALIAS    %s\\2\n' % (self._block_prefix, blockname, pv)]
+                # pv_prefix is hard-coded for non-local PVs
+                # Pattern match is for picking up any any SP or SP:RBV
+                lines.append('%s%s%s    ALIAS    %s\n' % (self._pv_prefix, self._block_prefix, blockname, pv))
+                lines.append('%s%s%s\([.:].*\)    ALIAS    %s\\1\n' % (self._pv_prefix, self._block_prefix, blockname, pv))
+        return lines
 
     def set_new_aliases(self, blocks):
         """Creates the aliases for the blocks and restarts the gateway.


### PR DESCRIPTION
The generated gwblock.pvlist used wildcards and so could match
name queries from other instrumemnts that got forwarded on.
This was not a real problem when the block gateway was purely
on localhost network, but as it can now resolve off instrumement
e.g. for beam currrent it needs to be much more selective