### PR TITLE
Ticket2290: Log if an encoded value is too long

### DIFF
--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -222,7 +222,7 @@ class DatabaseServer(Driver):
     @staticmethod
     def _check_pv_capacity(pv, size, prefix):
         """
-        Increases the capacity of a PV if necessary. Leave unchanged if already sufficient
+        Check the capacity of a PV and write to the log if it is too small
         :param pv: The PV to update
         :param size: The required size
         :param prefix: The PV prefix

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -119,11 +119,7 @@ class DatabaseServer(Driver):
 
         # Helper to consistently create pvs
         def create_pvdb_entry(count):
-            return {
-                'type': 'char',
-                'count': count,
-                'value': [0]
-            }
+            return {'type': 'char', 'count': count, 'value': [0]}
 
         return {
             'IOCS': create_pvdb_entry(pv_size_64k),

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -284,7 +284,8 @@ class DatabaseServer(Driver):
         return 'INSTETC', 'PSCTRL', 'ISISDAE', 'BLOCKSVR', 'ARINST', 'ARBLOCK', 'GWBLOCK', 'RUNCTRL'
 
     def close(self):
-        self._ca_server.close()
+        # Nothing needs activtely closing
+        pass
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -19,9 +19,6 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath(os.environ["MYDIRBLOCK"]))
 
-import time
-time.sleep(10)
-
 # Standard imports
 from pcaspy import Driver
 from time import sleep

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -138,25 +138,6 @@ class DatabaseServer(Driver):
             'IOCS_NOT_TO_STOP': create_pvdb_entry(pv_size_64k),
         }
 
-    def process(self, interval):
-        """
-        Tell the CA server to process requests
-        
-        Args:
-            interval (float): How long the processing loop will take in seconds
-        """
-        self._ca_server.process(interval)
-
-    def create_server_pv(self, prefix, pvs=None):
-        """
-        Instruct the CA server to create a set of PVs
-        
-        Args:
-            prefix (string): The PV prefix to prepend to the PVs
-            pvs (dict): A dictionary of PVs and associated metadata used to create PVs
-        """
-        self._ca_server.createPV(prefix, pvs if pvs is not None else self._pv_info)
-
     def read(self, reason):
         """A method called by SimpleServer when a PV is read from the DatabaseServer over Channel Access.
 
@@ -352,7 +333,7 @@ if __name__ == '__main__':
     # Process CA transactions
     while True:
         try:
-            DRIVER.process(0.1)
+            SERVER.process(0.1)
         except Exception as err:
             print_and_log(err, MAJOR_MSG)
             break

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -42,6 +42,8 @@ MACROS = {
 }
 
 LOG_TARGET = "DBSVR"
+INFO_MSG = "INFO"
+MAJOR_MSG = "MAJOR"
 
 class DatabaseServer(Driver):
     """The class for handling all the static PV access and monitors etc.
@@ -67,7 +69,7 @@ class DatabaseServer(Driver):
         # Initialise database connection
         try:
             self._db = IOCData(dbid, ps, MACROS["$(MYPVPREFIX)"])
-            print_and_log("Connected to database", "INFO", LOG_TARGET)
+            print_and_log("Connected to database", INFO_MSG, LOG_TARGET)
         except Exception as err:
             self._db = None
             print_and_log("Problem initialising DB connection: %s" % err, "MAJOR", LOG_TARGET)
@@ -75,10 +77,10 @@ class DatabaseServer(Driver):
         # Initialise experimental database connection
         try:
             self._ed = ExpData(MACROS["$(MYPVPREFIX)"])
-            print_and_log("Connected to experimental details database", "INFO", LOG_TARGET)
+            print_and_log("Connected to experimental details database", INFO_MSG, LOG_TARGET)
         except Exception as err:
             self._ed = None
-            print_and_log("Problem connecting to experimental details database: %s" % err, "MAJOR", LOG_TARGET)
+            print_and_log("Problem connecting to experimental details database: %s" % err, MAJOR_MSG, LOG_TARGET)
 
         if self._db is not None and not test_mode:
             # Start a background thread for keeping track of running IOCs
@@ -161,13 +163,13 @@ class DatabaseServer(Driver):
         status = True
         try:
             if reason == 'ED:RBNUMBER:SP':
-                #print_and_log("Updating to use experiment ID: " + value, "INFO", LOG_LOCATION)
+                #print_and_log("Updating to use experiment ID: " + value, INFO_MSG, LOG_LOCATION)
                 self._ed.updateExperimentID(value)
             elif reason == 'ED:USERNAME:SP':
                 self._ed.updateUsername(dehex_and_decompress(value))
         except Exception as err:
             value = compress_and_hex(convert_to_json("Error: " + str(err)))
-            print_and_log(str(err), "MAJOR")
+            print_and_log(str(err), MAJOR_MSG)
         # store the values
         if status:
             self.setParam(reason, value)
@@ -202,7 +204,7 @@ class DatabaseServer(Driver):
         if size > self._pvdb[pv]['count']:
             print_and_log("Too much data to encode PV {0}. Current size is {1} characters but {2} are required"
                           .format(prefix + pv, self._pvdb[pv]['count'], size),
-                          "MAJOR", LOG_TARGET)
+                          MAJOR_MSG, LOG_TARGET)
 
     def encode4return(self, data):
         """Converts data to JSON, compresses it and converts it to hex.
@@ -306,16 +308,16 @@ if __name__ == '__main__':
     if FACILITY == "ISIS":
         from server_common.loggers.isis_logger import IsisLogger
         set_logger(IsisLogger())
-    print_and_log("FACILITY = %s" % FACILITY, "INFO", LOG_TARGET)
+    print_and_log("FACILITY = %s" % FACILITY, INFO_MSG, LOG_TARGET)
 
     BLOCKSERVER_PREFIX = args.blockserver_prefix[0]
     if not BLOCKSERVER_PREFIX.endswith(':'):
         BLOCKSERVER_PREFIX += ":"
     BLOCKSERVER_PREFIX = BLOCKSERVER_PREFIX.replace('%MYPVPREFIX%', MACROS["$(MYPVPREFIX)"])
-    print_and_log("BLOCKSERVER PREFIX = %s" % BLOCKSERVER_PREFIX, "INFO", LOG_TARGET)
+    print_and_log("BLOCKSERVER PREFIX = %s" % BLOCKSERVER_PREFIX, INFO_MSG, LOG_TARGET)
 
     OPTIONS_DIR = os.path.abspath(args.options_dir[0])
-    print_and_log("OPTIONS DIRECTORY = %s" % OPTIONS_DIR, "INFO", LOG_TARGET)
+    print_and_log("OPTIONS DIRECTORY = %s" % OPTIONS_DIR, INFO_MSG, LOG_TARGET)
     if not os.path.isdir(os.path.abspath(OPTIONS_DIR)):
         # Create it then
         os.makedirs(os.path.abspath(OPTIONS_DIR))

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -64,7 +64,7 @@ class DatabaseServer(Driver):
         self._ca_server = ca_server
         self._options_holder = OptionsHolder(options_folder, OptionsLoader())
 
-        self._pv_info = self._generate_pv_info()
+        self._pv_info = self._generate_pv_acquisition_info()
 
         # Initialise database connection
         try:
@@ -89,7 +89,13 @@ class DatabaseServer(Driver):
             monitor_thread.daemon = True  # Daemonise thread
             monitor_thread.start()
 
-    def _generate_pv_info(self):
+    def _generate_pv_acquisition_info(self):
+        """
+        Generates information needed to get the data for the DB PVs.
+
+        Returns:
+            Dictionary : Dictionary containing the information to get the information for the PVs
+        """
         enhanced_info = DatabaseServer.generate_pv_info()
 
         def add_get_method(pv, get_function):
@@ -113,6 +119,9 @@ class DatabaseServer(Driver):
         """
         Generates information needed to construct PVs. Must be consumed by Server before
         DatabaseServer is initialized so must be static
+
+        Returns:
+            Dictionary : Dictionary containing the information to construct PVs
         """
         pv_size_64k = 64000
         pv_size_10k = 10000

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -288,10 +288,6 @@ class DatabaseServer(Driver):
         """
         return 'INSTETC', 'PSCTRL', 'ISISDAE', 'BLOCKSVR', 'ARINST', 'ARBLOCK', 'GWBLOCK', 'RUNCTRL'
 
-    def close(self):
-        # Nothing needs activtely closing
-        pass
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
@@ -338,4 +334,3 @@ if __name__ == '__main__':
             print_and_log(err, MAJOR_MSG)
             break
 
-    DRIVER.close()

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -41,6 +41,8 @@ MACROS = {
     "$(ICPCONFIGROOT)": os.environ['ICPCONFIGROOT']
 }
 
+LOG_TARGET = "DBSVR"
+
 class DatabaseServer(Driver):
     """The class for handling all the static PV access and monitors etc.
     """
@@ -65,18 +67,18 @@ class DatabaseServer(Driver):
         # Initialise database connection
         try:
             self._db = IOCData(dbid, ps, MACROS["$(MYPVPREFIX)"])
-            print_and_log("Connected to database", "INFO", "DBSVR")
+            print_and_log("Connected to database", "INFO", LOG_TARGET)
         except Exception as err:
             self._db = None
-            print_and_log("Problem initialising DB connection: %s" % err, "MAJOR", "DBSVR")
+            print_and_log("Problem initialising DB connection: %s" % err, "MAJOR", LOG_TARGET)
 
         # Initialise experimental database connection
         try:
             self._ed = ExpData(MACROS["$(MYPVPREFIX)"])
-            print_and_log("Connected to experimental details database", "INFO", "DBSVR")
+            print_and_log("Connected to experimental details database", "INFO", LOG_TARGET)
         except Exception as err:
             self._ed = None
-            print_and_log("Problem connecting to experimental details database: %s" % err, "MAJOR", "DBSVR")
+            print_and_log("Problem connecting to experimental details database: %s" % err, "MAJOR", LOG_TARGET)
 
         if self._db is not None and not test_mode:
             # Start a background thread for keeping track of running IOCs
@@ -159,7 +161,7 @@ class DatabaseServer(Driver):
         status = True
         try:
             if reason == 'ED:RBNUMBER:SP':
-                #print_and_log("Updating to use experiment ID: " + value, "INFO", "DBSVR")
+                #print_and_log("Updating to use experiment ID: " + value, "INFO", LOG_LOCATION)
                 self._ed.updateExperimentID(value)
             elif reason == 'ED:USERNAME:SP':
                 self._ed.updateUsername(dehex_and_decompress(value))
@@ -200,7 +202,7 @@ class DatabaseServer(Driver):
         if size > self._pvdb[pv]['count']:
             print_and_log("Too much data to encode PV {0}. Current size is {1} characters but {2} are required"
                           .format(prefix + pv, self._pvdb[pv]['count'], size),
-                          "MAJOR", "DBSVR")
+                          "MAJOR", LOG_TARGET)
 
     def encode4return(self, data):
         """Converts data to JSON, compresses it and converts it to hex.
@@ -304,16 +306,16 @@ if __name__ == '__main__':
     if FACILITY == "ISIS":
         from server_common.loggers.isis_logger import IsisLogger
         set_logger(IsisLogger())
-    print_and_log("FACILITY = %s" % FACILITY, "INFO", "DBSVR")
+    print_and_log("FACILITY = %s" % FACILITY, "INFO", LOG_TARGET)
 
     BLOCKSERVER_PREFIX = args.blockserver_prefix[0]
     if not BLOCKSERVER_PREFIX.endswith(':'):
         BLOCKSERVER_PREFIX += ":"
     BLOCKSERVER_PREFIX = BLOCKSERVER_PREFIX.replace('%MYPVPREFIX%', MACROS["$(MYPVPREFIX)"])
-    print_and_log("BLOCKSERVER PREFIX = %s" % BLOCKSERVER_PREFIX, "INFO", "DBSVR")
+    print_and_log("BLOCKSERVER PREFIX = %s" % BLOCKSERVER_PREFIX, "INFO", LOG_TARGET)
 
     OPTIONS_DIR = os.path.abspath(args.options_dir[0])
-    print_and_log("OPTIONS DIRECTORY = %s" % OPTIONS_DIR, "INFO", "DBSVR")
+    print_and_log("OPTIONS DIRECTORY = %s" % OPTIONS_DIR, "INFO", LOG_TARGET)
     if not os.path.isdir(os.path.abspath(OPTIONS_DIR)):
         # Create it then
         os.makedirs(os.path.abspath(OPTIONS_DIR))

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -256,10 +256,10 @@ class DatabaseServer(Driver):
 
     def _get_pvs(self, get_method, replace_pv_prefix, *get_args):
         if self._db is not None:
-            result = get_method(*get_args)
+            pv_data = get_method(*get_args)
             if replace_pv_prefix:
-                result = [p.replace(MACROS["$(MYPVPREFIX)"], "") for p in result]
-            return result
+                pv_data = [p.replace(MACROS["$(MYPVPREFIX)"], "") for p in pv_data]
+            return pv_data
         else:
             return list()
 
@@ -276,7 +276,7 @@ class DatabaseServer(Driver):
         return self._get_interesting_pvs("", ioc)
 
     def _get_interesting_pvs(self, level, ioc=None):
-        return self._get_pvs(self._db.get_interesting_pvs, False, (level, ioc))
+        return self._get_pvs(self._db.get_interesting_pvs, False, level, ioc)
 
     def _get_active_pvs(self):
         return self._get_pvs(self._db.get_active_pvs, False)

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -35,8 +35,6 @@ from options_holder import OptionsHolder
 from options_loader import OptionsLoader
 from mocks.mock_procserv_utils import MockProcServWrapper
 
-IOCDB = 'iocdb'
-
 MACROS = {
     "$(MYPVPREFIX)": os.environ['MYPVPREFIX'],
     "$(EPICS_KIT_ROOT)": os.environ['EPICS_KIT_ROOT'],
@@ -320,7 +318,7 @@ if __name__ == '__main__':
         # Create it then
         os.makedirs(os.path.abspath(OPTIONS_DIR))
 
-    DRIVER = DatabaseServer(CAServer(BLOCKSERVER_PREFIX), IOCDB, OPTIONS_DIR)
+    DRIVER = DatabaseServer(CAServer(BLOCKSERVER_PREFIX), "iocdb", OPTIONS_DIR)
     DRIVER.create_server_pv(BLOCKSERVER_PREFIX)
     DRIVER.create_server_pv(MACROS["$(MYPVPREFIX)"], ExpData.EDPV)
 

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -234,20 +234,20 @@ class DatabaseServer(Driver):
         else:
             return list()
 
-    def _get_high_interest_pvs(self, ioc=None):
-        return self._get_interesting_pvs("HIGH", ioc)
+    def _get_high_interest_pvs(self):
+        return self._get_interesting_pvs("HIGH")
 
-    def _get_medium_interest_pvs(self, ioc=None):
-        return self._get_interesting_pvs("MEDIUM", ioc)
+    def _get_medium_interest_pvs(self):
+        return self._get_interesting_pvs("MEDIUM")
 
-    def _get_facility_pvs(self, ioc=None):
-        return self._get_interesting_pvs("FACILITY", ioc)
+    def _get_facility_pvs(self):
+        return self._get_interesting_pvs("FACILITY")
 
-    def _get_all_pvs(self, ioc=None):
-        return self._get_interesting_pvs("", ioc)
+    def _get_all_pvs(self):
+        return self._get_interesting_pvs("")
 
-    def _get_interesting_pvs(self, level, ioc=None):
-        return self._get_pvs(self._db.get_interesting_pvs, False, level, ioc)
+    def _get_interesting_pvs(self, level):
+        return self._get_pvs(self._db.get_interesting_pvs, False, level)
 
     def _get_active_pvs(self):
         return self._get_pvs(self._db.get_active_pvs, False)

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -72,7 +72,7 @@ class DatabaseServer(Driver):
             print_and_log("Connected to database", INFO_MSG, LOG_TARGET)
         except Exception as err:
             self._db = None
-            print_and_log("Problem initialising DB connection: %s" % err, "MAJOR", LOG_TARGET)
+            print_and_log("Problem initialising DB connection: %s" % err, MAJOR_MSG, LOG_TARGET)
 
         # Initialise experimental database connection
         try:
@@ -331,7 +331,7 @@ if __name__ == '__main__':
         try:
             DRIVER.process(0.1)
         except Exception as err:
-            print_and_log(err,"MAJOR")
+            print_and_log(err,MAJOR_MSG)
             break
 
     DRIVER.close()

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -225,37 +225,29 @@ class DatabaseServer(Driver):
                 iocs[iocname].update(options[iocname])
         return iocs
 
+    def _get_pvs(self, get_method, *get_args):
+        if self._db is not None:
+            return [p.replace(MACROS["$(MYPVPREFIX)"], "") for p in get_method(get_args)]
+        else:
+            return list()
+
     def _get_high_interest_pvs(self, ioc=None):
         return self._get_interesting_pvs("HIGH", ioc)
 
-    def _get_high_interest_pvs(self, ioc=None):
+    def _get_medium_interest_pvs(self, ioc=None):
         return self._get_interesting_pvs("MEDIUM", ioc)
 
-    def _get_high_interest_pvs(self, ioc=None):
+    def _get_facility_pvs(self, ioc=None):
         return self._get_interesting_pvs("FACILITY", ioc)
 
     def _get_all_pvs(self, ioc=None):
         return self._get_interesting_pvs("", ioc)
 
     def _get_interesting_pvs(self, level, ioc=None):
-        if self._db is not None:
-            return self._db.get_interesting_pvs(level, ioc)
-        else:
-            return list()
+        return self._get_pvs(get_method, (level, ioc))
 
     def _get_active_pvs(self):
-        if self._db is not None:
-            return self._db.get_active_pvs()
-        else:
-            return list()
-
-    @staticmethod
-    def get_iocs_not_to_stop():
-        """
-        Returns: 
-            list: A list of IOCs not to stop
-        """
-        return ('INSTETC', 'PSCTRL', 'ISISDAE', 'BLOCKSVR', 'ARINST', 'ARBLOCK', 'GWBLOCK', 'RUNCTRL')
+        return self.get_pvs(self._db.get_active_pvs)
 
     def get_sample_par_names(self):
         """Returns the sample parameters from the database, replacing the MYPVPREFIX macro
@@ -263,10 +255,7 @@ class DatabaseServer(Driver):
         Returns:
             list : A list of sample parameter names, an empty list if the database does not exist
         """
-        if self._db is not None:
-            return [p.replace(MACROS["$(MYPVPREFIX)"], "") for p in self._db.get_sample_pars()]
-        else:
-            return list()
+        return self._get_pvs(self._db.get_sample_pars)
 
     def get_beamline_par_names(self):
         """Returns the beamline parameters from the database, replacing the MYPVPREFIX macro
@@ -274,10 +263,7 @@ class DatabaseServer(Driver):
         Returns:
             list : A list of beamline parameter names, an empty list if the database does not exist
         """
-        if self._db is not None:
-            return [p.replace(MACROS["$(MYPVPREFIX)"], "") for p in self._db.get_beamline_pars()]
-        else:
-            return list()
+        return self._get_pvs(self._db.get_beamline_pars)
 
     def get_user_par_names(self):
         """Returns the user parameters from the database, replacing the MYPVPREFIX macro
@@ -285,10 +271,15 @@ class DatabaseServer(Driver):
         Returns:
             list : A list of user parameter names, an empty list if the database does not exist
         """
-        if self._db is not None:
-            return [p.replace(MACROS["$(MYPVPREFIX)"], "") for p in self._db.get_user_pars()]
-        else:
-            return list()
+        return self._get_pvs(self._db.get_user_pars)
+    
+    @staticmethod
+    def get_iocs_not_to_stop():
+        """
+        Returns: 
+            list: A list of IOCs not to stop
+        """
+        return ('INSTETC', 'PSCTRL', 'ISISDAE', 'BLOCKSVR', 'ARINST', 'ARBLOCK', 'GWBLOCK', 'RUNCTRL')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -44,67 +44,30 @@ MACROS = {
     "$(ICPCONFIGROOT)": os.environ['ICPCONFIGROOT']
 }
 
+PV_SIZE_64K = 64000
+PV_SIZE_10K = 10000
+
+def create_pvdb_entry(count):
+    return {
+        'type': 'char',
+        'count' : count,
+        'value' : [0]
+    }
+
 PV_SIZE = {"default": 64000, "pars": 10000}
 
 PVDB = {
-    'IOCS': {
-        # Handled by the monitor thread
-        'type': 'char',
-        'count': PV_SIZE["default"],
-        'value': [0],
-    },
-    'PVS:INTEREST:HIGH': {
-        # Handled by the monitor thread
-        'type': 'char',
-        'count': PV_SIZE["default"],
-        'value': [0],
-    },
-    'PVS:INTEREST:MEDIUM': {
-        # Handled by the monitor thread
-        'type': 'char',
-        'count': PV_SIZE["default"],
-        'value': [0],
-    },
-    'PVS:INTEREST:FACILITY': {
-        # Handled by the monitor thread
-        'type': 'char',
-        'count': PV_SIZE["default"],
-        'value': [0],
-    },
-    'PVS:ACTIVE': {
-        # Handled by the monitor thread
-        'type': 'char',
-        'count': 64000,
-        'value': [0],
-    },
-    'PVS:ALL': {
-        # Handled by the monitor thread
-        'type': 'char',
-        'count': PV_SIZE["default"],
-        'value': [0],
-    },
-    'SAMPLE_PARS': {
-        'type': 'char',
-        'count': PV_SIZE["pars"],
-        'value': [0],
-    },
-    'BEAMLINE_PARS': {
-        'type': 'char',
-        'count': PV_SIZE["pars"],
-        'value': [0],
-    },
-    'USER_PARS': {
-        'type': 'char',
-        'count': PV_SIZE["pars"],
-        'value': [0],
-    },
-    'IOCS_NOT_TO_STOP': {
-        'type': 'char',
-        'count': PV_SIZE["default"],
-        'value': [0],
-    },
+    'IOCS': create_pvdb_entry(PV_SIZE_64K),
+    'PVS:INTEREST:HIGH': create_pvdb_entry(PV_SIZE_64K),
+    'PVS:INTEREST:MEDIUM': create_pvdb_entry(PV_SIZE_64K),
+    'PVS:INTEREST:FACILITY': create_pvdb_entry(PV_SIZE_64K),
+    'PVS:ACTIVE': create_pvdb_entry(PV_SIZE_64K),
+    'PVS:ALL': create_pvdb_entry(PV_SIZE_64K),
+    'SAMPLE_PARS': create_pvdb_entry(PV_SIZE_10K),
+    'BEAMLINE_PARS': create_pvdb_entry(PV_SIZE_10K),
+    'USER_PARS': create_pvdb_entry(PV_SIZE_10K),
+    'IOCS_NOT_TO_STOP': create_pvdb_entry(PV_SIZE_64K),
 }
-
 
 class DatabaseServer(Driver):
     """The class for handling all the static PV access and monitors etc.


### PR DESCRIPTION
### Description of work

As a result of this ticket, the length of the IOCs macro was too long. This wasn't reported in the system. I've increased the size of the PV and tidied up the code to better respond to this case in the future

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2290

### Acceptance criteria

- With all the PRs for this ticket, check that the IOC list still appears in the GUI
- In `C:\Instrument\Apps\EPICS\ISIS\inst_servers\master\DatabaseServer\database_server.py`, decrease PV_SIZE. Make sure that the system responds accordingly (check logs and IOC functionality as above).

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
