### PR TITLE
Comment the line

### DIFF
--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -206,7 +206,8 @@ class DatabaseServer(Driver):
                 self.setParam("PVS:INTEREST:HIGH", self.encode4return(self._get_interesting_pvs("HIGH")))
                 self.setParam("PVS:INTEREST:MEDIUM", self.encode4return(self._get_interesting_pvs("MEDIUM")))
                 self.setParam("PVS:INTEREST:FACILITY", self.encode4return(self._get_interesting_pvs("FACILITY")))
-                self._update_individual_interesting_pvs()
+                # Line below commented as quick fix to limit the number of connections to MySQL being generated
+                # self._update_individual_interesting_pvs()
                 # Update them
                 with self.monitor_lock:
                     self.updatePVs()


### PR DESCRIPTION
There were no unit tests, this has broken nothing. To test it, either make sure if you are getting a sockets error that you don't anymore, or make sure you can access an INTERSTING_PVS:IOC:HIGH of some variaty (these are blockserver/database server VIs to allow for the first part to be built), it is likely that the PV exists, but it shouldn't have much info in it.