### PR TITLE
Lock the SQL interactions to a single thread

### DIFF
--- a/DatabaseServer/mysql_abstraction_layer.py
+++ b/DatabaseServer/mysql_abstraction_layer.py
@@ -16,6 +16,7 @@
 
 import mysql.connector
 from server_common.utilities import print_and_log
+from threading import RLock
 
 
 class SQLAbstraction(object):
@@ -36,6 +37,7 @@ class SQLAbstraction(object):
         self._host = host
         self._conn = None
         self._curs = None
+        self._sql_lock = RLock()
 
     def check_db_okay(self):
         """Attempts to connect to the database and raises an error if not able to do so
@@ -104,30 +106,32 @@ class SQLAbstraction(object):
             values (list): list of all rows returned
         """
 
-        try:
-            self.open_connection_if_closed()
-            self._curs.execute(query)
-            values = self._curs.fetchall()
-            return values
-        except Exception as err:
-            if retry:
-                try:
-                    self.reset_connection()
-                    self.execute_query(query=query,retry=False)
-                except Exception as reconnection_err:
-                    err = reconnection_err
-            raise Exception("Error executing query: %s" % err)
+        with self._sql_lock:
+            try:
+                self.open_connection_if_closed()
+                self._curs.execute(query)
+                values = self._curs.fetchall()
+                return values
+            except Exception as err:
+                if retry:
+                    try:
+                        self.reset_connection()
+                        self.execute_query(query=query,retry=False)
+                    except Exception as reconnection_err:
+                        err = reconnection_err
+                raise Exception("Error executing query: %s" % err)
 
     def commit(self, query, retry=True):
-        try:
-            self.open_connection_if_closed()
-            self._curs.execute(query)
-            self._conn.commit()
-        except Exception as err:
-            if retry:
-                try:
-                    self.reset_connection()
-                    self.execute_query(query=query,retry=False)
-                except Exception as reconnection_err:
-                    err = reconnection_err
-            raise Exception("Error updating database: %s" % err)
+        with self._sql_lock:
+            try:
+                self.open_connection_if_closed()
+                self._curs.execute(query)
+                self._conn.commit()
+            except Exception as err:
+                if retry:
+                    try:
+                        self.reset_connection()
+                        self.execute_query(query=query,retry=False)
+                    except Exception as reconnection_err:
+                        err = reconnection_err
+                raise Exception("Error updating database: %s" % err)


### PR DESCRIPTION
Without adding debug comments this is a hard one to locate and test, however, if you have your system running as standard (prior to checking out this branch), open a console to the DBSVR, in another command prompt run the following:

```
camonitor NDW1032:KVLB23:PARS:SAMPLE:HEIGHT NDW1032:KVLB23:PARS:SAMPLE:HEIGHT:SP
```

and run the following in genie_python:

```
for i in range(250):
  change_sample_par("HEIGHT",i)
```

there should be some errors, or hangs, or some other odd behaviour visible either in the genie_python script, or in the monitors. Keep restarting the DBSVR (Ctrl-X in the DBSVR console window) until the script completes.

Checkout the branch for this pull request, and restart the DBSVR once more (to load the altered code). Re-run the script and this time it should go through with no issues at all, in fact increase the range to 2500 and there should still be no errors (at least according to my tests).

It might be worth trying some other parameters, or other SQL interactions for completeness, but I shall leave that to the reviewer to decide on.