### PR TITLE
Ticket1770 block server restart crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ runIOC.sh
 relPaths.sh
 *.py[oc]
 *.sq3
+.idea
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ runIOC.sh
 relPaths.sh
 *.py[oc]
 *.sq3
-.idea
+/.idea
 .project

--- a/BlockServer/core/ioc_control.py
+++ b/BlockServer/core/ioc_control.py
@@ -94,6 +94,17 @@ class IocControl(object):
         """
         return self._proc.get_ioc_status(self._prefix, ioc)
 
+    def ioc_restart_pending(self, ioc):
+        """Tests if the IOC has a pending restart
+
+        Args:
+            ioc (string): The name of the IOC
+
+        Returns:
+            bool : Whether a restart is pending
+        """
+        return self._proc.ioc_restart_pending(self._prefix, ioc)
+
     def start_iocs(self, iocs):
         """ Start a number of IOCs.
 
@@ -180,7 +191,7 @@ class IocControl(object):
         """
         if self.ioc_exists(ioc):
             start = time()
-            while self.get_ioc_status(ioc) != "RUNNING":
+            while self.ioc_restart_pending(ioc) or self.get_ioc_status(ioc) != "RUNNING":
                 sleep(0.5)
                 if time() - start >= timeout:
                     print_and_log("Gave up waiting for IOC %s to be running" % ioc, "MAJOR")

--- a/BlockServer/epics/procserv_utils.py
+++ b/BlockServer/epics/procserv_utils.py
@@ -15,7 +15,7 @@
 # http://opensource.org/licenses/eclipse-1.0.php
 
 from server_common.channel_access import ChannelAccess
-from server_common.utilities import print_and_log
+from server_common.utilities import print_and_log, check_if_restarting
 
 
 class ProcServWrapper(object):
@@ -74,8 +74,7 @@ class ProcServWrapper(object):
         Returns:
             bool: Whether a restart is pending
         """
-        return True if ChannelAccess.caget(self.generate_prefix(prefix, ioc) + ":RESTART",
-                                           as_string=True) is "Busy" else False
+        return check_if_restarting(self.generate_prefix(prefix, ioc),ChannelAccess)
 
     def get_ioc_status(self, prefix, ioc):
         """Gets the status of the specified IOC.

--- a/BlockServer/epics/procserv_utils.py
+++ b/BlockServer/epics/procserv_utils.py
@@ -74,7 +74,7 @@ class ProcServWrapper(object):
         Returns:
             bool: Whether a restart is pending
         """
-        return ioc_restart_pending(self.generate_prefix(prefix, ioc),ChannelAccess)
+        return ioc_restart_pending(self.generate_prefix(prefix, ioc), ChannelAccess)
 
     def get_ioc_status(self, prefix, ioc):
         """Gets the status of the specified IOC.

--- a/BlockServer/epics/procserv_utils.py
+++ b/BlockServer/epics/procserv_utils.py
@@ -15,7 +15,7 @@
 # http://opensource.org/licenses/eclipse-1.0.php
 
 from server_common.channel_access import ChannelAccess
-from server_common.utilities import print_and_log, check_if_restarting
+from server_common.utilities import print_and_log, ioc_restart_pending
 
 
 class ProcServWrapper(object):
@@ -74,7 +74,7 @@ class ProcServWrapper(object):
         Returns:
             bool: Whether a restart is pending
         """
-        return check_if_restarting(self.generate_prefix(prefix, ioc),ChannelAccess)
+        return ioc_restart_pending(self.generate_prefix(prefix, ioc),ChannelAccess)
 
     def get_ioc_status(self, prefix, ioc):
         """Gets the status of the specified IOC.

--- a/BlockServer/epics/procserv_utils.py
+++ b/BlockServer/epics/procserv_utils.py
@@ -74,7 +74,8 @@ class ProcServWrapper(object):
         Returns:
             bool: Whether a restart is pending
         """
-        return True if ChannelAccess.caget(self.generate_prefix(prefix, ioc) + ":RESTART", as_string=True) is "Busy" else False
+        return True if ChannelAccess.caget(self.generate_prefix(prefix, ioc) + ":RESTART",
+                                           as_string=True) is "Busy" else False
 
     def get_ioc_status(self, prefix, ioc):
         """Gets the status of the specified IOC.

--- a/BlockServer/epics/procserv_utils.py
+++ b/BlockServer/epics/procserv_utils.py
@@ -74,7 +74,7 @@ class ProcServWrapper(object):
         Returns:
             bool: Whether a restart is pending
         """
-        True if ChannelAccess.caget(self.generate_prefix(prefix, ioc) + ":RESTART", as_string=True) is "Busy" else False
+        return True if ChannelAccess.caget(self.generate_prefix(prefix, ioc) + ":RESTART", as_string=True) is "Busy" else False
 
     def get_ioc_status(self, prefix, ioc):
         """Gets the status of the specified IOC.

--- a/BlockServer/epics/procserv_utils.py
+++ b/BlockServer/epics/procserv_utils.py
@@ -64,6 +64,18 @@ class ProcServWrapper(object):
         print_and_log("Restarting IOC %s" % ioc)
         ChannelAccess.caput(self.generate_prefix(prefix, ioc) + ":RESTART", 1)
 
+    def ioc_restart_pending(self, prefix, ioc):
+        """Tests to see if an IOC restart is pending
+
+        Args:
+            prefix (string): The prefix for the instrument
+            ioc (string): The name of the IOC
+
+        Returns:
+            bool: Whether a restart is pending
+        """
+        True if ChannelAccess.caget(self.generate_prefix(prefix, ioc) + ":RESTART", as_string=True) is "Busy" else False
+
     def get_ioc_status(self, prefix, ioc):
         """Gets the status of the specified IOC.
 

--- a/BlockServer/mocks/mock_ioc_control.py
+++ b/BlockServer/mocks/mock_ioc_control.py
@@ -37,6 +37,9 @@ class MockIocControl(object):
     def get_ioc_status(self, ioc):
         return self._proc.get_ioc_status(self._prefix, ioc)
 
+    def ioc_restart_pending(self, ioc):
+        return self._proc.ioc_restart_pending(self._prefix, ioc)
+
     def start_iocs(self, iocs):
         for ioc in iocs:
             self._proc.start_ioc(self._prefix, ioc)

--- a/BlockServer/mocks/mock_procserv_utils.py
+++ b/BlockServer/mocks/mock_procserv_utils.py
@@ -35,6 +35,10 @@ class MockProcServWrapper(object):
         """Stops the specified IOC"""
         self.ps_status[ioc.lower()] = "SHUTDOWN"
 
+    def ioc_restart_pending(self, prefix, ioc):
+        """Currently mock restarts instantly"""
+        return False
+
     def restart_ioc(self, prefix, ioc):
         self.ps_status[ioc.lower()] = "RUNNING"
 

--- a/BlockServer/mocks/mock_procserv_utils.py
+++ b/BlockServer/mocks/mock_procserv_utils.py
@@ -23,6 +23,7 @@ class MockProcServWrapper(object):
         self.ps_status["simple2"] = "SHUTDOWN"
         self.ps_status["testioc"] = "SHUTDOWN"
         self.autorestart = False
+        self.restarting = False
 
     @staticmethod
     def generate_prefix(prefix, ioc):
@@ -36,10 +37,13 @@ class MockProcServWrapper(object):
         self.ps_status[ioc.lower()] = "SHUTDOWN"
 
     def ioc_restart_pending(self, prefix, ioc):
-        """Currently mock restarts instantly"""
-        return False
+        """Return the currently restarting state then complete the pending restart"""
+        restarting = self.restarting
+        self.restarting = False
+        return restarting
 
     def restart_ioc(self, prefix, ioc):
+        self.restarting = True
         self.ps_status[ioc.lower()] = "RUNNING"
 
     def get_ioc_status(self, prefix, ioc):

--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -24,10 +24,9 @@ from server_common.utilities import print_and_log, compress_and_hex, check_pv_na
 from server_common.channel_access import ChannelAccess
 from BlockServer.core.pv_names import BlockserverPVNames
 
-
 TAG_RC_DICT = {"LOW": TAG_RC_LOW, "HIGH": TAG_RC_HIGH, "ENABLE": TAG_RC_ENABLE}
 RC_IOC_PREFIX = "CS:PS:RUNCTRL_01"
-RC_RESET_PV = "CS:IOC:RUNCTRL_01:DEVIOS:SysReset"
+RC_START_PV = "CS:IOC:RUNCTRL_01:DEVIOS:STARTTOD"
 RUNCONTROL_SETTINGS = "rc_settings.cmd"
 AUTOSAVE_DIR = "autosave"
 RUNCONTROL_IOC = "RUNCTRL_01"
@@ -39,6 +38,7 @@ RUNCONTROL_GET_PV = BlockserverPVNames.prepend_blockserver('GET_RC_PARS')
 class RunControlManager(OnTheFlyPvInterface):
     """A class for taking care of setting up run-control.
     """
+
     def __init__(self, prefix, config_dir, var_dir, ioc_control, active_configholder, block_server,
                  channel_access=ChannelAccess()):
         """Constructor.
@@ -52,6 +52,7 @@ class RunControlManager(OnTheFlyPvInterface):
             block_server (BlockServer): A reference to the BlockServer instance
             channel_access (ChannelAccess): A reference to the ChannelAccess instance
         """
+        self._rc_ioc_start_time = ""
         self._prefix = prefix
         self._settings_file = os.path.join(config_dir, RUNCONTROL_SETTINGS)
         self._autosave_dir = os.path.join(var_dir, AUTOSAVE_DIR, RUNCONTROL_IOC)
@@ -219,18 +220,18 @@ class RunControlManager(OnTheFlyPvInterface):
         # TODO: Give up after a bit
         print_and_log("Waiting for runcontrol IOC to start")
         while True:
-            # See if the IOC has restarted by looking for a standard PV
+            # See if the IOC has restarted
             try:
-                running = True if self._channel_access.caget(self._prefix + RC_RESET_PV) is not None else False
-                restart_pending = ioc_restart_pending(self._prefix + RC_IOC_PREFIX, self._channel_access)
-                started = running and not restart_pending
-            except Exception as err:
-                # Probably has timed out
-                started = False
-            if started:
+                if ioc_restart_pending(self._prefix + RC_IOC_PREFIX, self._channel_access):
+                    raise Exception()
+                latest_ioc_start = self._channel_access.caget(self._prefix + RC_START_PV)
+                if latest_ioc_start is None or latest_ioc_start <= self._rc_ioc_start_time:
+                    raise Exception()
+                self._rc_ioc_start_time = latest_ioc_start
                 print_and_log("Runcontrol IOC started")
                 break
-            sleep(2)
+            except Exception as err:
+                sleep(2)
         # wait for other RC PVs to appear
         sleep(5)
 

--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -27,7 +27,7 @@ from BlockServer.core.pv_names import BlockserverPVNames
 
 TAG_RC_DICT = {"LOW": TAG_RC_LOW, "HIGH": TAG_RC_HIGH, "ENABLE": TAG_RC_ENABLE}
 RC_IOC_PREFIX = "CS:PS:RUNCTRL_01"
-RC_RESET_PV = RC_IOC_PREFIX + ":DEVIOS:SysReset"
+RC_RESET_PV = "CS:IOC:RUNCTRL_01:DEVIOS:SysReset"
 RUNCONTROL_SETTINGS = "rc_settings.cmd"
 AUTOSAVE_DIR = "autosave"
 RUNCONTROL_IOC = "RUNCTRL_01"
@@ -222,7 +222,7 @@ class RunControlManager(OnTheFlyPvInterface):
             # See if the IOC has restarted by looking for a standard PV
             try:
                 running = True if self._channel_access.caget(self._prefix + RC_RESET_PV) is not None else False
-                restart_pending = ioc_restart_pending(RC_IOC_PREFIX, self._channel_access)
+                restart_pending = ioc_restart_pending(self._prefix + RC_IOC_PREFIX, self._channel_access)
                 started = running and not restart_pending
             except Exception as err:
                 # Probably has timed out

--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -20,7 +20,7 @@ from time import sleep
 from BlockServer.core.constants import TAG_RC_LOW, TAG_RC_HIGH, TAG_RC_ENABLE, TAG_RC_OUT_LIST
 from BlockServer.core.on_the_fly_pv_interface import OnTheFlyPvInterface
 from server_common.utilities import print_and_log, compress_and_hex, check_pv_name_valid, create_pv_name, \
-    convert_to_json, check_if_ioc_restarting
+    convert_to_json, ioc_restart_pending
 from server_common.channel_access import ChannelAccess
 from BlockServer.core.pv_names import BlockserverPVNames
 
@@ -222,7 +222,7 @@ class RunControlManager(OnTheFlyPvInterface):
             # See if the IOC has restarted by looking for a standard PV
             try:
                 running = True if self._channel_access.caget(self._prefix + RC_RESET_PV) is not None else False
-                restart_pending = check_if_ioc_restarting(RC_IOC_PREFIX,self._channel_access)
+                restart_pending = ioc_restart_pending(RC_IOC_PREFIX, self._channel_access)
                 started = running and not restart_pending
             except Exception as err:
                 # Probably has timed out

--- a/BlockServer/test_modules/ioc_control_tests.py
+++ b/BlockServer/test_modules/ioc_control_tests.py
@@ -81,9 +81,16 @@ class TestIocControlSequence(unittest.TestCase):
         ic.set_autorestart("TESTIOC", False)
         self.assertEqual(ic.get_autorestart("TESTIOC"), False)
 
-    def test_when_restart_requested_then_gets_proc_serv_restart_pending_value(self):
+    def test_GIVEN_reapply_auto_default_WHEN_ioc_restart_requested_THEN_ioc_control_waits_for_restart_complete(self):
         ic = IocControl("", MockProcServWrapper())
         ic.start_ioc("TESTIOC")
         self.assertFalse(ic.ioc_restart_pending("TESTIOC"))
         ic.restart_ioc("TESTIOC")
+        self.assertFalse(ic.ioc_restart_pending("TESTIOC"))
+
+    def test_GIVEN_reapply_auto_False_WHEN_ioc_restart_requested_THEN_ioc_control_may_return_before_restart_complete(self):
+        ic = IocControl("", MockProcServWrapper())
+        ic.start_ioc("TESTIOC")
+        self.assertFalse(ic.ioc_restart_pending("TESTIOC"))
+        ic.restart_ioc("TESTIOC",reapply_auto=False)
         self.assertTrue(ic.ioc_restart_pending("TESTIOC"))

--- a/BlockServer/test_modules/ioc_control_tests.py
+++ b/BlockServer/test_modules/ioc_control_tests.py
@@ -80,3 +80,10 @@ class TestIocControlSequence(unittest.TestCase):
         self.assertEqual(ic.get_autorestart("TESTIOC"), True)
         ic.set_autorestart("TESTIOC", False)
         self.assertEqual(ic.get_autorestart("TESTIOC"), False)
+
+    def test_when_restart_requested_then_gets_proc_serv_restart_pending_value(self):
+        ic = IocControl("", MockProcServWrapper())
+        ic.start_ioc("TESTIOC")
+        self.assertFalse(ic.ioc_restart_pending("TESTIOC"))
+        ic.restart_ioc("TESTIOC")
+        self.assertTrue(ic.ioc_restart_pending("TESTIOC"))

--- a/BlocksCache/blocks_cache.py
+++ b/BlocksCache/blocks_cache.py
@@ -328,5 +328,5 @@ if __name__ == '__main__':
         try:
             SERVER.process(0.1)
         except Exception as err:
-            print_and_log(str(err))
+            print_and_log(str(err), "MAJOR")
             break

--- a/BlocksCache/blocks_cache.py
+++ b/BlocksCache/blocks_cache.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath(os.environ["MYDIRBLOCK"]))
 
 from pcaspy import SimpleServer, Driver
 from CaChannel import ca, CaChannel, CaChannelException
-from server_common.utilities import compress_and_hex, convert_to_json, waveform_to_string, dehex_and_decompress
+from server_common.utilities import compress_and_hex, convert_to_json, waveform_to_string, dehex_and_decompress,  print_and_log
 
 EXISTS_TIMEOUT = 3 
 PEND_EVENT_TIMEOUT = 0.1
@@ -325,4 +325,8 @@ if __name__ == '__main__':
 
     # Process CA transactions
     while True:
-        SERVER.process(0.1)
+        try:
+            SERVER.process(0.1)
+        except Exception as err:
+            print_and_log(str(err))
+            break

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -314,7 +314,8 @@ if __name__ == '__main__':
     while True:
         try:
             SERVER.process(0.1)
-        except:
+        except Exception as err:
+            print_and_log(err,"MAJOR")
             break
 
     DRIVER.close()

--- a/block_server.py
+++ b/block_server.py
@@ -726,17 +726,20 @@ class BlockServer(Driver):
     def add_string_pv_to_db(self, name, count=1000):
         # Check name not already in PVDB and that a PV does not already exist
         if name not in PVDB and name not in manager.pvs[self.port]:
-            print_and_log("Adding PV %s" % name)
-            PVDB[name] = {
-                'type': 'char',
-                'count': count,
-                'value': [0],
-            }
-            self._cas.createPV(BLOCKSERVER_PREFIX, PVDB)
-            # self.configure_pv_db()
-            data = Data()
-            data.value = manager.pvs[self.port][name].info.value
-            self.pvDB[name] = data
+            try:
+                print_and_log("Adding PV %s" % name)
+                PVDB[name] = {
+                    'type': 'char',
+                    'count': count,
+                    'value': [0],
+                }
+                self._cas.createPV(BLOCKSERVER_PREFIX, PVDB)
+                # self.configure_pv_db()
+                data = Data()
+                data.value = manager.pvs[self.port][name].info.value
+                self.pvDB[name] = data
+            except Exception as err:
+                print_and_log("Unable to add PV %S" % name,"MAJOR")
 
 
 if __name__ == '__main__':
@@ -800,4 +803,9 @@ if __name__ == '__main__':
 
     # Process CA transactions
     while True:
-        SERVER.process(0.1)
+        try:
+            SERVER.process(0.1)
+        except Exception as err:
+            print_and_log(err,"MAJOR")
+            break
+

--- a/server_common/utilities.py
+++ b/server_common/utilities.py
@@ -208,3 +208,16 @@ def waveform_to_string(data):
         output += str(unichr(i))
     return output
 
+
+def check_if_ioc_restarting(ioc_pv,channel_access):
+    """Check if a particular IOC is restarting. Assumes it has suitable restart PV
+
+    Args:
+        ioc_pv: The base PV for the IOC with instrument PV prefix
+        channel_access: The channel access object to be used for accessing PVs
+
+    Return
+        bool: True if restarting, else False
+    """
+    return True if channel_access.caget(ioc_pv + ":RESTART", as_string=True) is "Busy" else False
+

--- a/server_common/utilities.py
+++ b/server_common/utilities.py
@@ -209,7 +209,7 @@ def waveform_to_string(data):
     return output
 
 
-def check_if_ioc_restarting(ioc_pv,channel_access):
+def ioc_restart_pending(ioc_pv, channel_access):
     """Check if a particular IOC is restarting. Assumes it has suitable restart PV
 
     Args:


### PR DESCRIPTION
### Description of work

The call to restart an IOC returns immediately. When we check waitfor_running, we may query the IOC before it's actually stopped as part of that restart. To avoid this situation, we check the read back on the restart IOC PV to see if there are any operations pending.

In the course of the investigation, I've also added a bit more error handling code.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1770

### Acceptance criteria

- [x] Blockserver can be restarted consistently without it crashing (this happened for me about 25% of the time when restarting from the console pre-fix).
- [x] No changes to the availability of blocks from the GUI
- [x] Confirm that after restart that essential IOCs are still running (RUNCTRL, BLOCKSVR, BLOCKCACHE, ISISDAE)

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-thredded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [x] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
