### PR TITLE
Ticket1209 reload current config

### DIFF
--- a/BlockServer/core/active_config_holder.py
+++ b/BlockServer/core/active_config_holder.py
@@ -106,6 +106,16 @@ class ActiveConfigHolder(ConfigHolder):
         self.load_active(last_config)
         return last_config
 
+    def reload_current_config(self):
+        """ Reload the current configuration."""
+        current_config_name = self.get_config_name()
+        if current_config_name == "":
+            print_and_log("No current configuration defined. Nothing to reload.")
+            return
+
+        print_and_log("Trying to reload current configuration %s" % current_config_name)
+        self.load_active(current_config_name)
+
     def iocs_changed(self):
         """Checks to see if the IOCs have changed on saving."
 

--- a/BlockServer/core/pv_names.py
+++ b/BlockServer/core/pv_names.py
@@ -36,6 +36,7 @@ class BlockserverPVNames:
     LOAD_CONFIG = prepend_blockserver.__func__('LOAD_CONFIG')
     SAVE_CONFIG = prepend_blockserver.__func__('SAVE_CONFIG')
     CLEAR_CONFIG = prepend_blockserver.__func__('CLEAR_CONFIG')
+    RELOAD_CURRENT_CONFIG = prepend_blockserver.__func__('RELOAD_CURRENT_CONFIG')
     CONF_DESC_RULES = prepend_blockserver.__func__('CONF_DESC_RULES')
     START_IOCS = prepend_blockserver.__func__('START_IOCS')
     STOP_IOCS = prepend_blockserver.__func__('STOP_IOCS')

--- a/BlockServer/mocks/mock_file_manager.py
+++ b/BlockServer/mocks/mock_file_manager.py
@@ -26,6 +26,7 @@ class MockConfigurationFileManager(object):
         base = Configuration(None)
         base.set_name("_base")
         self.comps["_base"] = base
+        self._load_config_requests = list()
 
     def find_ci(self, root_path, name):
         """Find a file with a case insensitive match"""
@@ -36,6 +37,7 @@ class MockConfigurationFileManager(object):
         return res
 
     def load_config(self, name, macros, is_component):
+        self._load_config_requests.append(name)
         if is_component:
             if name.lower() not in self.comps:
                 raise IOError("Component could not be found: " + name)
@@ -63,3 +65,6 @@ class MockConfigurationFileManager(object):
 
     def get_files_in_directory(self, path):
         return list()
+
+    def get_load_config_history(self):
+        return self._load_config_requests

--- a/BlockServer/test_modules/configuration_tests.py
+++ b/BlockServer/test_modules/configuration_tests.py
@@ -40,6 +40,10 @@ class TestConfigurationSequence(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_new_config_has_blank_name(self):
+        # assert
+        self.assertEqual(self.config.get_name(), "")
+
     def test_adding_a_block_and_getting_block_names_returns_the_name_of_the_block(self):
         # arrange
         cf = self.config

--- a/scripts/hex_compress_and_put_pv.py
+++ b/scripts/hex_compress_and_put_pv.py
@@ -25,7 +25,7 @@ It has been placed here for tidiness. To run the script, move it to its parent d
 ...\EPICS\ISIS\inst_servers\master\
 """
 
-from server_common.channel_access import caget, caput
+from server_common.channel_access import ChannelAccess as ca
 import time
 import zlib
 import os
@@ -57,9 +57,9 @@ if __name__ == "__main__":
     
     new_value_compressed = compress_and_hex(new_value)
 
-    caput(pv_address, str(new_value_compressed), True)
+    ca.caput(pv_address, str(new_value_compressed), True)
 
-    result_compr = caget(pv_address, True)
+    result_compr = ca.caget(pv_address, True)
     result = dehex_and_decompress(result_compr)
 
     if result!=new_value:


### PR DESCRIPTION
For ticket ISISComputingGroup/IBEX#1209

The Blockserver now has a new PV (RELOAD_CURRENT_CONFIG) that, when written to, reloads the current configuration.
This means that any IOC that is marked as BOTH auto-start and auto-restart will restart when the current configuration is reloaded.

Also updated unit tests

To test: have one or more IOCs marked as both auto-start and auto-restart as part of your current config, then write any value to the new PV and verify that the IOCs restart.
To write to the PV you can use `scripts/hex_compress_and_put_pv.py` (you might have to copy it one folder up to get it to run)