### PR TITLE
Ticket1026 IOCs for components

### DIFF
--- a/BlockServer/block_server.py
+++ b/BlockServer/block_server.py
@@ -560,6 +560,10 @@ class BlockServer(Driver):
         finally:
             self._filewatcher.resume()
 
+        # Reload configuration if a component has changed
+        if (as_subconfig) and (new_details["name"] in self._active_configserver.get_component_names()):
+            self.load_last_config()
+
     def _get_inactive_history(self, name, is_component=False):
         # If it already exists load it
         try:

--- a/BlockServer/block_server.py
+++ b/BlockServer/block_server.py
@@ -476,7 +476,7 @@ class BlockServer(Driver):
         # Start the IOCs, if they are available and if they are flagged for autostart
         # Note: autostart means the IOC is started when the config is loaded,
         # restart means the IOC should automatically restart if it stops for some reason (e.g. it crashes)
-        for n, ioc in self._active_configserver.get_ioc_details().iteritems():
+        for n, ioc in self._active_configserver.get_all_ioc_details().iteritems():
             try:
                 # If autostart is not set to True then the IOC is not part of the configuration
                 if ioc.autostart:
@@ -716,7 +716,7 @@ class BlockServer(Driver):
         # If the IOC is in the config and auto-restart is set to true then
         # reapply the auto-restart setting after starting.
         # This is because stopping an IOC via procServ turns auto-restart off.
-        conf_iocs = self._active_configserver.get_ioc_details()
+        conf_iocs = self._active_configserver.get_all_ioc_details()
         for i in iocs:
             self._ioc_control.start_ioc(i)
             # Is IOC in config?

--- a/BlockServer/config/configuration.py
+++ b/BlockServer/config/configuration.py
@@ -29,6 +29,7 @@ class Configuration(object):
         self.macros = macros
         self.groups = OrderedDict()
         self.iocs = OrderedDict()
+        self.component_iocs = OrderedDict()
         self.meta = MetaData("")
         self.subconfigs = OrderedDict()
         self.is_component = False
@@ -75,7 +76,11 @@ class Configuration(object):
         """
         # Only add it if it has not been added before
         if not name.upper() in self.iocs.keys():
-            self.iocs[name.upper()] = IOC(name, autostart, restart, subconfig, macros, pvs, pvsets, simlevel)
+            if subconfig is None:
+                self.iocs[name.upper()] = IOC(name, autostart, restart, subconfig, macros, pvs, pvsets, simlevel)
+            else:
+                self.component_iocs[name.upper()] = IOC(name, autostart, restart, subconfig, macros, pvs, pvsets,
+                                                        simlevel)
 
     def update_runcontrol_settings_for_saving(self, rc_data):
         """ Updates the run-control settings for the configuration's blocks.

--- a/BlockServer/config/configuration.py
+++ b/BlockServer/config/configuration.py
@@ -29,7 +29,6 @@ class Configuration(object):
         self.macros = macros
         self.groups = OrderedDict()
         self.iocs = OrderedDict()
-        self.component_iocs = OrderedDict()
         self.meta = MetaData("")
         self.subconfigs = OrderedDict()
         self.is_component = False
@@ -76,11 +75,7 @@ class Configuration(object):
         """
         # Only add it if it has not been added before
         if not name.upper() in self.iocs.keys():
-            if subconfig is None:
-                self.iocs[name.upper()] = IOC(name, autostart, restart, subconfig, macros, pvs, pvsets, simlevel)
-            else:
-                self.component_iocs[name.upper()] = IOC(name, autostart, restart, subconfig, macros, pvs, pvsets,
-                                                        simlevel)
+            self.iocs[name.upper()] = IOC(name, autostart, restart, subconfig, macros, pvs, pvsets, simlevel)
 
     def update_runcontrol_settings_for_saving(self, rc_data):
         """ Updates the run-control settings for the configuration's blocks.

--- a/BlockServer/config/xml_converter.py
+++ b/BlockServer/config/xml_converter.py
@@ -108,8 +108,8 @@ class ConfigurationXmlConverter(object):
         root.attrib["xmlns"] = SCHEMA_PATH + COMPONENT_SCHEMA
         root.attrib["xmlns:comp"] = SCHEMA_PATH + COMPONENT_SCHEMA
         root.attrib["xmlns:xi"] = "http://www.w3.org/2001/XInclude"
-        for name, sub in comps.iteritems():
-            ConfigurationXmlConverter._subconfig_to_xml(root, name)
+        for name, case_sensitve_name in comps.iteritems():
+            ConfigurationXmlConverter._subconfig_to_xml(root, case_sensitve_name)
         return minidom.parseString(ElementTree.tostring(root)).toprettyxml()
 
     @staticmethod
@@ -378,7 +378,7 @@ class ConfigurationXmlConverter(object):
         for i in subconfigs_xml:
             n = i.attrib[TAG_NAME]
             if n is not None and n != "":
-                subconfigs[n.lower()] = None
+                subconfigs[n.lower()] = n
 
     @staticmethod
     def meta_from_xml(root_xml, data):

--- a/BlockServer/core/config_holder.py
+++ b/BlockServer/core/config_holder.py
@@ -212,17 +212,31 @@ class ConfigHolder(object):
         return iocs
 
     def get_ioc_details(self):
-        """ Get the details of the IOCs in the configuration and any components.
+        """ Get the details of the IOCs in the configuration.
+
+        Returns:
+            dict : A copy of all the configuration IOC details
+        """
+        iocs = copy.deepcopy(self._config.iocs)
+        return iocs
+
+    def get_component_ioc_details(self):
+        """ Get the details of the IOCs in any components.
+
+        Returns:
+            dict : A copy of all the component IOC details
+        """
+        iocs = copy.deepcopy(self._config.component_iocs)
+        return iocs
+
+    def get_all_ioc_details(self):
+        """  Ge the details of the IOCs in the configuration and any components.
 
         Returns:
             dict : A copy of all the IOC details
         """
-        # TODO: make sure iocs from default are returned
-        iocs = copy.deepcopy(self._config.iocs)
-        for cn, cv in self._components.iteritems():
-            for n, v in cv.iocs.iteritems():
-                if n not in iocs:
-                    iocs[n] = v
+        iocs = self.get_ioc_details()
+        iocs.update(self.get_component_ioc_details())
         return iocs
 
     def get_component_names(self, include_base=False):
@@ -274,6 +288,7 @@ class ConfigHolder(object):
         config['blocks'] = self._blocks_to_list(True)
         config['groups'] = self._groups_to_list()
         config['iocs'] = self._iocs_to_list()
+        config['component_iocs'] = self._iocs_to_list_with_components()
         # Just return the names of the components
         config['components'] = self._comps_to_list()
         config['name'] = self._config.get_name()
@@ -319,6 +334,11 @@ class ConfigHolder(object):
         ioc_list = list()
         for n, ioc in self._config.iocs.iteritems():
             ioc_list.append(ioc.to_dict())
+
+        return ioc_list
+
+    def _iocs_to_list_with_components(self):
+        ioc_list = self._iocs_to_list()
 
         for cn, cv in self._components.iteritems():
             for n, ioc in cv.iocs.iteritems():

--- a/BlockServer/core/config_holder.py
+++ b/BlockServer/core/config_holder.py
@@ -74,7 +74,7 @@ class ConfigHolder(object):
             # Add it
             component.set_name(name)
             self._components[name.lower()] = component
-            self._config.subconfigs[name.lower()] = None  # Does not need to actual hold anything
+            self._config.subconfigs[name.lower()] = name  # Only needs its case sensitive name name
         else:
             raise Exception("Requested component is already part of the configuration: " + str(name))
 
@@ -226,7 +226,11 @@ class ConfigHolder(object):
         Returns:
             dict : A copy of all the component IOC details
         """
-        iocs = copy.deepcopy(self._config.component_iocs)
+        iocs = {}
+        for cn, cv in self._components.iteritems():
+            for n, v in cv.iocs.iteritems():
+                if n not in iocs:
+                     iocs[n] = v
         return iocs
 
     def get_all_ioc_details(self):
@@ -249,11 +253,9 @@ class ConfigHolder(object):
             list : A list of components in the configuration
         """
         l = list()
-        for cn in self._components.keys():
-            if include_base:
-                l.append(cn)
-            elif cn.lower() != DEFAULT_COMPONENT.lower():
-                l.append(cn)
+        for cn, cv in self._components.iteritems():
+            if (include_base) or (cn.lower() != DEFAULT_COMPONENT.lower()):
+                l.append(cv.get_name())
         return l
 
     def add_block(self, blockargs):
@@ -393,7 +395,7 @@ class ConfigHolder(object):
                 # List of dicts
                 for args in details["components"]:
                     comp = self.load_configuration(args['name'], True)
-                    self.add_subconfig(args['name'], comp)
+                    self.add_subconfig(comp.get_name(), comp)
         except Exception as err:
             self._retrieve_cache()
             raise err
@@ -420,8 +422,8 @@ class ConfigHolder(object):
         if not is_component:
             for n, v in config.subconfigs.iteritems():
                 if n.lower() != DEFAULT_COMPONENT.lower():
-                    comp = self.load_configuration(n, True)
-                    self.add_subconfig(n, comp)
+                    comp = self.load_configuration(v.lower(), True)
+                    self.add_subconfig(v, comp)
             # add default subconfig to list of subconfigs
             basecomp = self.load_configuration(DEFAULT_COMPONENT, True)
             self.add_subconfig(DEFAULT_COMPONENT, basecomp)

--- a/BlockServer/core/config_list_manager.py
+++ b/BlockServer/core/config_list_manager.py
@@ -203,9 +203,10 @@ class ConfigListManager(object):
             if is_subconfig:
                 self._block_server.update_comp_monitor()
                 if config.get_config_name().lower() in [x.lower() for x in self.active_components]:
-                    print_and_log("Active component edited in filesystem, reload to receive changes",
+                    print_and_log("Active component edited in filesystem, reloading to get changes",
                                   src="FILEWTCHR")
                     self.set_active_changed(True)
+                    self._block_server.load_last_config()
             else:
                 self._block_server.update_config_monitors()
                 if config.get_config_name().lower() == self.active_config_name.lower():

--- a/BlockServer/mocks/mock_block_server.py
+++ b/BlockServer/mocks/mock_block_server.py
@@ -22,3 +22,6 @@ class MockBlockServer(object):
 
     def update_synoptic_monitor(self):
         pass
+
+    def load_last_config(self):
+        pass

--- a/BlockServer/test_modules/config_holder_tests.py
+++ b/BlockServer/test_modules/config_holder_tests.py
@@ -203,7 +203,7 @@ class TestConfigHolderSequence(unittest.TestCase):
 
         subs = ch.get_component_names()
         self.assertEqual(len(subs), 1)
-        self.assertTrue("TESTSUBCONFIG".lower() in subs)
+        self.assertTrue("TESTSUBCONFIG" in subs)
 
     def test_dummy_config_components_add_remove_subconfig(self):
         ch = ConfigHolder(CONFIG_PATH, MACROS, MockVersionControl(), test_config=create_dummy_config())
@@ -294,9 +294,9 @@ class TestConfigHolderSequence(unittest.TestCase):
         self.assertEqual(len(details['groups']), 2)
         self.assertEqual(details['groups'][0]['blocks'], ["SUBBLOCK1"])
         self.assertEqual(details['groups'][1]['blocks'], ["SUBBLOCK2"])
-        self.assertEqual(len(details['iocs']), 1)
+        self.assertEqual(len(details['iocs']), 0)
         iocs = [x['name'] for x in details['iocs']]
-        self.assertTrue("SUBSIMPLE1" in iocs)
+        self.assertFalse("SUBSIMPLE1" in iocs)
         self.assertEqual(len(details['components']), 1)
 
     def test_empty_config_save_and_load(self):

--- a/BlockServer/test_modules/config_list_manager_tests.py
+++ b/BlockServer/test_modules/config_list_manager_tests.py
@@ -538,7 +538,7 @@ class TestInactiveConfigsSequence(unittest.TestCase):
 
         confs = json.loads(dehex_and_decompress(ms.pv_list.get("TEST_SUBCONFIG1:" + DEPENDENCIES_PV)))
         self.assertEqual(len(confs), 1)
-        self.assertTrue("TEST_INACTIVE".lower() in confs)
+        self.assertTrue("TEST_INACTIVE" in confs)
 
     def test_dependencies_updates_remove(self):
         create_subconfigs(["TEST_SUBCONFIG1"])


### PR DESCRIPTION
To test this:
* Create a component and add one or more IOCs. Check the xml for the component is saved with the IOCs.
* Add this component to a configuration. Make sure that configuration does not have the IOCs that are contained in the component.
* Check the configuration does not save the component IOCs.
* Check adding Macros, PV Values or PV Sets saves them to the configuration or component, depending on where the change occurs.

As part of this ticket an issue with capitalisation of component names was fixed. To test this:
* Check capitalisation is obeyed when adding a component and reloading a configuration.
* Check configurations with components behave as expected when adding and deleting.
* Check that `caget %MYPVPREFIX%CS:BLOCKSERVER:COMPONENT_NAME:DEPENDENCIES` behaves correctly when adding and removing components from configurations.
