### PR TITLE
If devices file does not exist, create & use blank one

### DIFF
--- a/BlockServer/devices/devices_file_io.py
+++ b/BlockServer/devices/devices_file_io.py
@@ -1,5 +1,6 @@
 import os
-from server_common.utilities import print_and_log, retry
+from server_common.common_exceptions import MaxAttemptsExceededException
+from server_common.utilities import retry
 from xml.dom import minidom
 
 RETRY_MAX_ATTEMPTS = 20
@@ -20,11 +21,9 @@ class DevicesFileIO(object):
             string: the XML as a string
         """
 
-        # Create the file if it does not exist
         if not os.path.exists(file_name):
-            print_and_log("Device screens file not found.")
-            return ""
-
+            # Break retry loop if file does not exist.
+            raise MaxAttemptsExceededException
         with open(file_name, 'r') as devfile:
             data = devfile.read()
             return data

--- a/BlockServer/devices/devices_manager.py
+++ b/BlockServer/devices/devices_manager.py
@@ -68,8 +68,8 @@ class DevicesManager(OnTheFlyPvInterface):
                 self.save_devices_xml(data)
                 self.update_monitors()
             except IOError as err:
-                print_and_log(
-                    "Could not save device screens: {error} The PV data will not be updated.".format(error=err))
+                print_and_log("Could not save device screens: {error} "
+                              "The PV data will not be updated.".format(error=err), "MINOR")
 
     def handle_pv_read(self, pv):
         # Nothing to do as it is all handled by monitors
@@ -148,8 +148,7 @@ class DevicesManager(OnTheFlyPvInterface):
                 os.makedirs(FILEPATH_MANAGER.devices_dir)
             self._file_io.save_devices_file(self.get_devices_filename(), xml_data)
         except MaxAttemptsExceededException:
-            raise IOError("Unable to save devices file. Please check the file is not in use by another process.",
-                          "MINOR")
+            raise IOError("Unable to save devices file. Please check the file is not in use by another process.")
 
         # Update PVs
         self.update(xml_data, "Device screens modified by client")


### PR DESCRIPTION
### Description of work

Fixes a bug introduced with https://github.com/ISISComputingGroup/EPICS-inst_servers/pull/139 where the blockserver would not create and default back to a blank set of device screens if no device screens file was found on the instrument.

### Acceptance criteria

The blockserver handles a missing device screens file sensibly.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
