### PR TITLE
Ticket2273 groups should be orderable

### DIFF
--- a/BlockServer/config/xml_converter.py
+++ b/BlockServer/config/xml_converter.py
@@ -94,7 +94,7 @@ class ConfigurationXmlConverter(object):
         root.attrib["xmlns:xi"] = "http://www.w3.org/2001/XInclude"
         for name, group in groups.iteritems():
             # Don't generate xml if in NONE or if it is empty
-            if name != KEY_NONE and group.blocks is not None and len(group.blocks) > 0:
+            if name != KEY_NONE and group.blocks is not None:
                 ConfigurationXmlConverter._group_to_xml(root, group)
 
         # If we are adding the None group it should go at the end
@@ -215,6 +215,8 @@ class ConfigurationXmlConverter(object):
         """Generates the XML for a group"""
         grp = ElementTree.SubElement(root_xml, TAG_GROUP)
         grp.set(TAG_NAME, group.name)
+        if group.component is not None:
+            grp.set(TAG_COMPONENT, group.component)
         for blk in group.blocks:
             b = ElementTree.SubElement(grp, TAG_BLOCK)
             b.set(TAG_NAME, blk)

--- a/BlockServer/config/xml_converter.py
+++ b/BlockServer/config/xml_converter.py
@@ -322,11 +322,15 @@ class ConfigurationXmlConverter(object):
         grps = ConfigurationXmlConverter._find_all_nodes(root_xml, NS_TAG_GROUP, TAG_GROUP)
         for g in grps:
             gname = g.attrib[TAG_NAME]
+            try:
+                gcomp = g.attrib[TAG_COMPONENT]
+            except KeyError as e:
+                gcomp = None
             gname_low = gname.lower()
 
             # Add the group to the dict unless it already exists (i.e. the group is defined twice)
             if gname_low not in groups.keys():
-                groups[gname_low] = Group(gname)
+                groups[gname_low] = Group(gname, gcomp)
 
             blks = ConfigurationXmlConverter._find_all_nodes(g, NS_TAG_GROUP, TAG_BLOCK)
 
@@ -343,7 +347,6 @@ class ConfigurationXmlConverter(object):
                 if KEY_NONE in groups:
                     if name in groups[KEY_NONE].blocks:
                         groups[KEY_NONE].blocks.remove(name)
-
 
     @staticmethod
     def ioc_from_xml(root_xml, iocs):

--- a/BlockServer/core/config_holder.py
+++ b/BlockServer/core/config_holder.py
@@ -146,11 +146,9 @@ class ConfigHolder(object):
                 if gn not in groups.keys():
                     # Add the groups if they have not been used before and exist
                     blks = [x for x in grp.blocks if x not in used_blocks and x in blocks]
-                    if len(blks) > 0:
-                        # Only add if contains blocks
-                        groups[gn] = grp
-                        groups[gn].blocks = blks
-                        used_blocks.extend(blks)
+                    groups[gn] = grp
+                    groups[gn].blocks = blks
+                    used_blocks.extend(blks)
                 else:
                     # If group exists then append with component group
                     # But don't add any duplicate blocks or blocks that don't exist
@@ -169,7 +167,7 @@ class ConfigHolder(object):
                 continue
             # If the group is in the config then it can be changed completely
             if grp["name"].lower() in self._config.groups:
-                if len(grp["blocks"]) == 0:
+                if len(grp["blocks"]) == 0 and grp["component"] is None:
                     # No blocks so delete the group
                     del self._config.groups[grp["name"].lower()]
                     continue
@@ -180,8 +178,9 @@ class ConfigHolder(object):
                         homeless_blocks.remove(blk)
             else:
                 # Not in config yet, so add it (it will override settings in any components)
-                # Only add it if there are actually blocks
-                if len(grp["blocks"]) > 0:
+                if grp.get("component") is not None:
+                    self._config.groups[grp["name"].lower()] = Group(grp["name"], component=grp.get("component"))
+                elif len(grp["blocks"]) > 0:
                     self._config.groups[grp["name"].lower()] = Group(grp["name"])
                     for blk in grp["blocks"]:
                         if blk in homeless_blocks:
@@ -386,11 +385,7 @@ class ConfigHolder(object):
                         raise Exception('Cannot override blocks from components')
                     self.add_block(args)
             if "groups" in details:
-                # List of dicts
-                for args in details["groups"]:
-                    if args.get('component') is not None:
-                        raise Exception('Cannot override groups from components')
-                    self._set_group_details(details['groups'])
+                self._set_group_details(details["groups"])
             if "name" in details:
                 self._set_config_name(details["name"])
             if "description" in details:

--- a/BlockServer/core/config_holder.py
+++ b/BlockServer/core/config_holder.py
@@ -178,14 +178,14 @@ class ConfigHolder(object):
                         homeless_blocks.remove(blk)
             else:
                 # Not in config yet, so add it (it will override settings in any components)
-                if grp.get("component") is not None:
-                    self._config.groups[grp["name"].lower()] = Group(grp["name"], component=grp.get("component"))
-                elif len(grp["blocks"]) > 0:
-                    self._config.groups[grp["name"].lower()] = Group(grp["name"])
-                    for blk in grp["blocks"]:
-                        if blk in homeless_blocks:
-                            self._config.groups[grp["name"].lower()].blocks.append(blk)
-                            homeless_blocks.remove(blk)
+                if len(grp["blocks"]) > 0:
+                    component = grp.get("component")
+                    self._config.groups[grp["name"].lower()] = Group(grp["name"], component=component)
+                    if component is None:
+                        for blk in grp["blocks"]:
+                            if blk in homeless_blocks:
+                                self._config.groups[grp["name"].lower()].blocks.append(blk)
+                                homeless_blocks.remove(blk)
         # Finally, anything in homeless gets put in NONE
         if GRP_NONE.lower() not in self._config.groups:
             self._config.groups[GRP_NONE.lower()] = Group(GRP_NONE)

--- a/BlockServer/core/config_holder.py
+++ b/BlockServer/core/config_holder.py
@@ -511,6 +511,11 @@ class ConfigHolder(object):
                 self._is_component = True
             else:
                 raise Exception("Can not cast to a component as the configuration contains at least one component")
+
+            # Strip out any remaining groups that belong to components
+            for key in self._config.groups:
+                if self._config.groups[key].component is not None:
+                    del self._config.groups[key]
         else:
             self._is_component = False
 

--- a/BlockServer/core/config_holder.py
+++ b/BlockServer/core/config_holder.py
@@ -156,6 +156,12 @@ class ConfigHolder(object):
                         if bn not in groups[gn].blocks and bn not in used_blocks and bn in blocks:
                             groups[gn].blocks.append(bn)
                             used_blocks.append(bn)
+
+        # If any groups are empty now we've filled in from the components, get rid of them
+        for key in groups:
+            if len(groups[key].blocks)==0:
+                del groups[key]
+
         return groups
 
     def _set_group_details(self, redefinition):

--- a/BlockServer/core/config_holder.py
+++ b/BlockServer/core/config_holder.py
@@ -177,9 +177,10 @@ class ConfigHolder(object):
                         self._config.groups[grp["name"].lower()].blocks.append(blk)
                         homeless_blocks.remove(blk)
             else:
-                # Not in config yet, so add it (it will override settings in any components)
-                if len(grp["blocks"]) > 0:
-                    component = grp.get("component")
+                component = grp.get("component")
+                # Ignore empty groups, except those with components. Component groups are included just
+                # for ordering
+                if len(grp["blocks"]) > 0 or component is not None:
                     self._config.groups[grp["name"].lower()] = Group(grp["name"], component=component)
                     if component is None:
                         for blk in grp["blocks"]:

--- a/schema/groups.xsd
+++ b/schema/groups.xsd
@@ -13,9 +13,10 @@
   <xs:element name="group">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="grp:block"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="grp:block"/>
       </xs:sequence>
       <xs:attribute name="name" use="required"/>
+      <xs:attribute name="component" use="optional"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="block">


### PR DESCRIPTION
### Description of work

I've taken out much of the logic prohibiting empty groups. Groups will still be discarded if they are empty and have no component. However, empty component groups are permitted in that they indicate the desired ordering for the configuration.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2273

### Acceptance criteria

See https://github.com/ISISComputingGroup/ibex_gui/pull/509

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
