### PR TITLE
Auto-commit queries to avoid unwanted caching

### DIFF
--- a/DatabaseServer/mysql_abstraction_layer.py
+++ b/DatabaseServer/mysql_abstraction_layer.py
@@ -108,6 +108,9 @@ class SQLAbstraction(object):
             self.open_connection_if_closed()
             self._curs.execute(query)
             values = self._curs.fetchall()
+            # Commit as part of the query or results won't be updated between subsequent transactions. Can lead
+            # to values not auto-updating in the GUI.
+            self._conn.commit()
             return values
         except Exception as err:
             if retry:

--- a/DatabaseServer/mysql_abstraction_layer.py
+++ b/DatabaseServer/mysql_abstraction_layer.py
@@ -130,7 +130,7 @@ class SQLAbstraction(object):
             if retry:
                 try:
                     self.reset_connection()
-                    self.execute_query(query=query,retry=False)
+                    self.commit(query=query,retry=False)
                 except Exception as reconnection_err:
                     err = reconnection_err
             raise Exception("Error updating database: %s" % err)


### PR DESCRIPTION
This is a side-effect of the full fix of ticket https://github.com/ISISComputingGroup/IBEX/issues/1516 where we stopped opening a new connection for every query. The change in part makes the connection appear "stale", that is, when queries are run regularly they return the same result in spite of the content of the underlying database having changed.

The solution is to perform a commit after each query, even if the query itself doesn't explicitly update the database. This solves the problem with interesting PVs, as well as a number of other issues like the IOC status not updating properly in the IOC control panel.