### PR TITLE
Only select distinct fields

### DIFF
--- a/server_common/ioc_data.py
+++ b/server_common/ioc_data.py
@@ -162,7 +162,7 @@ SELECT s.iocname, p.pvname, lower(p.infoname), p.value
 """Query to return pv info for iocs from the ioc database"""
 
 GET_PVS_WITH_DETAILS = """
-    SELECT pvinfo.pvname, pvs.record_type, pvs.record_desc, pvs.iocname 
+    SELECT DISTINCT pvinfo.pvname, pvs.record_type, pvs.record_desc, pvs.iocname 
       FROM pvinfo
 INNER JOIN pvs ON pvs.pvname = pvinfo.pvname"""
 
@@ -196,7 +196,7 @@ GET_IOCS_AND_DESCRIPTIONS = "SELECT iocname, descr FROM iocs"
 """Return all IOC andes and their descriptions"""
 
 GET_IOCS_AND_RUNNING_STATUS = """
-  SELECT iocname, running 
+  SELECT DISTINCT iocname, running 
     FROM iocrt 
    WHERE iocname NOT LIKE 'PSCTRL_%'"""
 """Sql query for getting iocnames and their running status"""


### PR DESCRIPTION
### Description of work

Use select distinct to avoid returning two rows with exactly the same data when querying the database.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2565

Checkout the branch, restart DBSVR.

### Acceptance criteria

- [x] PV selector dialog does not contain any duplicate PVS
- [x] All expected PVs still appear in the PV selector dialog
- [x] Anything else that you can think of that uses the DB server is unaffected

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
