### PR TITLE
added fix and test for setting device screens

### DIFF
--- a/BlockServer/devices/devices_manager.py
+++ b/BlockServer/devices/devices_manager.py
@@ -153,6 +153,7 @@ class DevicesManager(OnTheFlyPvInterface):
             return
 
         # Update PVs
+        self._data = xml_data
         self.update_monitors()
 
         self._add_to_version_control("%s modified by client" % self._curr_config_name)

--- a/BlockServer/test_modules/devices_manager_tests.py
+++ b/BlockServer/test_modules/devices_manager_tests.py
@@ -171,15 +171,28 @@ class TestDevicesManagerSequence(unittest.TestCase):
         self.assertEquals(EXAMPLE_DEVICES, dehex_and_decompress(self.bs.pvs[GET_SCREENS]))
 
     def test_given_invalid_devices_data_when_device_xml_saved_then_not_saved(self):
+        # Arrange:
         self.ach.set_config_name(BASE_PATH)
         self.dm.initialise()
 
-        # Act: Save the new data to file
+        # Act: Save invalid new data to file
         self.dm.save_devices_xml(INVALID_DEVICES)
 
         # Assert
         # Should stay as blank (i.e. the previous value)
         self.assertEquals(self.dm.get_blank_devices(), dehex_and_decompress(self.bs.pvs[GET_SCREENS]))
+
+    def test_given_valid_devices_data_when_device_xml_saved_then_saved(self):
+        # Arrange:
+        self.ach.set_config_name(BASE_PATH)
+        self.dm.initialise()
+
+        # Act: Save the new data to file
+        self.dm.save_devices_xml(EXAMPLE_DEVICES)
+
+        # Assert:
+        # Device screens in blockserver should have been updated with value written to device manager
+        self.assertEquals(EXAMPLE_DEVICES, dehex_and_decompress(self.bs.pvs[GET_SCREENS]))
 
     def test_save_devices_xml_creates_get_screens_pv(self):
         self.ach.set_config_name(BASE_PATH)


### PR DESCRIPTION
### Description of work

Added a fix for setting device screens (data was not being updated previously).

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1724

### Acceptance criteria

* Adding, editing and deleting device screens works properly.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-thredded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

