### PR TITLE
Ensure that user entries are only referenced once

### DIFF
--- a/DatabaseServer/exp_data.py
+++ b/DatabaseServer/exp_data.py
@@ -100,6 +100,7 @@ class ExpData(object):
             sqlquery += " WHERE role.roleID = experimentteams.roleID"
             sqlquery += " AND user.userID = experimentteams.userID"
             sqlquery += " AND experimentteams.experimentID = %s" % experimentID
+            sqlquery += " GROUP BY user.userID"
             sqlquery += " ORDER BY role.priority"
             team = [list(element) for element in self._db.query(sqlquery)]
             if len(team) == 0:


### PR DESCRIPTION
### Description of work

Alteration to the SQL for experiment team lookups to ensure that multiple experiments do not lead to duplicated team members

### To test

Set an RB Number (via the GUI) to one with multiple parts listed, ensure that each name is only listed once, including the surname list (Dashboard) - note that surnames can be repeated but only if there are two Smiths - a Jane and a John, but if only Jane is in the list for the experiment then only one Smith should appear

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-thredded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [x] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated? - There should be no apparent changes to functionality, so no changes have been made

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
