### PR TITLE
Ticket1394 truncate long config names 

### DIFF
--- a/BlockServer/test_modules/config_list_manager_tests.py
+++ b/BlockServer/test_modules/config_list_manager_tests.py
@@ -127,29 +127,29 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertTrue("TEST_CONFIG2" in [c["name"] for c in confs])
 
     def test_initialisation_with_components_in_directory(self):
-        self._create_components(["COMP1", "COMP2"])
+        self._create_components(["TEST_COMPONENT1", "TEST_COMPONENT2"])
         confs = self.clm.get_components()
         self.assertEqual(len(confs), 2)
-        self.assertTrue("COMP1" in [c["name"] for c in confs])
-        self.assertTrue("COMP2" in [c["name"] for c in confs])
+        self.assertTrue("TEST_COMPONENT1" in [c["name"] for c in confs])
+        self.assertTrue("TEST_COMPONENT2" in [c["name"] for c in confs])
 
     def test_initialisation_with_configs_in_directory_pv(self):
-        self._create_configs(["CONF1", "CONF2"])
+        self._create_configs(["TEST_CONFIG1", "TEST_CONFIG2"])
 
-        self.assertTrue(self._does_pv_exist("CONF1:" + GET_CONFIG_PV))
-        self.assertTrue(self._does_pv_exist("CONF2:" + GET_CONFIG_PV))
-        self.assertFalse(self._does_pv_exist("CONF1:" + GET_COMPONENT_PV))
-        self.assertFalse(self._does_pv_exist("CONF2:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_CONFIG1:" + GET_CONFIG_PV))
+        self.assertTrue(self._does_pv_exist("TEST_CONFIG2:" + GET_CONFIG_PV))
+        self.assertFalse(self._does_pv_exist("TEST_CONFIG1:" + GET_COMPONENT_PV))
+        self.assertFalse(self._does_pv_exist("TEST_CONFIG2:" + GET_COMPONENT_PV))
 
     def test_initialisation_with_components_in_directory_pv(self):
-        self._create_components(["COMP1", "COMP2"])
+        self._create_components(["TEST_COMPONENT1", "TEST_COMPONENT2"])
 
-        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("COMP2:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("COMP1:" + DEPENDENCIES_PV))
-        self.assertTrue(self._does_pv_exist("COMP2:" + DEPENDENCIES_PV))
-        self.assertFalse(self._does_pv_exist("COMP1:" + GET_CONFIG_PV))
-        self.assertFalse(self._does_pv_exist("COMP2:" + GET_CONFIG_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + DEPENDENCIES_PV))
+        self.assertFalse(self._does_pv_exist("TEST_COMPONENT1:" + GET_CONFIG_PV))
+        self.assertFalse(self._does_pv_exist("TEST_COMPONENT2:" + GET_CONFIG_PV))
 
     def test_update_config_from_object(self):
         self.icm = InactiveConfigHolder(MACROS, MockVersionControl())
@@ -159,7 +159,7 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         confs = self.clm.get_configs()
         self.assertEqual(len(confs), 1)
         self.assertTrue("TEST_CONFIG" in [conf.get('name') for conf in confs])
-        self.assertTrue("TEST_C" in [conf.get('pv') for conf in confs])
+        self.assertTrue("TEST_CONFIG" in [conf.get('pv') for conf in confs])
         self.assertTrue("A Test Configuration" in [conf.get('description') for conf in confs])
         self.assertTrue("TEST_SYNOPTIC" in [conf.get('synoptic') for conf in confs])
 
@@ -174,7 +174,7 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         confs = self.clm.get_components()
         self.assertEqual(len(confs), 1)
         self.assertTrue("TEST_CONFIG" in [conf.get('name') for conf in confs])
-        self.assertTrue("TEST_C" in [conf.get('pv') for conf in confs])
+        self.assertTrue("TEST_CONFIG" in [conf.get('pv') for conf in confs])
         self.assertTrue("A Test Configuration" in [conf.get('description') for conf in confs])
         self.assertTrue("TEST_SYNOPTIC" in [conf.get('synoptic') for conf in confs])
 
@@ -195,24 +195,24 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertTrue("TEST_COMPONENT2" in [comp.get('name') for comp in comps])
 
     def test_pv_of_lower_case_name(self):
-        config_name = "CONfig"
-        self._test_pv_changed_but_not_name(config_name, "CONFIG")
+        config_name = "test_CONfig1"
+        self._test_pv_changed_but_not_name(config_name, "TEST_CONFIG1")
 
     def test_config_and_component_allowed_same_pv(self):
-        self._create_configs(["TEST1", "TEST2"])
-        self._create_components(["TEST1", "TEST2"])
+        self._create_configs(["TEST_CONFIG_AND_COMPONENT1", "TEST_CONFIG_AND_COMPONENT2"])
+        self._create_components(["TEST_CONFIG_AND_COMPONENT1", "TEST_CONFIG_AND_COMPONENT2"])
 
         confs = self.clm.get_configs()
         self.assertEqual(len(confs), 2)
 
-        self.assertTrue("TEST1" in [m["pv"] for m in confs])
-        self.assertTrue("TEST2" in [m["pv"] for m in confs])
+        self.assertTrue("TEST_CONFIG_AND_COMPONENT1" in [m["pv"] for m in confs])
+        self.assertTrue("TEST_CONFIG_AND_COMPONENT2" in [m["pv"] for m in confs])
 
         comps = self.clm.get_components()
         self.assertEqual(len(comps), 2)
 
-        self.assertTrue("TEST1" in [m["pv"] for m in comps])
-        self.assertTrue("TEST2" in [m["pv"] for m in comps])
+        self.assertTrue("TEST_CONFIG_AND_COMPONENT1" in [m["pv"] for m in comps])
+        self.assertTrue("TEST_CONFIG_AND_COMPONENT2" in [m["pv"] for m in comps])
 
     def _test_is_configuration_json(self, data, name):
         self.assertTrue("name" in data)
@@ -247,20 +247,20 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertTrue("TEST_CONFIG2" in config_names)
 
     def test_delete_components_empty(self):
-        self._create_components(["COMP1", "COMP2"])
+        self._create_components(["TEST_COMPONENT1", "TEST_COMPONENT2"])
 
         self.clm.active_config_name = "TEST_ACTIVE"
         self.clm.delete_configs([], True)
 
         config_names = [c["name"] for c in self.clm.get_components()]
         self.assertEqual(len(config_names), 2)
-        self.assertTrue("COMP1" in config_names)
-        self.assertTrue("COMP2" in config_names)
+        self.assertTrue("TEST_COMPONENT1" in config_names)
+        self.assertTrue("TEST_COMPONENT2" in config_names)
 
-        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("COMP1:" + DEPENDENCIES_PV))
-        self.assertTrue(self._does_pv_exist("COMP2:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("COMP2:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + DEPENDENCIES_PV))
 
     def test_delete_active_config(self):
         self._create_configs(["TEST_CONFIG1", "TEST_CONFIG2"])
@@ -340,17 +340,17 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertFalse("TEST_CONFIG1" in config_names)
 
     def test_delete_one_component(self):
-        self._create_components(["COMP1", "COMP2"])
+        self._create_components(["TEST_COMPONENT1", "TEST_COMPONENT2"])
 
-        self.clm.delete_configs(["COMP1"], True)
+        self.clm.delete_configs(["TEST_COMPONENT1"], True)
         self.clm.active_config_name = "TEST_ACTIVE"
 
         config_names = [c["name"] for c in self.clm.get_components()]
         self.assertEqual(len(config_names), 1)
-        self.assertTrue("COMP2" in config_names)
-        self.assertFalse("COMP1" in config_names)
-        self.assertTrue(self._does_pv_exist("COMP2:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("COMP2:" + DEPENDENCIES_PV))
+        self.assertTrue("TEST_COMPONENT2" in config_names)
+        self.assertFalse("TEST_COMPONENT1" in config_names)
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + DEPENDENCIES_PV))
 
     def test_delete_many_configs(self):
         self._create_configs(["TEST_CONFIG1", "TEST_CONFIG2", "TEST_CONFIG3"])
@@ -371,24 +371,24 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertFalse("TEST_CONFIG3" in config_names)
 
     def test_delete_many_components(self):
-        self._create_components(["COMP1", "COMP2", "COMP3"])
+        self._create_components(["TEST_COMPONENT1", "TEST_COMPONENT2", "TEST_COMPONENT3"])
         self.clm.active_config_name = "TEST_ACTIVE"
 
         config_names = [c["name"] for c in self.clm.get_components()]
         self.assertEqual(len(config_names), 3)
-        self.assertTrue("COMP1" in config_names)
-        self.assertTrue("COMP2" in config_names)
-        self.assertTrue("COMP3" in config_names)
+        self.assertTrue("TEST_COMPONENT1" in config_names)
+        self.assertTrue("TEST_COMPONENT2" in config_names)
+        self.assertTrue("TEST_COMPONENT3" in config_names)
 
-        self.clm.delete_configs(["COMP1", "COMP3"],  True)
+        self.clm.delete_configs(["TEST_COMPONENT1", "TEST_COMPONENT3"],  True)
 
         config_names = [c["name"] for c in self.clm.get_components()]
         self.assertEqual(len(config_names), 1)
-        self.assertTrue("COMP2" in config_names)
-        self.assertFalse("COMP1" in config_names)
-        self.assertFalse("COMP3" in config_names)
-        self.assertTrue(self._does_pv_exist("COMP2:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("COMP2:" + DEPENDENCIES_PV))
+        self.assertTrue("TEST_COMPONENT2" in config_names)
+        self.assertFalse("TEST_COMPONENT1" in config_names)
+        self.assertFalse("TEST_COMPONENT3" in config_names)
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + DEPENDENCIES_PV))
 
     def test_delete_config_affects_filesystem(self):
         self._create_configs(["TEST_CONFIG1", "TEST_CONFIG2"])
@@ -429,68 +429,68 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertEqual(len(config_names), 0)
 
     def test_delete_component_after_add_and_remove(self):
-        self._create_components(["COMP1", "COMP2", "COMP3"])
-        self.clm.active_config_name = "ACTIVE"
+        self._create_components(["TEST_COMPONENT1", "TEST_COMPONENT2", "TEST_COMPONENT3"])
+        self.clm.active_config_name = "TEST_ACTIVE"
 
         inactive = InactiveConfigHolder(MACROS, MockVersionControl())
 
-        inactive.add_component("COMP1", Configuration(MACROS))
-        inactive.save_inactive("INACTIVE")
-        self.clm.update_a_config_in_list(inactive)
-
-        inactive.remove_comp("COMP1")
-        inactive.save_inactive("INACTIVE")
-        self.clm.update_a_config_in_list(inactive)
-
-        self.clm.delete_configs(["COMP1"], True)
-        config_names = [c["name"] for c in self.clm.get_components()]
-        self.assertEqual(len(config_names), 2)
-        self.assertTrue("COMP2" in config_names)
-        self.assertTrue("COMP3" in config_names)
-        self.assertFalse("COMP1" in config_names)
-
-        self.assertTrue(self._does_pv_exist("INACTI:" + GET_CONFIG_PV))
-        self.assertTrue(self._does_pv_exist("COMP2:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("COMP2:" + DEPENDENCIES_PV))
-        self.assertTrue(self._does_pv_exist("COMP3:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("COMP3:" + DEPENDENCIES_PV))
-
-    def test_dependencies_initialises(self):
-        self._create_components(["COMP1"])
-
-        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("COMP1:" + DEPENDENCIES_PV))
-
-    def test_dependencies_updates_add(self):
-        self._create_components(["COMP1"])
-        inactive = InactiveConfigHolder(MACROS, MockVersionControl())
-
-        inactive.add_component("COMP1", Configuration(MACROS))
+        inactive.add_component("TEST_COMPONENT1", Configuration(MACROS))
         inactive.save_inactive("TEST_INACTIVE")
         self.clm.update_a_config_in_list(inactive)
 
-        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("COMP1:" + DEPENDENCIES_PV))
+        inactive.remove_comp("TEST_COMPONENT1")
+        inactive.save_inactive("TEST_INACTIVE")
+        self.clm.update_a_config_in_list(inactive)
+
+        self.clm.delete_configs(["TEST_COMPONENT1"], True)
+        config_names = [c["name"] for c in self.clm.get_components()]
+        self.assertEqual(len(config_names), 2)
+        self.assertTrue("TEST_COMPONENT2" in config_names)
+        self.assertTrue("TEST_COMPONENT3" in config_names)
+        self.assertFalse("TEST_COMPONENT1" in config_names)
+
+        self.assertTrue(self._does_pv_exist("TEST_INACTIVE:" + GET_CONFIG_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT3:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT3:" + DEPENDENCIES_PV))
+
+    def test_dependencies_initialises(self):
+        self._create_components(["TEST_COMPONENT1"])
+
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + DEPENDENCIES_PV))
+
+    def test_dependencies_updates_add(self):
+        self._create_components(["TEST_COMPONENT1"])
+        inactive = InactiveConfigHolder(MACROS, MockVersionControl())
+
+        inactive.add_component("TEST_COMPONENT1", Configuration(MACROS))
+        inactive.save_inactive("TEST_INACTIVE")
+        self.clm.update_a_config_in_list(inactive)
+
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + DEPENDENCIES_PV))
 
         confs = self.clm.get_configs()
         self.assertEqual(len(confs), 1)
         self.assertEqual("TEST_INACTIVE", confs[0]["name"])
 
     def test_dependencies_updates_remove(self):
-        self._create_components(["COMP1"])
+        self._create_components(["TEST_COMPONENT1"])
 
         inactive = InactiveConfigHolder(MACROS, MockVersionControl())
 
-        inactive.add_component("COMP1", Configuration(MACROS))
+        inactive.add_component("TEST_COMPONENT1", Configuration(MACROS))
         inactive.save_inactive("TEST_INACTIVE", False)
         self.clm.update_a_config_in_list(inactive)
 
-        inactive.remove_comp("COMP1")
+        inactive.remove_comp("TEST_COMPONENT1")
         inactive.save_inactive("TEST_INACTIVE", False)
         self.clm.update_a_config_in_list(inactive)
 
-        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("COMP1:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + DEPENDENCIES_PV))
 
         comps = self.clm.get_components()
         self.assertEqual(len(comps), 1)
@@ -498,17 +498,17 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertFalse("TEST_INACTIVE" in names)
 
     def test_delete_config_deletes_dependency(self):
-        self._create_components(["COMP1"])
+        self._create_components(["TEST_COMPONENT1"])
         inactive = InactiveConfigHolder(MACROS, MockVersionControl())
         self.clm.active_config_name = "TEST_ACTIVE"
-        inactive.add_component("COMP1", Configuration(MACROS))
+        inactive.add_component("TEST_COMPONENT1", Configuration(MACROS))
         inactive.save_inactive("TEST_INACTIVE", False)
         self.clm.update_a_config_in_list(inactive)
 
         self.clm.delete_configs(["TEST_INACTIVE"])
 
-        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
 
         comps = self.clm.get_components()
         self.assertEqual(len(comps), 1)

--- a/BlockServer/test_modules/config_list_manager_tests.py
+++ b/BlockServer/test_modules/config_list_manager_tests.py
@@ -127,29 +127,29 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertTrue("TEST_CONFIG2" in [c["name"] for c in confs])
 
     def test_initialisation_with_components_in_directory(self):
-        self._create_components(["TEST_COMPONENT1", "TEST_COMPONENT2"])
+        self._create_components(["COMP1", "COMP2"])
         confs = self.clm.get_components()
         self.assertEqual(len(confs), 2)
-        self.assertTrue("TEST_COMPONENT1" in [c["name"] for c in confs])
-        self.assertTrue("TEST_COMPONENT2" in [c["name"] for c in confs])
+        self.assertTrue("COMP1" in [c["name"] for c in confs])
+        self.assertTrue("COMP2" in [c["name"] for c in confs])
 
     def test_initialisation_with_configs_in_directory_pv(self):
-        self._create_configs(["TEST_CONFIG1", "TEST_CONFIG2"])
+        self._create_configs(["CONF1", "CONF2"])
 
-        self.assertTrue(self._does_pv_exist("TEST_CONFIG1:" + GET_CONFIG_PV))
-        self.assertTrue(self._does_pv_exist("TEST_CONFIG2:" + GET_CONFIG_PV))
-        self.assertFalse(self._does_pv_exist("TEST_CONFIG1:" + GET_COMPONENT_PV))
-        self.assertFalse(self._does_pv_exist("TEST_CONFIG2:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("CONF1:" + GET_CONFIG_PV))
+        self.assertTrue(self._does_pv_exist("CONF2:" + GET_CONFIG_PV))
+        self.assertFalse(self._does_pv_exist("CONF1:" + GET_COMPONENT_PV))
+        self.assertFalse(self._does_pv_exist("CONF2:" + GET_COMPONENT_PV))
 
     def test_initialisation_with_components_in_directory_pv(self):
-        self._create_components(["TEST_COMPONENT1", "TEST_COMPONENT2"])
+        self._create_components(["COMP1", "COMP2"])
 
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + DEPENDENCIES_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + DEPENDENCIES_PV))
-        self.assertFalse(self._does_pv_exist("TEST_COMPONENT1:" + GET_CONFIG_PV))
-        self.assertFalse(self._does_pv_exist("TEST_COMPONENT2:" + GET_CONFIG_PV))
+        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP2:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP1:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("COMP2:" + DEPENDENCIES_PV))
+        self.assertFalse(self._does_pv_exist("COMP1:" + GET_CONFIG_PV))
+        self.assertFalse(self._does_pv_exist("COMP2:" + GET_CONFIG_PV))
 
     def test_update_config_from_object(self):
         self.icm = InactiveConfigHolder(MACROS, MockVersionControl())
@@ -159,7 +159,7 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         confs = self.clm.get_configs()
         self.assertEqual(len(confs), 1)
         self.assertTrue("TEST_CONFIG" in [conf.get('name') for conf in confs])
-        self.assertTrue("TEST_CONFIG" in [conf.get('pv') for conf in confs])
+        self.assertTrue("TEST_C" in [conf.get('pv') for conf in confs])
         self.assertTrue("A Test Configuration" in [conf.get('description') for conf in confs])
         self.assertTrue("TEST_SYNOPTIC" in [conf.get('synoptic') for conf in confs])
 
@@ -174,7 +174,7 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         confs = self.clm.get_components()
         self.assertEqual(len(confs), 1)
         self.assertTrue("TEST_CONFIG" in [conf.get('name') for conf in confs])
-        self.assertTrue("TEST_CONFIG" in [conf.get('pv') for conf in confs])
+        self.assertTrue("TEST_C" in [conf.get('pv') for conf in confs])
         self.assertTrue("A Test Configuration" in [conf.get('description') for conf in confs])
         self.assertTrue("TEST_SYNOPTIC" in [conf.get('synoptic') for conf in confs])
 
@@ -195,24 +195,24 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertTrue("TEST_COMPONENT2" in [comp.get('name') for comp in comps])
 
     def test_pv_of_lower_case_name(self):
-        config_name = "test_CONfig1"
-        self._test_pv_changed_but_not_name(config_name, "TEST_CONFIG1")
+        config_name = "CONfig"
+        self._test_pv_changed_but_not_name(config_name, "CONFIG")
 
     def test_config_and_component_allowed_same_pv(self):
-        self._create_configs(["TEST_CONFIG_AND_COMPONENT1", "TEST_CONFIG_AND_COMPONENT2"])
-        self._create_components(["TEST_CONFIG_AND_COMPONENT1", "TEST_CONFIG_AND_COMPONENT2"])
+        self._create_configs(["TEST1", "TEST2"])
+        self._create_components(["TEST1", "TEST2"])
 
         confs = self.clm.get_configs()
         self.assertEqual(len(confs), 2)
 
-        self.assertTrue("TEST_CONFIG_AND_COMPONENT1" in [m["pv"] for m in confs])
-        self.assertTrue("TEST_CONFIG_AND_COMPONENT2" in [m["pv"] for m in confs])
+        self.assertTrue("TEST1" in [m["pv"] for m in confs])
+        self.assertTrue("TEST2" in [m["pv"] for m in confs])
 
         comps = self.clm.get_components()
         self.assertEqual(len(comps), 2)
 
-        self.assertTrue("TEST_CONFIG_AND_COMPONENT1" in [m["pv"] for m in comps])
-        self.assertTrue("TEST_CONFIG_AND_COMPONENT2" in [m["pv"] for m in comps])
+        self.assertTrue("TEST1" in [m["pv"] for m in comps])
+        self.assertTrue("TEST2" in [m["pv"] for m in comps])
 
     def _test_is_configuration_json(self, data, name):
         self.assertTrue("name" in data)
@@ -247,20 +247,20 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertTrue("TEST_CONFIG2" in config_names)
 
     def test_delete_components_empty(self):
-        self._create_components(["TEST_COMPONENT1", "TEST_COMPONENT2"])
+        self._create_components(["COMP1", "COMP2"])
 
         self.clm.active_config_name = "TEST_ACTIVE"
         self.clm.delete_configs([], True)
 
         config_names = [c["name"] for c in self.clm.get_components()]
         self.assertEqual(len(config_names), 2)
-        self.assertTrue("TEST_COMPONENT1" in config_names)
-        self.assertTrue("TEST_COMPONENT2" in config_names)
+        self.assertTrue("COMP1" in config_names)
+        self.assertTrue("COMP2" in config_names)
 
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + DEPENDENCIES_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP1:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("COMP2:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP2:" + DEPENDENCIES_PV))
 
     def test_delete_active_config(self):
         self._create_configs(["TEST_CONFIG1", "TEST_CONFIG2"])
@@ -340,17 +340,17 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertFalse("TEST_CONFIG1" in config_names)
 
     def test_delete_one_component(self):
-        self._create_components(["TEST_COMPONENT1", "TEST_COMPONENT2"])
+        self._create_components(["COMP1", "COMP2"])
 
-        self.clm.delete_configs(["TEST_COMPONENT1"], True)
+        self.clm.delete_configs(["COMP1"], True)
         self.clm.active_config_name = "TEST_ACTIVE"
 
         config_names = [c["name"] for c in self.clm.get_components()]
         self.assertEqual(len(config_names), 1)
-        self.assertTrue("TEST_COMPONENT2" in config_names)
-        self.assertFalse("TEST_COMPONENT1" in config_names)
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + DEPENDENCIES_PV))
+        self.assertTrue("COMP2" in config_names)
+        self.assertFalse("COMP1" in config_names)
+        self.assertTrue(self._does_pv_exist("COMP2:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP2:" + DEPENDENCIES_PV))
 
     def test_delete_many_configs(self):
         self._create_configs(["TEST_CONFIG1", "TEST_CONFIG2", "TEST_CONFIG3"])
@@ -371,24 +371,24 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertFalse("TEST_CONFIG3" in config_names)
 
     def test_delete_many_components(self):
-        self._create_components(["TEST_COMPONENT1", "TEST_COMPONENT2", "TEST_COMPONENT3"])
+        self._create_components(["COMP1", "COMP2", "COMP3"])
         self.clm.active_config_name = "TEST_ACTIVE"
 
         config_names = [c["name"] for c in self.clm.get_components()]
         self.assertEqual(len(config_names), 3)
-        self.assertTrue("TEST_COMPONENT1" in config_names)
-        self.assertTrue("TEST_COMPONENT2" in config_names)
-        self.assertTrue("TEST_COMPONENT3" in config_names)
+        self.assertTrue("COMP1" in config_names)
+        self.assertTrue("COMP2" in config_names)
+        self.assertTrue("COMP3" in config_names)
 
-        self.clm.delete_configs(["TEST_COMPONENT1", "TEST_COMPONENT3"],  True)
+        self.clm.delete_configs(["COMP1", "COMP3"],  True)
 
         config_names = [c["name"] for c in self.clm.get_components()]
         self.assertEqual(len(config_names), 1)
-        self.assertTrue("TEST_COMPONENT2" in config_names)
-        self.assertFalse("TEST_COMPONENT1" in config_names)
-        self.assertFalse("TEST_COMPONENT3" in config_names)
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + DEPENDENCIES_PV))
+        self.assertTrue("COMP2" in config_names)
+        self.assertFalse("COMP1" in config_names)
+        self.assertFalse("COMP3" in config_names)
+        self.assertTrue(self._does_pv_exist("COMP2:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP2:" + DEPENDENCIES_PV))
 
     def test_delete_config_affects_filesystem(self):
         self._create_configs(["TEST_CONFIG1", "TEST_CONFIG2"])
@@ -429,68 +429,68 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertEqual(len(config_names), 0)
 
     def test_delete_component_after_add_and_remove(self):
-        self._create_components(["TEST_COMPONENT1", "TEST_COMPONENT2", "TEST_COMPONENT3"])
-        self.clm.active_config_name = "TEST_ACTIVE"
+        self._create_components(["COMP1", "COMP2", "COMP3"])
+        self.clm.active_config_name = "ACTIVE"
 
         inactive = InactiveConfigHolder(MACROS, MockVersionControl())
 
-        inactive.add_component("TEST_COMPONENT1", Configuration(MACROS))
-        inactive.save_inactive("TEST_INACTIVE")
+        inactive.add_component("COMP1", Configuration(MACROS))
+        inactive.save_inactive("INACTIVE")
         self.clm.update_a_config_in_list(inactive)
 
-        inactive.remove_comp("TEST_COMPONENT1")
-        inactive.save_inactive("TEST_INACTIVE")
+        inactive.remove_comp("COMP1")
+        inactive.save_inactive("INACTIVE")
         self.clm.update_a_config_in_list(inactive)
 
-        self.clm.delete_configs(["TEST_COMPONENT1"], True)
+        self.clm.delete_configs(["COMP1"], True)
         config_names = [c["name"] for c in self.clm.get_components()]
         self.assertEqual(len(config_names), 2)
-        self.assertTrue("TEST_COMPONENT2" in config_names)
-        self.assertTrue("TEST_COMPONENT3" in config_names)
-        self.assertFalse("TEST_COMPONENT1" in config_names)
+        self.assertTrue("COMP2" in config_names)
+        self.assertTrue("COMP3" in config_names)
+        self.assertFalse("COMP1" in config_names)
 
-        self.assertTrue(self._does_pv_exist("TEST_INACTIVE:" + GET_CONFIG_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT2:" + DEPENDENCIES_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT3:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT3:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("INACTI:" + GET_CONFIG_PV))
+        self.assertTrue(self._does_pv_exist("COMP2:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP2:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("COMP3:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP3:" + DEPENDENCIES_PV))
 
     def test_dependencies_initialises(self):
-        self._create_components(["TEST_COMPONENT1"])
+        self._create_components(["COMP1"])
 
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP1:" + DEPENDENCIES_PV))
 
     def test_dependencies_updates_add(self):
-        self._create_components(["TEST_COMPONENT1"])
+        self._create_components(["COMP1"])
         inactive = InactiveConfigHolder(MACROS, MockVersionControl())
 
-        inactive.add_component("TEST_COMPONENT1", Configuration(MACROS))
+        inactive.add_component("COMP1", Configuration(MACROS))
         inactive.save_inactive("TEST_INACTIVE")
         self.clm.update_a_config_in_list(inactive)
 
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP1:" + DEPENDENCIES_PV))
 
         confs = self.clm.get_configs()
         self.assertEqual(len(confs), 1)
         self.assertEqual("TEST_INACTIVE", confs[0]["name"])
 
     def test_dependencies_updates_remove(self):
-        self._create_components(["TEST_COMPONENT1"])
+        self._create_components(["COMP1"])
 
         inactive = InactiveConfigHolder(MACROS, MockVersionControl())
 
-        inactive.add_component("TEST_COMPONENT1", Configuration(MACROS))
+        inactive.add_component("COMP1", Configuration(MACROS))
         inactive.save_inactive("TEST_INACTIVE", False)
         self.clm.update_a_config_in_list(inactive)
 
-        inactive.remove_comp("TEST_COMPONENT1")
+        inactive.remove_comp("COMP1")
         inactive.save_inactive("TEST_INACTIVE", False)
         self.clm.update_a_config_in_list(inactive)
 
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + DEPENDENCIES_PV))
+        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP1:" + DEPENDENCIES_PV))
 
         comps = self.clm.get_components()
         self.assertEqual(len(comps), 1)
@@ -498,17 +498,17 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.assertFalse("TEST_INACTIVE" in names)
 
     def test_delete_config_deletes_dependency(self):
-        self._create_components(["TEST_COMPONENT1"])
+        self._create_components(["COMP1"])
         inactive = InactiveConfigHolder(MACROS, MockVersionControl())
         self.clm.active_config_name = "TEST_ACTIVE"
-        inactive.add_component("TEST_COMPONENT1", Configuration(MACROS))
+        inactive.add_component("COMP1", Configuration(MACROS))
         inactive.save_inactive("TEST_INACTIVE", False)
         self.clm.update_a_config_in_list(inactive)
 
         self.clm.delete_configs(["TEST_INACTIVE"])
 
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
-        self.assertTrue(self._does_pv_exist("TEST_COMPONENT1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
+        self.assertTrue(self._does_pv_exist("COMP1:" + GET_COMPONENT_PV))
 
         comps = self.clm.get_components()
         self.assertEqual(len(comps), 1)

--- a/BlockServer/test_modules/synoptic_manager_tests.py
+++ b/BlockServer/test_modules/synoptic_manager_tests.py
@@ -34,8 +34,8 @@ EXAMPLE_SYNOPTIC = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 SCHEMA_PATH = os.path.abspath(os.path.join(".", "..", "schema"))
 
-SYNOPTIC_1 = "synoptic1"
-SYNOPTIC_2 = "synoptic2"
+SYNOPTIC_1 = "synop1"
+SYNOPTIC_2 = "synop2"
 
 
 def construct_pv_name(name):
@@ -80,7 +80,7 @@ class TestSynopticManagerSequence(unittest.TestCase):
         self.sm._load_initial()
 
         # Assert
-        self.assertTrue(self.bs.does_pv_exist("%sSYNOPTIC1%s" % (SYNOPTIC_PRE, SYNOPTIC_GET)))
+        self.assertTrue(self.bs.does_pv_exist("%sSYNOP1%s" % (SYNOPTIC_PRE, SYNOPTIC_GET)))
 
     def test_get_default_synoptic_xml_returns_nothing(self):
         # Arrange
@@ -116,13 +116,13 @@ class TestSynopticManagerSequence(unittest.TestCase):
 
     def test_set_current_synoptic_xml_creates_pv(self):
         # Arrange
-        syn_name = "new_synoptic"
+        syn_name = "synopt"
 
         # Act
         self.sm.save_synoptic_xml(EXAMPLE_SYNOPTIC % syn_name)
 
         # Assert
-        self.assertTrue(self.bs.does_pv_exist("%sNEW_SYNOPTIC%s" % (SYNOPTIC_PRE, SYNOPTIC_GET)))
+        self.assertTrue(self.bs.does_pv_exist("%sSYNOPT%s" % (SYNOPTIC_PRE, SYNOPTIC_GET)))
 
     def test_delete_synoptics_empty(self):
         # Arrange
@@ -171,9 +171,9 @@ class TestSynopticManagerSequence(unittest.TestCase):
         # Assert
         synoptics = os.listdir(FILEPATH_MANAGER.synoptic_dir)
         self.assertEqual(len(synoptics), 1)
-        self.assertTrue("synoptic2.xml" in synoptics)
+        self.assertTrue("synop2.xml" in synoptics)
 
-    def test_cannot_delete_non_existant_synoptic(self):
+    def test_cannot_delete_non_existent_synoptic(self):
         # Arrange
         # Act
         self.assertRaises(InvalidDeleteException, self.sm.delete_synoptics, ["invalid"])

--- a/server_common/test_modules/utilities_tests.py
+++ b/server_common/test_modules/utilities_tests.py
@@ -11,17 +11,33 @@ class TestCreatePVName(unittest.TestCase):
         pass
 
     def test_when_config_name_contains_whitespace_then_replace_with_underscore(self):
+        config = create_pv_name("config name", [], "Default")
+
+        self.assertEquals(config, "CONFIG_NAME")
         pass
 
     def test_when_config_name_contains_non_alphanumeric_characters_then_remove(self):
+        config = create_pv_name("c-onf@ig *n>ame=!", [], "Default")
+
+        self.assertEquals(config, "CONFIG_NAME")
         pass
 
     def test_when_config_name_contains_only_numbers_and_underscores_then_replace_with_default_config_name(self):
+        config = create_pv_name("1_2_3_4", [], "Default")
+
+        self.assertEquals(config, "Default")
         pass
 
     def test_when_config_name_is_blank_then_replace_with_default_config_name(self):
-        create_pv_name("", [], "Default")
-        self.assertEquals(create_pv_name(), "Default")
+        config = create_pv_name("", [], "Default")
+
+        self.assertEquals(config, "Default")
 
     def test_given_blank_config_name_when_another_blank_config_name_then_append_numbers(self):
-        pass
+        config_01 = create_pv_name("", [], "Default")
+        config_02 = create_pv_name("", [config_01], "Default")
+        config_03 = create_pv_name("", [config_01, config_02], "Default")
+
+        self.assertEquals(config_01, "Default")
+        self.assertEquals(config_02, "Default0")
+        self.assertEquals(config_03, "Default1")

--- a/server_common/test_modules/utilities_tests.py
+++ b/server_common/test_modules/utilities_tests.py
@@ -10,52 +10,85 @@ class TestCreatePVName(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_when_pv_name_contains_whitespace_then_replace_with_underscore(self):
-        pv = create_pv_name("config name", [], "peevee")
+    def test_WHEN_pv_name_contains_whitespace_THEN_replace_whitespace_with_underscore(self):
+        # Act
+        pv = create_pv_name("config name", [], "PEEVEE")
 
+        # Assert
         self.assertEquals(pv, "CONFIG")
 
-    def test_when_pv_name_contains_non_alphanumeric_characters_then_remove(self):
-        pv = create_pv_name("c-onf@ig", [], "peevee")
+    def test_WHEN_pv_name_contains_non_alphanumeric_characters_THEN_remove_non_alphanumeric_characters(self):
+        # Act
+        pv = create_pv_name("c-onf@ig", [], "PEEVEE")
 
+        # Assert
         self.assertEquals(pv, "CONFIG")
 
-    def test_when_pv_name_contains_only_numbers_and_underscores_then_replace_with_default_pv_name(self):
-        pv = create_pv_name("1_2_3_4", [], "peevee")
+    def test_WHEN_pv_name_contains_only_numbers_and_underscores_THEN_replace_pv_with_default_pv_name(self):
+        # Act
+        pv = create_pv_name("1_2_3_4", [], "PEEVEE")
 
-        self.assertEquals(pv, "peevee")
+        # Assert
+        self.assertEquals(pv, "PEEVEE")
 
-    def test_when_pv_name_is_blank_then_replace_with_default_pv_name(self):
-        pv = create_pv_name("", [], "peevee")
+    def test_WHEN_pv_name_is_blank_THEN_replace_pv_with_default_pv_name(self):
+        # Act
+        pv = create_pv_name("", [], "PEEVEE")
 
-        self.assertEquals(pv, "peevee")
+        # Assert
+        self.assertEquals(pv, "PEEVEE")
 
-    def test_given_blank_pv_name_when_another_blank_pv_name_then_append_numbers(self):
-        pv_01 = create_pv_name("", [], "peevee")
-        pv_02 = create_pv_name("", [pv_01], "peevee")
-        pv_03 = create_pv_name("", [pv_01, pv_02], "peevee")
+    def test_GIVEN_blank_pv_name_WHEN_another_blank_pv_name_THEN_append_numbers(self):
+        # Arrange
+        pv_01 = create_pv_name("", [], "PEEVEE")
 
-        self.assertEquals(pv_01, "peevee")
+        # Act
+        pv_02 = create_pv_name("", [pv_01], "PEEVEE")
+        pv_03 = create_pv_name("", [pv_01, pv_02], "PEEVEE")
+
+        # Assert
+        self.assertEquals(pv_01, "PEEVEE")
         self.assertEquals(pv_02, "peev01")
         self.assertEquals(pv_03, "peev02")
 
-    def test_when_pv_name_too_long_then_truncate(self):
-        pv = create_pv_name("Configuration", [], "peevee")
+    def test_WHEN_pv_name_too_long_THEN_truncate_to_six_chars(self):
+        # Act
+        pv = create_pv_name("Configuration", [], "PEEVEE")
 
+        # Assert
         self.assertEquals(pv, "CONFIG")
 
-    def test_given_an_existing_pv_when_another_pv_of_same_name_then_rename_differently(self):
-        pv_01 = create_pv_name("Conf", [], "peevee")
-        pv_02 = create_pv_name("Conf", [pv_01], "peevee")
+    def test_GIVEN_an_existing_pv_WHEN_create_another_pv_of_same_name_THEN_append_numbers(self):
+        # Arrange
+        pv_01 = create_pv_name("Conf", [], "PEEVEE")
 
+        # Act
+        pv_02 = create_pv_name("Conf", [pv_01], "PEEVEE")
+
+        # Assert
         self.assertEquals(pv_01, "CONF")
         self.assertEquals(pv_02, "CONF01")
 
-    def test_given_an_existing_truncated_pv_when_another_pv_of_same_name_then_truncate_and_rename_differently(self):
-        pv_01 = create_pv_name("Configuration", [], "peevee")
-        pv_02 = create_pv_name("Configuration", [pv_01], "peevee")
-        pv_03 = create_pv_name("Configuration", [pv_01, pv_02], "peevee")
+    def test_GIVEN_an_existing_truncated_pv_WHEN_another_pv_of_same_name_THEN_truncate_and_rename_differently(self):
+        # Arrange
+        pv_01 = create_pv_name("Configuration", [], "PEEVEE")
 
+        # Act
+        pv_02 = create_pv_name("Configuration", [pv_01], "PEEVEE")
+        pv_03 = create_pv_name("Configuration", [pv_01, pv_02], "PEEVEE")
+
+        # Assert
         self.assertEquals(pv_01, "CONFIG")
         self.assertEquals(pv_02, "CONF01")
         self.assertEquals(pv_03, "CONF02")
+
+    def test_GIVEN_a_long_pv_WHEN_create_pv_with_same_name_and_invalid_chars_THEN_remove_invalid_chars_and_truncate_and_number_correctly(self):
+        # Arrange
+        pv_01 = create_pv_name("Configuration", [], "PEEVEE")
+
+        # Act
+        pv_02 = create_pv_name("Co*&^nfiguration", [pv_01], "PEEVEE")
+
+        # Assert
+        self.assertEquals(pv_01, "CONFIG")
+        self.assertEquals(pv_02, "CONF01")

--- a/server_common/test_modules/utilities_tests.py
+++ b/server_common/test_modules/utilities_tests.py
@@ -10,34 +10,52 @@ class TestCreatePVName(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_when_config_name_contains_whitespace_then_replace_with_underscore(self):
-        config = create_pv_name("config name", [], "Default")
+    def test_when_pv_name_contains_whitespace_then_replace_with_underscore(self):
+        pv = create_pv_name("config name", [], "peevee")
 
-        self.assertEquals(config, "CONFIG_NAME")
-        pass
+        self.assertEquals(pv, "CONFIG")
 
-    def test_when_config_name_contains_non_alphanumeric_characters_then_remove(self):
-        config = create_pv_name("c-onf@ig *n>ame=!", [], "Default")
+    def test_when_pv_name_contains_non_alphanumeric_characters_then_remove(self):
+        pv = create_pv_name("c-onf@ig", [], "peevee")
 
-        self.assertEquals(config, "CONFIG_NAME")
-        pass
+        self.assertEquals(pv, "CONFIG")
 
-    def test_when_config_name_contains_only_numbers_and_underscores_then_replace_with_default_config_name(self):
-        config = create_pv_name("1_2_3_4", [], "Default")
+    def test_when_pv_name_contains_only_numbers_and_underscores_then_replace_with_default_pv_name(self):
+        pv = create_pv_name("1_2_3_4", [], "peevee")
 
-        self.assertEquals(config, "Default")
-        pass
+        self.assertEquals(pv, "peevee")
 
-    def test_when_config_name_is_blank_then_replace_with_default_config_name(self):
-        config = create_pv_name("", [], "Default")
+    def test_when_pv_name_is_blank_then_replace_with_default_pv_name(self):
+        pv = create_pv_name("", [], "peevee")
 
-        self.assertEquals(config, "Default")
+        self.assertEquals(pv, "peevee")
 
-    def test_given_blank_config_name_when_another_blank_config_name_then_append_numbers(self):
-        config_01 = create_pv_name("", [], "Default")
-        config_02 = create_pv_name("", [config_01], "Default")
-        config_03 = create_pv_name("", [config_01, config_02], "Default")
+    def test_given_blank_pv_name_when_another_blank_pv_name_then_append_numbers(self):
+        pv_01 = create_pv_name("", [], "peevee")
+        pv_02 = create_pv_name("", [pv_01], "peevee")
+        pv_03 = create_pv_name("", [pv_01, pv_02], "peevee")
 
-        self.assertEquals(config_01, "Default")
-        self.assertEquals(config_02, "Default0")
-        self.assertEquals(config_03, "Default1")
+        self.assertEquals(pv_01, "peevee")
+        self.assertEquals(pv_02, "peev01")
+        self.assertEquals(pv_03, "peev02")
+
+    def test_when_pv_name_too_long_then_truncate(self):
+        pv = create_pv_name("Configuration", [], "peevee")
+
+        self.assertEquals(pv, "CONFIG")
+
+    def test_given_an_existing_pv_when_another_pv_of_same_name_then_rename_differently(self):
+        pv_01 = create_pv_name("Conf", [], "peevee")
+        pv_02 = create_pv_name("Conf", [pv_01], "peevee")
+
+        self.assertEquals(pv_01, "CONF")
+        self.assertEquals(pv_02, "CONF01")
+
+    def test_given_an_existing_truncated_pv_when_another_pv_of_same_name_then_truncate_and_rename_differently(self):
+        pv_01 = create_pv_name("Configuration", [], "peevee")
+        pv_02 = create_pv_name("Configuration", [pv_01], "peevee")
+        pv_03 = create_pv_name("Configuration", [pv_01, pv_02], "peevee")
+
+        self.assertEquals(pv_01, "CONFIG")
+        self.assertEquals(pv_02, "CONF01")
+        self.assertEquals(pv_03, "CONF02")

--- a/server_common/test_modules/utilities_tests.py
+++ b/server_common/test_modules/utilities_tests.py
@@ -48,8 +48,8 @@ class TestCreatePVName(unittest.TestCase):
 
         # Assert
         self.assertEquals(pv_01, "PEEVEE")
-        self.assertEquals(pv_02, "peev01")
-        self.assertEquals(pv_03, "peev02")
+        self.assertEquals(pv_02, "PEEV01")
+        self.assertEquals(pv_03, "PEEV02")
 
     def test_WHEN_pv_name_too_long_THEN_truncate_to_six_chars(self):
         # Act

--- a/server_common/test_modules/utilities_tests.py
+++ b/server_common/test_modules/utilities_tests.py
@@ -1,0 +1,27 @@
+import unittest
+from server_common.utilities import create_pv_name
+
+
+class TestCreatePVName(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_when_config_name_contains_whitespace_then_replace_with_underscore(self):
+        pass
+
+    def test_when_config_name_contains_non_alphanumeric_characters_then_remove(self):
+        pass
+
+    def test_when_config_name_contains_only_numbers_and_underscores_then_replace_with_default_config_name(self):
+        pass
+
+    def test_when_config_name_is_blank_then_replace_with_default_config_name(self):
+        create_pv_name("", [], "Default")
+        self.assertEquals(create_pv_name(), "Default")
+
+    def test_given_blank_config_name_when_another_blank_config_name_then_append_numbers(self):
+        pass

--- a/server_common/utilities.py
+++ b/server_common/utilities.py
@@ -148,13 +148,14 @@ def check_pv_name_valid(name):
     return True
 
 
-def create_pv_name(name, current_pvs, default_pv):
+def create_pv_name(name, current_pvs, default_pv, limit=6):
     """Uses the given name as a basis for a valid PV.
 
     Args:
         name (string): The basis for the PV
         current_pvs (list): List of already allocated pvs
-        default_pv (string): Basis for the PV if name is unreasonable
+        default_pv (string): Basis for the PV if name is unreasonable, must be a valid PV name
+        limit (integer): Character limit for the PV
 
     Returns:
         string : A valid PV
@@ -165,19 +166,18 @@ def create_pv_name(name, current_pvs, default_pv):
     if re.search(r"[^0-9_]", pv_text) is None or pv_text == '':
         pv_text = default_pv
 
-    # Ensure PVs aren't too long
-    max_length = 6
-
-    if pv_text > max_length:
-        pv_text = pv_text[0:max_length]
+    # Ensure PVs aren't too long for the 60 character limit
+    if pv_text > limit:
+        pv_text = pv_text[0:limit]
 
     # Make sure PVs are unique
     i = 1
     pv = pv_text
 
+    # Append a number if the PV already exists
     while pv in current_pvs:
-        if len(pv) > max_length - 2:
-            pv = pv[0:max_length - 2]
+        if len(pv) > limit - 2:
+            pv = pv[0:limit - 2]
         pv += format(i, '02d')
         i += 1
 

--- a/server_common/utilities.py
+++ b/server_common/utilities.py
@@ -165,12 +165,20 @@ def create_pv_name(name, current_pvs, default_pv):
     if re.search(r"[^0-9_]", pv_text) is None or pv_text == '':
         pv_text = default_pv
 
+    # Ensure PVs aren't too long
+    max_length = 6
+
+    if pv_text > max_length:
+        pv_text = pv_text[0:max_length]
+
     # Make sure PVs are unique
-    i = 0
+    i = 1
     pv = pv_text
 
     while pv in current_pvs:
-        pv = pv_text + str(i)
+        if len(pv) > max_length - 2:
+            pv = pv[0:max_length - 2]
+        pv += format(i, '02d')
         i += 1
 
     return pv


### PR DESCRIPTION
ISISComputingGroup/IBEX/issues/1394

Config names are now truncated to six characters (to accommodate a 60 char PV limit). If the shortened name already exists, the PV is further shortened to four characters, with two numbers being appended for  uniqueness (01, 02, etc.). 