### PR TITLE
Do not reappy autorestart on restart

### DIFF
--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -250,7 +250,7 @@ class RunControlManager(OnTheFlyPvInterface):
             print_and_log("Reusing the existing run-control autosave files")
 
         try:
-            self._ioc_control.restart_ioc(RUNCONTROL_IOC, force=True)
+            self._ioc_control.restart_ioc(RUNCONTROL_IOC, force=True, reapply_auto=False)
         except Exception as err:
             print_and_log("Problem with restarting the run-control IOC: %s" % str(err), "MAJOR")
 


### PR DESCRIPTION
### Description of work

Do not re-apply previous autorestart value for run control, which should ensure it is always on
 
See ISISComputingGroup/IBEX#1711

### To test

Check run control restart on config/block change

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-thredded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

