### PR TITLE
Ticket951 Git Failure No Longer Crashes Blockserver

### DIFF
--- a/BlockServer/block_server.py
+++ b/BlockServer/block_server.py
@@ -216,6 +216,9 @@ class BlockServer(Driver):
         except NotUnderVersionControl as err:
             print_and_log("Warning: Configurations not under version control", "INFO")
             self._vc = MockVersionControl()
+        except Exception as err:
+            print_and_log("Version control failed: " + str(err), "INFO")
+            self._vc = MockVersionControl()
 
         # Import data about all configs
         try:


### PR DESCRIPTION
To test:
* Point the remote of your configurations repository to a bad link
* Start the blockserver, confirm that a warning message is logged but otherwise the BlockServer functions normally