### PR TITLE
Only recreate single new PV and not recreate all existing PVs too

### DIFF
--- a/block_server.py
+++ b/block_server.py
@@ -755,6 +755,7 @@ class BlockServer(Driver):
                     }
                 }
                 self._cas.createPV(BLOCKSERVER_PREFIX, newPV)
+                PVDB[name] = newPV
                 # self.configure_pv_db()
                 data = Data()
                 data.value = manager.pvs[self.port][name].info.value

--- a/block_server.py
+++ b/block_server.py
@@ -748,14 +748,14 @@ class BlockServer(Driver):
         if name not in PVDB and name not in manager.pvs[self.port]:
             try:
                 print_and_log("Adding PV %s" % name)
-                newPV = { name : {
+                new_pv = { name : {
                     'type': 'char',
                     'count': count,
                     'value': [0],
                     }
                 }
                 self._cas.createPV(BLOCKSERVER_PREFIX, newPV)
-                PVDB[name] = newPV
+                PVDB[name] = new_pv
                 # self.configure_pv_db()
                 data = Data()
                 data.value = manager.pvs[self.port][name].info.value

--- a/block_server.py
+++ b/block_server.py
@@ -754,7 +754,7 @@ class BlockServer(Driver):
                     'value': [0],
                     }
                 }
-                self._cas.createPV(BLOCKSERVER_PREFIX, newPV)
+                self._cas.createPV(BLOCKSERVER_PREFIX, new_pv)
                 PVDB[name] = new_pv
                 # self.configure_pv_db()
                 data = Data()

--- a/block_server.py
+++ b/block_server.py
@@ -748,12 +748,13 @@ class BlockServer(Driver):
         if name not in PVDB and name not in manager.pvs[self.port]:
             try:
                 print_and_log("Adding PV %s" % name)
-                PVDB[name] = {
+                newPV = { name : {
                     'type': 'char',
                     'count': count,
                     'value': [0],
+                    }
                 }
-                self._cas.createPV(BLOCKSERVER_PREFIX, PVDB)
+                self._cas.createPV(BLOCKSERVER_PREFIX, newPV)
                 # self.configure_pv_db()
                 data = Data()
                 data.value = manager.pvs[self.port][name].info.value


### PR DESCRIPTION
### Description of work

The pevious implementation re-created all existing PV by overwriting
the dictionary entries, the PVs would then get destroyed in C++ when
python garbage collected leading to random crashes.

### To test

See ISISComputingGroup/IBEX#2824

### Acceptance criteria

* blockserver restarts with many synoptics and clients present

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] ~Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?~

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
