### PR TITLE
Updated Linux startup script for new synoptic schema location

### DIFF
--- a/start_blockserver_cmd.sh
+++ b/start_blockserver_cmd.sh
@@ -23,5 +23,5 @@ fi
 
 export MYDIRVC="$MYDIRBLOCK/../../ConfigVersionControl/master"
 
-python "$MYDIRBLOCK/BlockServer/block_server.py" -od "$MYDIRBLOCK/../../../iocstartup" -sd "$MYDIRBLOCK/../../../schema/configurations" -cd "$ICPCONFIGROOT" -pv "$GWBLOCK_PVLIST" -f ISIS
+python "$MYDIRBLOCK/BlockServer/block_server.py" -od "$MYDIRBLOCK/../../../iocstartup" -sd "$MYDIRBLOCK/schema" -cd "$ICPCONFIGROOT" -pv "$GWBLOCK_PVLIST" -f ISIS
 


### PR DESCRIPTION
The location of the synoptic.xsd schema file was changed in https://github.com/ISISComputingGroup/EPICS-inst_servers/pull/32.

This PR updates the startup shell script to mirror the changes made to the startup batch file.