### PR TITLE
Ticket 1122: Blockserver makes screens schema available as PV

### DIFF
--- a/BlockServer/block_server.py
+++ b/BlockServer/block_server.py
@@ -217,6 +217,11 @@ PVDB = {
         'type': 'char',
         'count': 16000,
         'value': [0],
+    },
+    BlockserverPVNames.SCREENS_SCHEMA: {
+        'type': 'char',
+        'count': 16000,
+        'value': [0],
     }
 }
 
@@ -345,6 +350,8 @@ class BlockServer(Driver):
                 value = compress_and_hex(self._syn.get_synoptic_schema())
             elif reason == BlockserverPVNames.BUMPSTRIP_AVAILABLE:
                 value = compress_and_hex(self.bumpstrip)
+            elif reason == BlockserverPVNames.SCREENS_SCHEMA:
+                value = compress_and_hex(self._devices.get_devices_schema())
             else:
                 value = self.getParam(reason)
         except Exception as err:

--- a/BlockServer/core/devices_manager.py
+++ b/BlockServer/core/devices_manager.py
@@ -144,6 +144,17 @@ class DevicesManager(object):
         if commit_message is not None:
             self._vc.commit(commit_message)
 
+    def get_devices_schema(self):
+        """Gets the XSD data for the devices screens.
+
+        Returns:
+            string : The XML for the devices screens schema
+        """
+        schema = ""
+        with open(os.path.join(self._schema_folder, SCREENS_SCHEMA), 'r') as schemafile:
+            schema = schemafile.read()
+        return schema
+
     def get_blank_devices(self):
         """Gets a blank devices xml
 

--- a/BlockServer/core/pv_names.py
+++ b/BlockServer/core/pv_names.py
@@ -58,6 +58,7 @@ class BlockserverPVNames:
     BUMPSTRIP_AVAILABLE_SP = prepend_blockserver.__func__('BUMPSTRIP_AVAILABLE:SP')
     GET_SCREENS = prepend_blockserver.__func__('GET_SCREENS')
     SET_SCREENS = prepend_blockserver.__func__('SET_SCREENS')
+    SCREENS_SCHEMA = prepend_blockserver.__func__('SCREENS_SCHEMA')
 
     @staticmethod
     def get_config_details_pv(pv_key):


### PR DESCRIPTION
Verify that the schema of devices screens is made available in the PV %MYPVPREFIX%CS:BLOCKSERVER:SCREENS_SCHEMA (it's a waveform compressed an hexed):

`caget -t -S %MYPVPREFIX%CS:BLOCKSERVER:SCREENS_SCHEMA|uzhex`

Compare with the contents of `schema\screens.xsd`