### PR TITLE
Changed 1 and 0 to True and False for clarity

### DIFF
--- a/BlockServer/core/runcontrol.py
+++ b/BlockServer/core/runcontrol.py
@@ -100,9 +100,9 @@ class RunControlManager(object):
         for n, blk in blocks.iteritems():
             settings = dict()
             if blk.rc_enabled:
-                settings["ENABLE"] = 1
+                settings["ENABLE"] = True
             else:
-                settings["ENABLE"] = 0
+                settings["ENABLE"] = False
             if blk.rc_lowlimit is not None:
                 settings["LOW"] = blk.rc_lowlimit
             if blk.rc_highlimit is not None:


### PR DESCRIPTION
After updating the block server check that setting run control enabled/disabled on blocks works correctly, for old and newly created configuratinos, and the unit tests pass.