### PR TITLE
Don't add 'recommended' suffix to synoptic name. Let GUI handle it

### DIFF
--- a/BlockServer/synoptic/synoptic_manager.py
+++ b/BlockServer/synoptic/synoptic_manager.py
@@ -169,11 +169,11 @@ class SynopticManager(OnTheFlyPvInterface):
         syn_list = list()
         default_is_none_synoptic = True
         for k, v in self._synoptic_pvs.iteritems():
+            is_default = False
             if "<name>" + k + "</name>" in self._default_syn_xml:
-                syn_list.append({"name": k + " (recommended)", "pv": v, "is_default": True})
                 default_is_none_synoptic = False
-            else:
-                syn_list.append({"name": k, "pv": v, "is_default": False})
+                is_default = True
+            syn_list.append({"name": k, "pv": v, "is_default": is_default})
         ans = sorted(syn_list, key=lambda x: x['name'].lower())
         # Insert the "blank" synoptic
         ans.insert(0, {"pv": "__BLANK__", "name": "-- NONE --", "is_default": default_is_none_synoptic})


### PR DESCRIPTION
### Description of work

`(recommended)` is no longer appended to the default synoptic name. It is superfluous since the default-ness is sent separately. The GUI handles any manipulation of the data owing to its needs.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2527

### Acceptance criteria

See GUI PR

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [x] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
