### PR TITLE
Add a dataweb group of non-logged blocks

### DIFF
--- a/BlockServer/epics/archiver_manager.py
+++ b/BlockServer/epics/archiver_manager.py
@@ -103,6 +103,5 @@ class ArchiverManager(object):
             name = eTree.SubElement(channel, 'name')
             name.text = block_prefix + block.name
             period = eTree.SubElement(channel, 'period')
-            period.text = str(datetime.timedelta(seconds=5))
-            monitor = eTree.SubElement(channel, 'monitor')
-            monitor.text = "0"
+            period.text = str(datetime.timedelta(seconds=300))
+            eTree.SubElement(channel, 'scan')

--- a/BlockServer/epics/archiver_manager.py
+++ b/BlockServer/epics/archiver_manager.py
@@ -64,9 +64,12 @@ class ArchiverManager(object):
         group = eTree.SubElement(root, 'group')
         name = eTree.SubElement(group, 'name')
         name.text = "BLOCKS"
+        dataweb = eTree.SubElement(root, 'group')
+        dataweb_name = eTree.SubElement(dataweb, 'name')
+        dataweb_name.text = "DATAWEB"
         for block in blocks:
             # Append prefix for the archiver
-            self._generate_archive_channel(group, block_prefix, block)
+            self._generate_archive_channel(group, block_prefix, block, dataweb)
 
         with open(self._settings_path, 'w') as f:
             xml = minidom.parseString(eTree.tostring(root)).toprettyxml()
@@ -80,9 +83,9 @@ class ArchiverManager(object):
         else:
             print_and_log("Could not find specified archiver uploader batch file: %s" % self._uploader_path)
 
-    def _generate_archive_channel(self, group, block_prefix, block):
-        # xml not produced for scans of 0 period
+    def _generate_archive_channel(self, group, block_prefix, block, dataweb):
         if not (block.log_periodic and block.log_rate == 0):
+            # Blocks that are logged
             channel = eTree.SubElement(group, 'channel')
             name = eTree.SubElement(channel, 'name')
             name.text = block_prefix + block.name
@@ -94,3 +97,12 @@ class ArchiverManager(object):
                 period.text = str(datetime.timedelta(seconds=1))
                 monitor = eTree.SubElement(channel, 'monitor')
                 monitor.text = str(block.log_deadband)
+        else:
+            # Blocks that aren't logged, but are needed for the dataweb view
+            channel = eTree.SubElement(dataweb, 'channel')
+            name = eTree.SubElement(channel, 'name')
+            name.text = block_prefix + block.name
+            period = eTree.SubElement(channel, 'period')
+            period.text = str(datetime.timedelta(seconds=5))
+            monitor = eTree.SubElement(channel, 'monitor')
+            monitor.text = "0"


### PR DESCRIPTION
Relates to https://github.com/ISISComputingGroup/IBEX/issues/1370

To test:
With this branch checked out start your instrument (otherwise restart the blockserver from a console in order to pick up the code change)
Generate/edit a config so that there are some blocks which are logged, and some which aren't.
Go to the page http://localhost:4813/groups
There should be two entries, one for BLOCKS, one for DATAWEB
If you look at the BLOCKS page then the logged blocks should be shown
If you look at the DATAWEB page then the un-logged blocks should be shown

If the pages don't display all the expected groups or blocks, go to http://localhost:4813/restart, then go back to the groups, BLOCKS or DATAWEB pages and the information should be visible.
