### PR TITLE
Ticket2007 delete component dependency check

### DIFF
--- a/BlockServer/core/config_list_manager.py
+++ b/BlockServer/core/config_list_manager.py
@@ -229,7 +229,7 @@ class ConfigListManager(object):
             if name_lower is not DEFAULT_COMPONENT.lower():
                 self._component_metas[name_lower] = meta
                 self._update_component_pv(name_lower, config.get_config_details())
-                self._update_component_dependencies_pv(name_lower.lower())
+                self._update_component_dependencies_pv(name_lower)
         else:
             if name_lower in self._config_metas.keys():
                 # Config already exists
@@ -241,7 +241,7 @@ class ConfigListManager(object):
             # Update component dependencies
             comps = config.get_component_names()
             for comp in comps:
-                if comp in self._comp_dependencies:
+                if comp.lower() in self._comp_dependencies:
                     self._comp_dependencies[comp.lower()].append(config.get_config_name())
                 else:
                     self._comp_dependencies[comp.lower()] = [config.get_config_name()]

--- a/BlockServer/test_modules/config_list_manager_tests.py
+++ b/BlockServer/test_modules/config_list_manager_tests.py
@@ -471,6 +471,19 @@ class TestInactiveConfigsSequence(unittest.TestCase):
         self.clm.update_a_config_in_list(inactive)
         self.assertTrue("TEST_INACTIVE" in self.clm.get_dependencies("TEST_COMPONENT1"))
 
+    def test_dependencies_updates_when_component_added_to_multiple_configs(self):
+        self._create_components(["TEST_COMPONENT1"])
+        config1 = self._create_inactive_config_holder()
+        config1.add_component("TEST_COMPONENT1", Configuration(MACROS))
+        config1.save_inactive("TEST_CONFIG1")
+        config2 = self._create_inactive_config_holder()
+        config2.add_component("TEST_COMPONENT1", Configuration(MACROS))
+        config2.save_inactive("TEST_CONFIG2")
+        self.clm.update_a_config_in_list(config1)
+        self.clm.update_a_config_in_list(config2)
+        self.assertTrue("TEST_CONFIG1" in self.clm.get_dependencies("TEST_COMPONENT1"))
+        self.assertTrue("TEST_CONFIG2" in self.clm.get_dependencies("TEST_COMPONENT1"))
+
     def test_dependencies_updates_remove(self):
         self._create_components(["TEST_COMPONENT1"])
 


### PR DESCRIPTION
### Description of work

There was a faulty check in the Blockserver that would lead to the dependencies of a component to be overwritten rather than appended, which could lead to the PV holding the components dependencies to be wrongly blank:
1. Comp added to Conf_1 -> dependencies are [Conf_1]
2. Comp added to Conf_2 -> dependencies are [Conf_2], should be [Conf_1, Conf_2]
3. Comp deleted from Conf_2 -> dependencies are [ ], should be [Conf_1]

This change fixes this behaviour.
### To test

https://github.com/ISISComputingGroup/IBEX/issues/2007

### Acceptance criteria

Can never delete a component that is part of a configuration.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-thredded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
