### PR TITLE
Fix blockserver config update is slow

### DIFF
--- a/BlockServer/mocks/mock_channel_access.py
+++ b/BlockServer/mocks/mock_channel_access.py
@@ -26,7 +26,8 @@ class MockChannelAccess(object):
 
     @staticmethod
     def caget(name, as_string=False):
-        """Mock channel access get.
+        """
+        Mock channel access get.
 
         Args:
             name (str): the PV to return a value for
@@ -46,7 +47,8 @@ class MockChannelAccess(object):
 
     @staticmethod
     def caput(name, value, wait=False):
-        """Mock channel access put.
+        """
+        Mock channel access put.
 
         Args:
             name (str): the PV to set a value for
@@ -58,7 +60,8 @@ class MockChannelAccess(object):
 
 
 class ChannelAccessEnv(object):
-    """Channel access environment setup.
+    """
+    Channel access environment setup.
 
     Use this to create a channel access environment that can return different
     values depending on the number of times a PV is accessed. This will also
@@ -66,7 +69,8 @@ class ChannelAccessEnv(object):
     """
 
     def __init__(self, pv_values):
-        """Create a new channel access environment.
+        """
+        Create a new channel access environment.
 
         This will set up a number of PVs with a series of different values to
         return each time they are accessed.
@@ -80,7 +84,9 @@ class ChannelAccessEnv(object):
         self._old_index = None
 
     def __enter__(self):
-        """Create a global environment dict for channel access."""
+        """
+        Create a global environment dict for channel access.
+        """
         global PV_TEST_DICT, PV_TEST_DICT_CALL_INDEX
         self._old_values = PV_TEST_DICT
         self._old_index = PV_TEST_DICT_CALL_INDEX
@@ -93,12 +99,16 @@ class ChannelAccessEnv(object):
         return self
 
     def __exit__(self, t, value, trace):
-        """Tear down a global environment dict for channel access."""
+        """
+        Tear down a global environment dict for channel access.
+        """
         global PV_TEST_DICT, PV_TEST_DICT_CALL_INDEX
         PV_TEST_DICT = self._old_values
         PV_TEST_DICT_CALL_INDEX = self._old_index
 
     def get_call_count(self, name):
-        """Get the number of times a PV was called."""
+        """
+        Get the number of times a PV was called.
+        """
         global PV_TEST_DICT_CALL_INDEX
         return PV_TEST_DICT_CALL_INDEX[name]

--- a/BlockServer/mocks/mock_channel_access.py
+++ b/BlockServer/mocks/mock_channel_access.py
@@ -1,13 +1,15 @@
+"""Channel Access Mocking Objects."""
 # This file is part of the ISIS IBEX application.
 # Copyright (C) 2012-2016 Science & Technology Facilities Council.
 # All rights reserved.
 #
-# This program is distributed in the hope that it will be useful.
-# This program and the accompanying materials are made available under the
-# terms of the Eclipse Public License v1.0 which accompanies this distribution.
-# EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM
-# AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
-# OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+# This program is distributed in the hope that it will be useful.  This program
+# and the accompanying materials are made available under the terms of the
+# Eclipse Public License v1.0 which accompanies this distribution.  EXCEPT AS
+# EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM AND
+# ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more
+# details.
 #
 # You should have received a copy of the Eclipse Public License v1.0
 # along with this program; if not, you can obtain a copy from
@@ -18,10 +20,18 @@ PVS = dict()
 PV_TEST_DICT = None
 PV_TEST_DICT_CALL_INDEX = None
 
+
 class MockChannelAccess(object):
+    """Mock Channel Access methods."""
 
     @staticmethod
     def caget(name, as_string=False):
+        """Mock channel access get.
+
+        Args:
+            name (str): the PV to return a value for
+            as_string (bool): this option is unimplemented
+        """
         if PV_TEST_DICT is not None and name in PV_TEST_DICT:
             return MockChannelAccess._get_from_ca_env(name)
         if name in PVS:
@@ -34,18 +44,29 @@ class MockChannelAccess(object):
         PV_TEST_DICT_CALL_INDEX[name] += 1
         return PV_TEST_DICT[name][call_index]
 
-
     @staticmethod
     def caput(name, value, wait=False):
+        """Mock channel access put.
+
+        Args:
+            name (str): the PV to set a value for
+            value (any): the value to set the PV to
+            wait (boo): this option is unimplemented
+        """
         global PVS
         PVS[name] = value
 
 
 class ChannelAccessEnv(object):
+    """Channel access environment setup.
+
+    Use this to create a channel access environment that can return different
+    values depending on the number of times a PV is accessed. This will also
+    track how many times a PV has been accessed.
+    """
 
     def __init__(self, pv_values):
-        """
-        Setup a new channel access environment.
+        """Create a new channel access environment.
 
         This will set up a number of PVs with a series of different values to
         return each time they are accessed.
@@ -59,7 +80,7 @@ class ChannelAccessEnv(object):
         self._old_index = None
 
     def __enter__(self):
-        """ Setup a global environment dict for channel access"""
+        """Create a global environment dict for channel access."""
         global PV_TEST_DICT, PV_TEST_DICT_CALL_INDEX
         self._old_values = PV_TEST_DICT
         self._old_index = PV_TEST_DICT_CALL_INDEX
@@ -72,12 +93,12 @@ class ChannelAccessEnv(object):
         return self
 
     def __exit__(self, t, value, trace):
-        """ Tear down a global environment dict for channel access"""
+        """Tear down a global environment dict for channel access."""
         global PV_TEST_DICT, PV_TEST_DICT_CALL_INDEX
         PV_TEST_DICT = self._old_values
         PV_TEST_DICT_CALL_INDEX = self._old_index
 
     def get_call_count(self, name):
-        """ Get the number of times a PV was called"""
+        """Get the number of times a PV was called."""
         global PV_TEST_DICT_CALL_INDEX
         return PV_TEST_DICT_CALL_INDEX[name]

--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -231,7 +231,6 @@ class RunControlManager(OnTheFlyPvInterface):
         latest_ioc_start = self._channel_access.caget(self._prefix + RC_START_PV)
 
         if latest_ioc_start is not None:
-            print latest_ioc_start
             latest_ioc_start = datetime.strptime(latest_ioc_start, '%m/%d/%Y %H:%M:%S')
 
         return latest_ioc_start
@@ -250,7 +249,7 @@ class RunControlManager(OnTheFlyPvInterface):
             Bool whether the parsed datetime is valid
         """
         return latest_ioc_start is None or (self._rc_ioc_start_time is
-                not None and latest_ioc_start < self._rc_ioc_start_time)
+                not None and latest_ioc_start <= self._rc_ioc_start_time)
 
     def wait_for_ioc_start(self, time_between_tries=2):
         """

--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -260,9 +260,11 @@ class RunControlManager(OnTheFlyPvInterface):
         latest_ioc_start = self._channel_access.caget(self._prefix
                                                       + RC_START_PV)
 
-        if latest_ioc_start is not None:
+        if latest_ioc_start is not None and latest_ioc_start != '':
             frmt = '%m/%d/%Y %H:%M:%S'
             latest_ioc_start = datetime.strptime(latest_ioc_start, frmt)
+        else:
+            return None
 
         return latest_ioc_start
 

--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -48,7 +48,8 @@ class RunControlManager(OnTheFlyPvInterface):
     def __init__(self, prefix, config_dir, var_dir, ioc_control,
                  active_configholder, block_server,
                  channel_access=ChannelAccess(), sleep_func=sleep):
-        """Constructor.
+        """
+        Constructor.
 
         Args:
             prefix (string): The instrument prefix
@@ -79,20 +80,28 @@ class RunControlManager(OnTheFlyPvInterface):
         self._intialise_runcontrol_ioc()
 
     def read_pv_exists(self, pv):
-        """Check is a PV exists."""
+        """
+        Check is a PV exists.
+        """
         return pv in self._pvs_to_read
 
     def write_pv_exists(self, pv):
-        """Unimplemented."""
+        """
+        Unimplemented.
+        """
         return False
 
     def handle_pv_write(self, pv, data):
-        """Unimplemented."""
+        """
+        Unimplemented.
+        """
         # Nothing to write
         pass
 
     def handle_pv_read(self, pv):
-        """Handle reading a run control PV."""
+        """
+        Handle reading a run control PV.
+        """
         if pv == RUNCONTROL_GET_PV:
             js = convert_to_json(self.get_current_settings())
             value = compress_and_hex(js)
@@ -104,12 +113,16 @@ class RunControlManager(OnTheFlyPvInterface):
         return ""
 
     def update_monitors(self):
-        """Unimplemented."""
+        """
+        Unimplemented.
+        """
         # No monitors
         pass
 
     def initialise(self, full_init=False):
-        """Initilise & create a new set of run control PVs."""
+        """
+        Initilise & create a new set of run control PVs.
+        """
         self.create_runcontrol_pvs(full_init)
 
     def _create_standard_pvs(self):
@@ -124,7 +137,8 @@ class RunControlManager(OnTheFlyPvInterface):
         print_and_log("Runcontrol IOC started")
 
     def create_runcontrol_pvs(self, clear_autosave, time_between_tries=2):
-        """Create the PVs for run-control.
+        """
+        Create the PVs for run-control.
 
         Configures the run-control IOC to have PVs for the current
         configuration.
@@ -143,7 +157,8 @@ class RunControlManager(OnTheFlyPvInterface):
                 self._active_configholder.get_block_details())
 
     def update_runcontrol_blocks(self, blocks):
-        """Update the run-control settings in the IOC with the current blocks.
+        """
+        Update the run-control settings in the IOC with the current blocks.
 
         Args:
             blocks (OrderedDict): The blocks that are part of the current
@@ -165,7 +180,8 @@ class RunControlManager(OnTheFlyPvInterface):
                 f.close()
 
     def get_out_of_range_pvs(self):
-        """Get a list of PVs that are currently out of range.
+        """
+        Get a list of PVs that are currently out of range.
 
         This may include PVs that are not blocks, but have had run-control
         settings applied directly
@@ -187,7 +203,8 @@ class RunControlManager(OnTheFlyPvInterface):
             return list()
 
     def get_current_settings(self):
-        """Get the current run-control settings.
+        """
+        Get the current run-control settings.
 
         Returns:
             dict : The current run-control settings
@@ -210,7 +227,8 @@ class RunControlManager(OnTheFlyPvInterface):
         return settings
 
     def restore_config_settings(self, blocks):
-        """Restore run-control settings based on what is stored in a configuration.
+        """
+        Restore run-control settings based on what is stored in a configuration.
 
         Args:
             blocks (OrderedDict): The blocks for the configuration
@@ -228,7 +246,8 @@ class RunControlManager(OnTheFlyPvInterface):
             self._set_rc_values(blk.name, settings)
 
     def set_runcontrol_settings(self, data):
-        """Replace the run-control settings with new values.
+        """
+        Replace the run-control settings with new values.
 
         Args:
             data (dict): The new run-control settings to set (dictionary of
@@ -251,7 +270,8 @@ class RunControlManager(OnTheFlyPvInterface):
                                   % (bn, err))
 
     def _get_latest_ioc_start(self):
-        """Get the latest IOC start time.
+        """
+        Get the latest IOC start time.
 
         Returns:
             latest_ioc_start (datetime): the latest IOC start time
@@ -269,7 +289,8 @@ class RunControlManager(OnTheFlyPvInterface):
         return latest_ioc_start
 
     def _invalid_ioc_start_time(self, latest_ioc_start):
-        """Check is this start time is invalid.
+        """
+        Check is this start time is invalid.
 
         This checks if it was successfully parsed and whether it is less than
         the current run control IOC start time.
@@ -286,7 +307,8 @@ class RunControlManager(OnTheFlyPvInterface):
                                             <= self._rc_ioc_start_time)
 
     def wait_for_ioc_start(self, time_between_tries=2):
-        """Wait for the run-control IOC to start.
+        """
+        Wait for the run-control IOC to start.
 
         Args:
             time_between_tries (int): time to wait before checking if run
@@ -321,7 +343,9 @@ class RunControlManager(OnTheFlyPvInterface):
             self._sleep_func(time_between_tries * 3)
 
     def _start_ioc(self):
-        """Start the IOC."""
+        """
+        Start the IOC.
+        """
         try:
             self._ioc_control.start_ioc(RUNCONTROL_IOC)
         except Exception as err:
@@ -329,7 +353,8 @@ class RunControlManager(OnTheFlyPvInterface):
                           % str(err), "MAJOR")
 
     def restart_ioc(self, clear_autosave):
-        """Restarts the IOC.
+        """
+        Restarts the IOC.
 
         Args:
             clear_autosave (bool): Whether to delete the autosave files first

--- a/BlockServer/test_modules/runcontrol_manager_tests.py
+++ b/BlockServer/test_modules/runcontrol_manager_tests.py
@@ -21,7 +21,7 @@ os.environ['MYPVPREFIX'] = ""
 from BlockServer.runcontrol.runcontrol_manager import RunControlManager, RC_START_PV
 from BlockServer.mocks.mock_block_server import MockBlockServer
 from BlockServer.mocks.mock_ioc_control import MockIocControl
-from BlockServer.mocks.mock_channel_access import MockChannelAccess, PVS
+from BlockServer.mocks.mock_channel_access import MockChannelAccess, PVS, ChannelAccessEnv
 from BlockServer.mocks.mock_active_config_holder import MockActiveConfigHolder
 from BlockServer.config.configuration import Configuration
 from BlockServer.mocks.mock_version_control import MockVersionControl
@@ -30,6 +30,7 @@ from BlockServer.mocks.mock_archiver_wrapper import MockArchiverWrapper
 from BlockServer.epics.archiver_manager import ArchiverManager
 from BlockServer.core.file_path_manager import FILEPATH_MANAGER
 import unittest
+from datetime import datetime
 
 
 MACROS = {
@@ -47,15 +48,22 @@ def add_block(cs, data):
     cs.add_block(data)
 
 
+def _get_current_time():
+    return datetime.strftime(datetime.now(), '%m/%d/%Y %H:%M:%S')
+
 class TestRunControlSequence(unittest.TestCase):
 
     def setUp(self):
         self.activech = MockActiveConfigHolder(MACROS)
         self.cs = MockChannelAccess()
-        self.set_start_time_of_run_control(1)
-        self.rcm = RunControlManager("", "", "", MockIocControl(""), self.activech, MockBlockServer(), self.cs)
+        self.set_start_time_of_run_control()
 
-    def set_start_time_of_run_control(self, start_time=2):
+        def dummy_sleep_func(seconds):
+            return
+
+        self.rcm = RunControlManager("", "", "", MockIocControl(""), self.activech, MockBlockServer(), self.cs, dummy_sleep_func)
+
+    def set_start_time_of_run_control(self, start_time=_get_current_time()):
         PVS[MACROS["$(MYPVPREFIX)"] + RC_START_PV] = start_time
 
     def test_get_runcontrol_settings_empty(self):
@@ -63,7 +71,6 @@ class TestRunControlSequence(unittest.TestCase):
         self.rcm.create_runcontrol_pvs(False, 0)
         ans = self.rcm.get_current_settings()
         self.assertTrue(len(ans) == 0)
-
 
     def test_get_runcontrol_settings_blocks(self):
         add_block(self.activech, quick_block_to_json("TESTBLOCK1", "PV1", "GROUP1", True))
@@ -112,6 +119,14 @@ class TestRunControlSequence(unittest.TestCase):
         self.assertEqual(ans["TESTBLOCK1"]["LOW"], 0)
 
     def test_GIVEN_non_restarting_runcontrol_WHEN_create_PVs_THAT_code_is_not_stuck_in_loop(self):
+        rc_pv = MACROS["$(MYPVPREFIX)"] + RC_START_PV
+        with ChannelAccessEnv({rc_pv: [_get_current_time()]}) as channel:
+            self.rcm.create_runcontrol_pvs(False, 0)
+            self.assertEqual(channel.get_call_count(rc_pv), 1)
 
-        self.rcm.create_runcontrol_pvs(False, 0)
-
+    def test_GIVEN_nonsense_runcontrol_start_time_WHEN_restart_runcontrol_THAT_code_loops_to_restart_runcontrol(self):
+        rc_pv = MACROS["$(MYPVPREFIX)"] + RC_START_PV
+        with ChannelAccessEnv({rc_pv: [""] * 60}) as channel:
+            self.set_start_time_of_run_control(2)
+            self.rcm.create_runcontrol_pvs(False, 0)
+            self.assertEqual(channel.get_call_count(rc_pv), 60)

--- a/BlockServer/test_modules/runcontrol_manager_tests.py
+++ b/BlockServer/test_modules/runcontrol_manager_tests.py
@@ -51,8 +51,8 @@ def add_block(cs, data):
 def _get_current_time():
     return datetime.strftime(datetime.now(), '%m/%d/%Y %H:%M:%S')
 
-class TestRunControlSequence(unittest.TestCase):
 
+class TestRunControlSequence(unittest.TestCase):
     def setUp(self):
         self.activech = MockActiveConfigHolder(MACROS)
         self.cs = MockChannelAccess()
@@ -61,7 +61,8 @@ class TestRunControlSequence(unittest.TestCase):
         def dummy_sleep_func(seconds):
             return
 
-        self.rcm = RunControlManager("", "", "", MockIocControl(""), self.activech, MockBlockServer(), self.cs, dummy_sleep_func)
+        self.rcm = RunControlManager("", "", "", MockIocControl(""), self.activech, MockBlockServer(), self.cs,
+                                     dummy_sleep_func)
 
     def set_start_time_of_run_control(self, start_time=_get_current_time()):
         PVS[MACROS["$(MYPVPREFIX)"] + RC_START_PV] = start_time


### PR DESCRIPTION
### Description of work

This converts the run control manager to use python `datetime` objects instead of comparing strings.

I've also tidied up the code and added some tests to check what's happening. 

### To test

- Run the run control manager tests in the `inst_servers`
- Code review
- Try to reproduce the issue outlined in the ticket description.

This PR is for https://github.com/ISISComputingGroup/IBEX/issues/2526

### Acceptance criteria
 - Tests pass
 - Code does not wait for ~4 minutes

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
