### PR TITLE
Restart autorestart IOCs on config change

### DIFF
--- a/block_server.py
+++ b/block_server.py
@@ -477,14 +477,16 @@ class BlockServer(Driver):
         # restart means the IOC should automatically restart if it stops for some reason (e.g. it crashes)
         for n, ioc in self._active_configserver.get_all_ioc_details().iteritems():
             try:
-                # If autostart is not set to True then the IOC is not part of the configuration
-                if ioc.autostart:
+                # If autostart and restart are not set to True then the IOC is not part of the configuration
+                if ioc.autostart or ioc.restart:
                     # Throws if IOC does not exist
                     running = self._ioc_control.get_ioc_status(n)
                     if running == "RUNNING":
-                        # Restart it
+                        # Restart for both autostart and autorestart. Slightly counter intuitive but this is the
+                        # established behaviour.
                         self._ioc_control.restart_ioc(n)
-                    else:
+                    # Only start an IOC if it is set to autostart, not autorestart
+                    elif ioc.autostart:
                         # Start it
                         self._ioc_control.start_ioc(n)
             except Exception as err:


### PR DESCRIPTION
### Description of work

I've updated the IOC tabs description in the manual to give better detail on the behaviour:

https://github.com/ISISComputingGroup/ibex_user_manual/wiki/CreateandManageConfigurations

I've updated the behaviour of IOCs so that those set to auto restart, but not auto start, will restart when the configuration is changed.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1788

### Acceptance criteria

Verify: Manual behaviour corresponds with Blockserver behaviour
Validate: New IOC behaviour is what would be expected. I think auto-start possibly should also imply auto-restart but as a well-established behaviour I think that would be a significant shift.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-thredded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

