### PR TITLE
Ticket1515 remove tests that reference removed pv

### DIFF
--- a/DatabaseServer/test_modules/database_server_test_mysql.py
+++ b/DatabaseServer/test_modules/database_server_test_mysql.py
@@ -28,7 +28,6 @@ class TestDatabaseServer(unittest.TestCase):
     def setUp(self):
         self.ms = MockCAServer()
         self.db_server = DatabaseServer(self.ms, TEST_DB, os.path.abspath('./test_files'), True)
-        self.db_server._update_individual_interesting_pvs()
 
     def test_interest_high_pvs_correct(self):
         on_fly_pvs = self.ms.pv_list

--- a/DatabaseServer/test_modules/database_server_test_mysql.py
+++ b/DatabaseServer/test_modules/database_server_test_mysql.py
@@ -30,18 +30,6 @@ class TestDatabaseServer(unittest.TestCase):
         self.db_server = DatabaseServer(self.ms, TEST_DB, os.path.abspath('./test_files'), True)
         self.db_server._update_individual_interesting_pvs()
 
-    def test_interest_high_pvs_exist(self):
-        on_fly_pvs = self.ms.pv_list
-        self.assertTrue("INTERESTING_PVS:TESTIOC:HIGH" in on_fly_pvs.keys())
-        self.assertTrue("INTERESTING_PVS:SIMPLE1:HIGH" in on_fly_pvs.keys())
-        self.assertTrue("INTERESTING_PVS:SIMPLE2:HIGH" in on_fly_pvs.keys())
-
-    def test_interest_medium_pvs_exist(self):
-        on_fly_pvs = self.ms.pv_list
-        self.assertTrue("INTERESTING_PVS:TESTIOC:MEDIUM" in on_fly_pvs.keys())
-        self.assertTrue("INTERESTING_PVS:SIMPLE1:MEDIUM" in on_fly_pvs.keys())
-        self.assertTrue("INTERESTING_PVS:SIMPLE2:MEDIUM" in on_fly_pvs.keys())
-
     def test_interest_high_pvs_correct(self):
         on_fly_pvs = self.ms.pv_list
         data = [json.loads(dehex_and_decompress(x)) for x in on_fly_pvs.values()]


### PR DESCRIPTION
These tests reference a method and PV that no longer exist. Remove them. I've double-checked and the PV no longer exists anywhere else in EPICS