### PR TITLE
Keep Component observers updated

### DIFF
--- a/BlockServer/core/config_list_manager.py
+++ b/BlockServer/core/config_list_manager.py
@@ -356,5 +356,8 @@ class ConfigListManager(object):
             self._bs.setParam(BlockserverPVNames.CONFIGS, compress_and_hex(convert_to_json(self.get_configs())))
             # Set the available comps
             self._bs.setParam(BlockserverPVNames.COMPS, compress_and_hex(convert_to_json(self.get_components())))
+            # Set the available component details
+            self._bs.setParam(BlockserverPVNames.ALL_COMPONENT_DETAILS,
+                              compress_and_hex(convert_to_json(self.all_components.values())))
             # Update them
             self._bs.updatePVs()


### PR DESCRIPTION
### Description of work

Now propagates changes to Blockserver PV  `ALL_COMPONENT_DETAILS` to its monitors as intended

### To test

For https://github.com/ISISComputingGroup/IBEX/issues/1884

### Acceptance criteria

Changes made to a component (e.g. to resolve duplicates) take effect immediately and not just after restarting the GUI.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-thredded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
