### PR TITLE
Wait after Popen call

### DIFF
--- a/BlockServer/epics/archiver_manager.py
+++ b/BlockServer/epics/archiver_manager.py
@@ -79,7 +79,8 @@ class ArchiverManager(object):
         f = os.path.abspath(self._uploader_path)
         if os.path.isfile(f):
             print_and_log("Running archiver settings uploader: %s" % f)
-            Popen(f)
+            p = Popen(f)
+            p.wait()
         else:
             print_and_log("Could not find specified archiver uploader batch file: %s" % self._uploader_path)
 

--- a/BlockServer/epics/archiver_wrapper.py
+++ b/BlockServer/epics/archiver_wrapper.py
@@ -23,4 +23,5 @@ class ArchiverWrapper(object):
         proxy_handler = urllib2.ProxyHandler({})
         opener = urllib2.build_opener(proxy_handler)
         urllib2.install_opener(opener)
-        urllib2.urlopen("http://localhost:4813/restart")
+        res = urllib2.urlopen("http://localhost:4813/restart")
+        d = res.read()


### PR DESCRIPTION
Fix race condition with archiver restart and mysql config update. Popen is asynchronous, need to wait() for archive details to upload

To test:

prior to merge, swap between two configurations with different named blocks and examine  
http://localhost:4813/group?name=BLOCKS - you should find that occasionally this is not updated and shows old disconnected block names instead.

After merging, this should then work properly every time.

see ISISComputingGroup/IBEX#1413
