### PR TITLE
Ticket1518 file watcher error

### DIFF
--- a/BlockServer/devices/devices_manager.py
+++ b/BlockServer/devices/devices_manager.py
@@ -111,7 +111,7 @@ class DevicesManager(OnTheFlyPvInterface):
                                                                                   SCREENS_SCHEMA), self._data)
         except ConfigurationInvalidUnderSchema as err:
             self._data = self.get_blank_devices()
-            print_and_log(err)
+            print_and_log(err.message)
             return
 
         try:
@@ -142,7 +142,7 @@ class DevicesManager(OnTheFlyPvInterface):
             ConfigurationSchemaChecker.check_xml_data_matches_schema(os.path.join(self._schema_folder, SCREENS_SCHEMA),
                                                                      xml_data)
         except ConfigurationInvalidUnderSchema as err:
-            print_and_log(err)
+            print_and_log(err.message)
             return
 
         try:

--- a/BlockServer/fileIO/config_file_event_handler.py
+++ b/BlockServer/fileIO/config_file_event_handler.py
@@ -94,7 +94,7 @@ class ConfigFileEventHandler(FileSystemEventHandler):
         except Exception as err:
             print_and_log("File Watcher: " + str(err), "MAJOR", "FILEWTCHR")
 
-        print_and_log("File Watcher: Recovered %s, please delete via client" % event.src_path, "MAJOR", "FILEWTCHR")
+        print_and_log("File Watcher: Repository reverted after %s deleted manually. Please delete files via client" % event.src_path, "MAJOR", "FILEWTCHR")
 
     def _check_config_valid(self, path):
         if self._check_file_at_root(path):

--- a/BlockServer/fileIO/config_file_event_handler.py
+++ b/BlockServer/fileIO/config_file_event_handler.py
@@ -97,6 +97,8 @@ class ConfigFileEventHandler(FileSystemEventHandler):
         print_and_log("File Watcher: Repository reverted after %s deleted manually. Please delete files via client" % event.src_path, "MAJOR", "FILEWTCHR")
 
     def _check_config_valid(self, path):
+        ic = None
+
         if self._check_file_at_root(path):
             raise NotConfigFileException("File in root directory")
 

--- a/BlockServer/fileIO/schema_checker.py
+++ b/BlockServer/fileIO/schema_checker.py
@@ -60,7 +60,7 @@ class ConfigurationSchemaChecker(object):
         try:
             etree.fromstring(xml_data, xmlparser)
         except etree.XMLSyntaxError as err:
-            raise ConfigurationInvalidUnderSchema(str(err.message))
+            raise ConfigurationInvalidUnderSchema(err.message)
 
     @staticmethod
     def check_xml_matches_schema(schema_filepath, screen_xml_data, object_type):
@@ -68,7 +68,7 @@ class ConfigurationSchemaChecker(object):
             ConfigurationSchemaChecker.check_xml_data_matches_schema(schema_filepath, screen_xml_data)
         except ConfigurationInvalidUnderSchema as err:
             raise ConfigurationInvalidUnderSchema(
-                "{object_type} incorrectly formatted: {err}".format(object_type=object_type, err=str(err.value)))
+                "{object_type} incorrectly formatted: {err}".format(object_type=object_type, err=err.message))
 
     @staticmethod
     def _check_file_against_schema(xml_file, schema_folder, schema_file):

--- a/BlockServer/fileIO/schema_checker.py
+++ b/BlockServer/fileIO/schema_checker.py
@@ -24,18 +24,19 @@ from BlockServer.core.file_path_manager import FILEPATH_MANAGER
 
 
 class NotConfigFileException(Exception):
-    def __init__(self, value):
-        super(Exception,self).__init__(value)
-
+    def __init__(self, message):
+        super(Exception,self).__init__(message)
+        self.message = message
 
 class ConfigurationIncompleteException(Exception):
-    def __init__(self, value):
-        super(Exception,self).__init__(value)
-
+    def __init__(self, message):
+        super(Exception,self).__init__(message)
+        self.message = message
 
 class ConfigurationInvalidUnderSchema(Exception):
-    def __init__(self, value):
-        super(Exception,self).__init__(value)
+    def __init__(self, message):
+        super(Exception,self).__init__(message)
+        self.message = message
 
 
 class ConfigurationSchemaChecker(object):

--- a/BlockServer/fileIO/synoptic_file_event_handler.py
+++ b/BlockServer/fileIO/synoptic_file_event_handler.py
@@ -92,7 +92,7 @@ class SynopticFileEventHandler(FileSystemEventHandler):
         except Exception as err:
             print_and_log("File Watcher: " + str(err), "MAJOR", "FILEWTCHR")
 
-        print_and_log("File Watcher: Recovered %s, please delete via client" % event.src_path, "MAJOR", "FILEWTCHR")
+        print_and_log("File Watcher: Repository reverted after %s deleted manually. Please delete files via client" % event.src_path, "MAJOR", "FILEWTCHR")
 
     def _check_synoptic_valid(self, path):
         extension = path[-4:]

--- a/BlockServer/fileIO/synoptic_file_event_handler.py
+++ b/BlockServer/fileIO/synoptic_file_event_handler.py
@@ -70,7 +70,7 @@ class SynopticFileEventHandler(FileSystemEventHandler):
 
                     # Inform user
                     print_and_log("The synoptic, %s, has been modified in the filesystem, ensure it is added to "
-                                  "version control" % name, "INFO", "FILEWTCHER")
+                                  "version control" % name, "INFO", "FILEWTCHR")
 
                 except NotConfigFileException as err:
                     print_and_log("File Watcher: " + str(err), src="FILEWTCHR")

--- a/block_server.py
+++ b/block_server.py
@@ -657,16 +657,16 @@ class BlockServer(Driver):
             self.load_config, ("configname",), "LOADING_CONFIG")
         """
         while True:
-            with self.write_lock:
+            while len(self.write_queue) > 0:
                 if self._filewatcher is not None: self._filewatcher.pause()
-                while len(self.write_queue) > 0:
+                with self.write_lock:
                     cmd, arg, state = self.write_queue.pop(0)
-                    self.update_server_status(state)
-                    if arg is not None:
-                        cmd(*arg)
-                    else:
-                        cmd()
-                    self.update_server_status("")
+                self.update_server_status(state)
+                if arg is not None:
+                    cmd(*arg)
+                else:
+                    cmd()
+                self.update_server_status("")
                 if self._filewatcher is not None: self._filewatcher.resume()
             sleep(1)
 

--- a/block_server.py
+++ b/block_server.py
@@ -390,7 +390,11 @@ class BlockServer(Driver):
             if status:
                 value = compress_and_hex(convert_to_json("OK"))
         finally:
-            pass
+            queue_empty = False
+            while not queue_empty:
+                with self.write_lock:
+                    queue_empty = len(self.write_queue) == 0
+                sleep(1)
             self._filewatcher.resume()
 
         # store the values

--- a/block_server.py
+++ b/block_server.py
@@ -662,10 +662,13 @@ class BlockServer(Driver):
                 with self.write_lock:
                     cmd, arg, state = self.write_queue.pop(0)
                 self.update_server_status(state)
-                if arg is not None:
-                    cmd(*arg)
-                else:
-                    cmd()
+                try:
+                    if arg is not None:
+                        cmd(*arg)
+                    else:
+                        cmd()
+                except Exception as err:
+                    print_and_log("Error executing write queue command %s for state %s: %s" % (cmd.__name__, state, err.message), "MAJOR")
                 self.update_server_status("")
                 if self._filewatcher is not None: self._filewatcher.resume()
             sleep(1)

--- a/block_server.py
+++ b/block_server.py
@@ -320,7 +320,7 @@ class BlockServer(Driver):
             commands are queued as Channel Access is single-threaded.
 
             Note that the filewatcher is disabled as part of the write queue so any operations that intend to modify
-            files should use the write queue. See tickets 1500 and 1518
+            files should use the write queue.
 
         Args:
             reason (string): The PV that is being requested (without the PV prefix)


### PR DESCRIPTION
### Description of work

_Wait for https://github.com/ISISComputingGroup/EPICS-inst_servers/pull/80 to be merged_

The filewatcher is supposed to be disabled when the block server writes to the file system. However in the previous setup, the asynchronous nature of the write queue meant that often (e.g. synoptics), the filewatcher was re-enabled before the command was executed.

I've changed the flow of logic so that the filewatcher is disabled as part of the execution of the write queue so it will automatically apply to all write commands.

Note that if a write command is executed outside of the queue, as is currently the case for config methods, then they will now throw the error currently reported by the synoptics. This will be fixed by ticket #1500. Please wait for that to be merged first.

Also tidied up some of the exception coding to Python standards.
### To test

https://github.com/ISISComputingGroup/IBEX/issues/1518
### Acceptance criteria
- [ ] Deleting synoptics no longer results in `filewtchr` errors
- [ ] Add/edit/remove operations for configs/components/synoptics continue to work as expected with no `filewtchr` errors
- [ ] Modifying/deleting files from the file system directly still result in errors from the `filewtchr` and the file is restored automatically by the block server.

---
#### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-thredded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?
### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed.
### Final steps
- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
