### PR TITLE
Send start/restart commands for all IOCs before reapplying auto restarts

### DIFF
--- a/BlockServer/core/ioc_control.py
+++ b/BlockServer/core/ioc_control.py
@@ -44,7 +44,7 @@ class IocControl(object):
         except Exception as err:
             print_and_log("Could not start IOC %s: %s" % (ioc, str(err)), "MAJOR")
 
-    def restart_ioc(self, ioc, force=False, reapply_auto=True):
+    def restart_ioc(self, ioc, force=False):
         """Restart an IOC.
 
         Note: restarting an IOC automatically sets the IOC to auto-restart, so it is neccessary to reapply the
@@ -53,7 +53,6 @@ class IocControl(object):
         Args:
             ioc (string): The name of the IOC
             force (bool): Force it to restart even if it is an IOC not to stop
-            reapply_auto (bool): Whether to reapply the current auto-restart setting
         """
         # Check it is okay to stop it
         if not force and ioc.startswith(IOCS_NOT_TO_STOP):
@@ -61,10 +60,6 @@ class IocControl(object):
         try:
             auto = self._proc.get_autorestart(self._prefix, ioc)
             self._proc.restart_ioc(self._prefix, ioc)
-            if reapply_auto:
-                # Need the IOC to restart before reapplying the auto-restart
-                self.waitfor_running(ioc)
-                self.set_autorestart(ioc, auto)
         except Exception as err:
             print_and_log("Could not restart IOC %s: %s" % (ioc, str(err)), "MAJOR")
 
@@ -114,14 +109,23 @@ class IocControl(object):
         for ioc in iocs:
             self.start_ioc(ioc)
 
-    def restart_iocs(self, iocs):
+    def restart_iocs(self, iocs, reapply_auto=False):
         """ Restart a number of IOCs.
 
         Args:
             iocs (list): The IOCs to restart
+            reapply_auto (bool): Whether to reapply auto restart settings automatically
         """
+        auto = dict()
         for ioc in iocs:
+            auto[ioc] = self.get_autorestart(ioc)
             self.restart_ioc(ioc)
+
+        # Reapply auto-restart settings
+        if reapply_auto:
+            for ioc in iocs:
+                self.waitfor_running(ioc)
+                self.set_autorestart(ioc, auto[ioc])
 
     def stop_iocs(self, iocs):
         """ Stop a number of IOCs.

--- a/BlockServer/mocks/mock_ioc_control.py
+++ b/BlockServer/mocks/mock_ioc_control.py
@@ -28,7 +28,7 @@ class MockIocControl(object):
     def start_ioc(self, ioc):
         self._proc.start_ioc(self._prefix, ioc)
 
-    def restart_ioc(self, ioc, force, reapply_auto):
+    def restart_ioc(self, ioc, force):
         self._proc.restart_ioc(self._prefix, ioc)
 
     def stop_ioc(self, ioc):
@@ -44,7 +44,7 @@ class MockIocControl(object):
         for ioc in iocs:
             self._proc.start_ioc(self._prefix, ioc)
 
-    def restart_iocs(self, iocs):
+    def restart_iocs(self, iocs, reapply_auto):
         for ioc in iocs:
             # Check it is okay to stop it
             if ioc.startswith(IOCS_NOT_TO_STOP):

--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -234,7 +234,8 @@ class RunControlManager(OnTheFlyPvInterface):
                 if ioc_restart_pending(self._prefix + RC_IOC_PREFIX, self._channel_access):
                     raise Exception()
                 latest_ioc_start = self._channel_access.caget(self._prefix + RC_START_PV)
-                if latest_ioc_start is None or (self._rc_ioc_start_time != "" and latest_ioc_start <= self._rc_ioc_start_time):
+                if latest_ioc_start is None or (self._rc_ioc_start_time != "" and
+                                                        latest_ioc_start <= self._rc_ioc_start_time):
                     raise Exception()
                 self._rc_ioc_start_time = latest_ioc_start
                 started = True
@@ -267,7 +268,7 @@ class RunControlManager(OnTheFlyPvInterface):
             print_and_log("Reusing the existing run-control autosave files")
 
         try:
-            self._ioc_control.restart_ioc(RUNCONTROL_IOC, force=True, reapply_auto=False)
+            self._ioc_control.restart_ioc(RUNCONTROL_IOC, force=True)
         except Exception as err:
             print_and_log("Problem with restarting the run-control IOC: %s" % str(err), "MAJOR")
 

--- a/BlockServer/test_modules/ioc_control_tests.py
+++ b/BlockServer/test_modules/ioc_control_tests.py
@@ -81,16 +81,23 @@ class TestIocControlSequence(unittest.TestCase):
         ic.set_autorestart("TESTIOC", False)
         self.assertEqual(ic.get_autorestart("TESTIOC"), False)
 
-    def test_GIVEN_reapply_auto_default_WHEN_ioc_restart_requested_THEN_ioc_control_waits_for_restart_complete(self):
+    def test_WHEN_ioc_restart_requested_THEN_ioc_control_may_return_before_restart_complete(self):
         ic = IocControl("", MockProcServWrapper())
         ic.start_ioc("TESTIOC")
         self.assertFalse(ic.ioc_restart_pending("TESTIOC"))
         ic.restart_ioc("TESTIOC")
-        self.assertFalse(ic.ioc_restart_pending("TESTIOC"))
+        self.assertTrue(ic.ioc_restart_pending("TESTIOC"))
 
-    def test_GIVEN_reapply_auto_False_WHEN_ioc_restart_requested_THEN_ioc_control_may_return_before_restart_complete(self):
+    def test_GIVEN_reapply_auto_default_WHEN_ioc_restarts_requested_THEN_ioc_control_may_return_before_restart_complete(self):
         ic = IocControl("", MockProcServWrapper())
         ic.start_ioc("TESTIOC")
         self.assertFalse(ic.ioc_restart_pending("TESTIOC"))
-        ic.restart_ioc("TESTIOC",reapply_auto=False)
+        ic.restart_iocs(["TESTIOC"])
         self.assertTrue(ic.ioc_restart_pending("TESTIOC"))
+
+    def test_GIVEN_reapply_auto_true_WHEN_multiple_ioc_restarts_requested_THEN_ioc_control_waits_for_restart_complete(self):
+        ic = IocControl("", MockProcServWrapper())
+        ic.start_ioc("TESTIOC")
+        self.assertFalse(ic.ioc_restart_pending("TESTIOC"))
+        ic.restart_iocs(["TESTIOC"],reapply_auto=True)
+        self.assertFalse(ic.ioc_restart_pending("TESTIOC"))

--- a/block_server.py
+++ b/block_server.py
@@ -354,7 +354,7 @@ class BlockServer(Driver):
                     self.write_queue.append((self._ioc_control.stop_iocs, (convert_from_json(data),), "STOP_IOCS"))
             elif reason == BlockserverPVNames.RESTART_IOCS:
                 with self.write_lock:
-                    self.write_queue.append((self._ioc_control.restart_iocs, (convert_from_json(data),),
+                    self.write_queue.append((self._ioc_control.restart_iocs, (convert_from_json(data), True),
                                              "RESTART_IOCS"))
             elif reason == BlockserverPVNames.SET_CURR_CONFIG_DETAILS:
                 with self.write_lock:
@@ -482,18 +482,20 @@ class BlockServer(Driver):
                     running = self._ioc_control.get_ioc_status(n)
                     if running == "RUNNING":
                         # Restart it
-                        self._ioc_control.restart_ioc(n, reapply_auto=False)
+                        self._ioc_control.restart_ioc(n)
                     else:
                         # Start it
                         self._ioc_control.start_ioc(n)
-
-                    # Give it time to start as IOC has to be running to be able to set restart property
-                    sleep(2)
-                    # Set the restart property
-                    print_and_log("Setting IOC %s's auto-restart to %s" % (n, ioc.restart))
-                    self._ioc_control.set_autorestart(n, ioc.restart)
             except Exception as err:
                 print_and_log("Could not (re)start IOC %s: %s" % (n, str(err)), "MAJOR")
+
+        # Give it time to start as IOC has to be running to be able to set restart property
+        sleep(2)
+        for n, ioc in self._active_configserver.get_all_ioc_details().iteritems():
+            if ioc.autostart:
+                # Set the restart property
+                print_and_log("Setting IOC %s's auto-restart to %s" % (n, ioc.restart))
+                self._ioc_control.set_autorestart(n, ioc.restart)
 
     def _get_iocs(self, include_running=False):
         # Get IOCs from DatabaseServer
@@ -703,9 +705,13 @@ class BlockServer(Driver):
         # reapply the auto-restart setting after starting.
         # This is because stopping an IOC via procServ turns auto-restart off.
         conf_iocs = self._active_configserver.get_all_ioc_details()
+
+        # Request IOCs to start
         for i in iocs:
             self._ioc_control.start_ioc(i)
-            # Is IOC in config?
+
+        # Once all IOC start requests issued, wait for running and apply auto restart as needed
+        for i in iocs:
             if i in conf_iocs and conf_iocs[i].restart:
                 # Give it time to start as IOC has to be running to be able to set restart property
                 print "Re-applying auto-restart setting to %s" % i


### PR DESCRIPTION
### Description of work

I've replaced all of the start-wait and restart-wait loops for IOCS with an equivalent start/restart loop and wait loop. This means that we're not forced to serially wait for each independent IOC to start/restart before moving on to the next one.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1793

### Acceptance criteria

- [x] Start/restart behaviour for IOCs is unchanged (check with variations on auto-start/auto-restart). Note that behaviour is unchanged, not necessarily correct. There are multiple tickets in this area
- [x] Time to load/update current configurations with multiple IOCs set to autorestart is reduced.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-thredded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

