### PR TITLE
Ticket1595 macro updates too slow

### DIFF
--- a/block_server.py
+++ b/block_server.py
@@ -419,7 +419,7 @@ class BlockServer(Driver):
             details (string): the configuration XML
         """
         self._active_configserver.set_config_details(details)
-        # Need to save the config to file before we initialize or the changes won't be propogated to IOCS
+        # Need to save the config to file before we initialize or the changes won't be propagated to IOCS
         self.save_active_config(self._active_configserver.get_config_name())
         self._initialise_config()
 

--- a/block_server.py
+++ b/block_server.py
@@ -413,12 +413,14 @@ class BlockServer(Driver):
         self._initialise_config()
 
     def _set_curr_config(self, details):
-        """Sets the current configuration details to that defined in the XML, then initialises it.
+        """Sets the current configuration details to that defined in the XML, saves to disk, then initialises it.
 
         Args:
             details (string): the configuration XML
         """
         self._active_configserver.set_config_details(details)
+        # Need to save the config to file before we initialize or the changes won't be propogated to IOCS
+        self.save_active_config(self._active_configserver.get_config_name())
         self._initialise_config()
 
     def _initialise_config(self, init_gateway=True, full_init=False):


### PR DESCRIPTION
### Description of work

Do a save to file operation as part of setting the current config. This is necessary because IOCs in particular use the file values of macros on startup. Any changes to the current config need to be saved to disc before restarting them.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1595

### Acceptance criteria

1. Set up some IOCs
2. Start them and check their macro values
3. Edit the current configuration from the GUI, changing the macro values
4. Wait for the update to complete and check the new macro values
5. Verify that the new values have been used

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-thredded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
