### PR TITLE
Save config crashes if a component was not loaded

### DIFF
--- a/BlockServer/core/config_list_manager.py
+++ b/BlockServer/core/config_list_manager.py
@@ -175,8 +175,10 @@ class ConfigListManager(object):
         configs = []
         if name in self._comp_dependecncies.keys():
             configs = self._comp_dependecncies[name]
-        self._ca_server.updatePV(self._subconfig_metas[name].pv + DEPENDENCIES_PV,
-                                 compress_and_hex(json.dumps(configs)))
+        if name in self._subconfig_metas.keys():
+            # Check just in case sub-config failed to load
+            self._ca_server.updatePV(self._subconfig_metas[name].pv + DEPENDENCIES_PV,
+                                     compress_and_hex(json.dumps(configs)))
 
     def _update_config_pv(self, name, data):
         # Updates pvs with new data


### PR DESCRIPTION
If a component failed to load because it was invalid then it won't appear in the list of subconfig metas. When a configuration using this component is saved the BlockServer throws an uncaught error

<BOOM!>