### PR TITLE
Ticket 998: Auto-restart should now work

### DIFF
--- a/BlockServer/blockserver_docs/configuration_rules.rst
+++ b/BlockServer/blockserver_docs/configuration_rules.rst
@@ -43,7 +43,7 @@ Components
 ----------
 
 #. Components cannot contain other components
-#. A component groups cannot contain blocks that are not in that component
+#. A component group cannot contain blocks that are not in that component
 #. When a component is loaded as part of a configuration its IOCs are started if they are not already started
 #. Components cannot be loaded on their own only as part of a configuration
 
@@ -53,4 +53,5 @@ IOCs
 
 #. If an IOC's macros or pvsets changes then restart the IOC on a configuration change
 #. It should be possible to force IOCs to restart on a configuration change even if the macros or pvsets have not changed
+#. An IOC is only included in a configuration/component if its auto-start setting is true
 

--- a/BlockServer/core/active_config_holder.py
+++ b/BlockServer/core/active_config_holder.py
@@ -155,7 +155,7 @@ class ActiveConfigHolder(ConfigHolder):
         iocs_to_start = list()
         iocs_to_restart = list()
 
-        # Check to see if any macros, pvs, pvsets have changed
+        # Check to see if any macros, pvs, pvsets etc. have changed
         for n in self._config.iocs.keys():
             if n not in self._cached_config.iocs.keys():
                 # If not in previously then add it to start
@@ -179,6 +179,12 @@ class ActiveConfigHolder(ConfigHolder):
             if cmp(old_pvsets, new_pvsets) != 0:
                 if n not in iocs_to_restart:
                     iocs_to_restart.append(n)
+            # Auto-restart changed
+            if n in self._cached_config.iocs.keys() and \
+                            self._config.iocs[n].restart != self._cached_config.iocs[n].restart:
+                # If not in previously then add it to start
+                iocs_to_restart.append(n)
+                continue
 
         # Look for any new components
         for cn, cv in self._components.iteritems():

--- a/BlockServer/core/config_holder.py
+++ b/BlockServer/core/config_holder.py
@@ -217,7 +217,7 @@ class ConfigHolder(object):
         Returns:
             dict : A copy of all the IOC details
         """
-        # TODO: make sure iocs are from default are returned
+        # TODO: make sure iocs from default are returned
         iocs = copy.deepcopy(self._config.iocs)
         for cn, cv in self._components.iteritems():
             for n, v in cv.iocs.iteritems():

--- a/BlockServer/epics/procserv_utils.py
+++ b/BlockServer/epics/procserv_utils.py
@@ -18,8 +18,7 @@ class ProcServWrapper(object):
         """
         return "%sCS:PS:%s" % (prefix, ioc)
 
-    @staticmethod
-    def start_ioc(prefix, ioc):
+    def start_ioc(self, prefix, ioc):
         """Starts the specified IOC.
 
         Args:
@@ -27,7 +26,7 @@ class ProcServWrapper(object):
             ioc (string) : The name of the IOC
         """
         print_and_log("Starting IOC %s" % ioc)
-        caput(ProcServWrapper.generate_prefix(prefix, ioc) + ":START", 1)
+        caput(self.generate_prefix(prefix, ioc) + ":START", 1)
 
     def stop_ioc(self, prefix, ioc):
         """Stops the specified IOC.
@@ -55,8 +54,42 @@ class ProcServWrapper(object):
         Args:
             prefix (string) : The prefix for the instrument
             ioc (string) : The name of the IOC
+
+        Returns:
+            string : The status
         """
         ans = caget(self.generate_prefix(prefix, ioc) + ":STATUS", as_string=True)
         if ans is None:
             raise Exception("Could not find IOC (%s)" % self.generate_prefix(prefix, ioc))
         return ans.upper()
+
+    def toggle_autorestart(self, prefix, ioc):
+        """Toggles the auto-restart property.
+
+        Args:
+            prefix (string) : The prefix for the instrument
+            ioc (string) : The name of the IOC
+        """
+        # Check IOC is running, otherwise command is ignored
+        print_and_log("Toggling auto-restart for IOC %s" % ioc)
+        caput(self.generate_prefix(prefix, ioc) + ":TOGGLE", 1)
+
+    def get_autorestart(self, prefix, ioc):
+        """Gets the current auto-restart setting of the specified IOC.
+
+        Args:
+            prefix (string) : The prefix for the instrument
+            ioc (string) : The name of the IOC
+
+        Returns:
+            bool : Whether auto-restart is enabled
+        """
+        ans = caget(self.generate_prefix(prefix, ioc) + ":AUTORESTART", as_string=True)
+        if ans is None:
+            raise Exception("Could not find IOC (%s)" % self.generate_prefix(prefix, ioc))
+        elif ans == "On":
+            return True
+        elif ans == "Off":
+            return False
+        else:
+            raise Exception("Could not get auto-restart property for IOC (%s)" % self.generate_prefix(prefix, ioc))

--- a/BlockServer/mocks/mock_procserv_utils.py
+++ b/BlockServer/mocks/mock_procserv_utils.py
@@ -6,6 +6,7 @@ class MockProcServWrapper(object):
         self.ps_status["simple1"] = "SHUTDOWN"
         self.ps_status["simple2"] = "SHUTDOWN"
         self.ps_status["testioc"] = "SHUTDOWN"
+        self.autorestart = False
 
     @staticmethod
     def generate_prefix(prefix, ioc):
@@ -33,3 +34,9 @@ class MockProcServWrapper(object):
             return True
         except:
             return False
+
+    def get_autorestart(self, prefix, ioc):
+        return self.autorestart
+
+    def toggle_autorestart(self, prefix, ioc):
+        self.autorestart = not self.autorestart

--- a/BlockServer/test_modules/ioc_control_tests.py
+++ b/BlockServer/test_modules/ioc_control_tests.py
@@ -56,3 +56,11 @@ class TestIocControlSequence(unittest.TestCase):
     def test_ioc_exists(self):
         ic = IocControl("", MockProcServWrapper())
         self.assertTrue(ic.ioc_exists("TESTIOC"))
+
+    def test_set_autorestart_works(self):
+        ic = IocControl("", MockProcServWrapper())
+        ic.start_ioc("TESTIOC")
+        ic.set_autorestart("TESTIOC", True)
+        self.assertEqual(ic.get_autorestart("TESTIOC"), True)
+        ic.set_autorestart("TESTIOC", False)
+        self.assertEqual(ic.get_autorestart("TESTIOC"), False)


### PR DESCRIPTION
To test:

From the GUI create a new config with an IOC (TPG300_01 is a good choice) set to auto-start and auto-restart. Save it as "restart"

Edit it and uncheck auto-restart and save as "norestart"

From the command line, start a monitor: 
camonitor %MYPVPREFIX%CS:PS:TPG300_01:AUTORESTART

Open another command line and connect to the TPG300_01 console:
console -M localhost TPG300_01

Load the "restart" configuration. The monitor should report AUTORESTART as On. The IOC should be running and if you stop it, it restarts.

Load the "norestart" configuration. The monitor should report AUTORESTART as Off. The IOC should be running and if you stop it, it DOES NOT restart.

