### PR TITLE
Stops IOCs when removed from the current configuration

### DIFF
--- a/BlockServer/core/active_config_holder.py
+++ b/BlockServer/core/active_config_holder.py
@@ -124,6 +124,7 @@ class ActiveConfigHolder(ConfigHolder):
         """
         iocs_to_start = set()
         iocs_to_restart = set()
+        iocs_to_stop = set()
 
         # Check to see if any macros, pvs, pvsets etc. have changed
         for n in self._config.iocs.keys():
@@ -146,4 +147,9 @@ class ActiveConfigHolder(ConfigHolder):
                 for n in cv.iocs.keys():
                     iocs_to_start.add(n)
 
-        return iocs_to_start, iocs_to_restart
+        # Look for any removed IOCs
+        for n in self._cached_config.iocs.keys():
+            if n not in self._config.iocs.keys():
+                iocs_to_stop.add(n)
+
+        return iocs_to_start, iocs_to_restart, iocs_to_stop

--- a/BlockServer/test_modules/active_config_holder_tests.py
+++ b/BlockServer/test_modules/active_config_holder_tests.py
@@ -205,9 +205,10 @@ class TestActiveConfigHolderSequence(unittest.TestCase):
         details = ch.get_config_details()
         ch.set_config_details(details)
         # Assert
-        start, restart = ch.iocs_changed()
+        start, restart, stop = ch.iocs_changed()
         self.assertEqual(len(start), 0)
         self.assertEqual(len(restart), 0)
+        self.assertEqual(len(stop), 0)
 
     def test_iocs_changed_ioc_added(self):
         # Arrange
@@ -217,9 +218,10 @@ class TestActiveConfigHolderSequence(unittest.TestCase):
         details['iocs'].append(MockIoc())
         ch.set_config_details(details)
         # Assert
-        start, restart = ch.iocs_changed()
+        start, restart, stop = ch.iocs_changed()
         self.assertEqual(len(start), 1)
         self.assertEqual(len(restart), 0)
+        self.assertEqual(len(stop), 0)
 
     def test_iocs_changed_ioc_removed(self):
         # Arrange
@@ -231,9 +233,10 @@ class TestActiveConfigHolderSequence(unittest.TestCase):
         details['iocs'].pop(0)
         ch.set_config_details(details)
         # Assert
-        start, restart = ch.iocs_changed()
+        start, restart, stop = ch.iocs_changed()
         self.assertEqual(len(start), 0)
         self.assertEqual(len(restart), 0)
+        self.assertEqual(len(stop), 1)
 
     def _test_attribute_changes(self, initial_attrs={}, final_attrs={}, has_changed=True):
         # Take a dict of initial attributes and final attributes and
@@ -256,9 +259,10 @@ class TestActiveConfigHolderSequence(unittest.TestCase):
         details['iocs'][0] = final_ioc
         ch.set_config_details(details)
         # Assert
-        start, restart = ch.iocs_changed()
+        start, restart, stop = ch.iocs_changed()
         self.assertEqual(len(start), 0)
         self.assertEqual(len(restart), 1 if has_changed else 0)
+        self.assertEqual(len(stop), 0)
 
     def test_iocs_changed_macro_added(self):
         self._test_attribute_changes(final_attrs={'macros':[{"name": "TESTMACRO1", "value": "TEST"}]})

--- a/block_server.py
+++ b/block_server.py
@@ -447,7 +447,9 @@ class BlockServer(Driver):
         """
         # First stop all IOCS, then start the ones for the config
         # TODO: Should we stop all configs?
-        iocs_to_start, iocs_to_restart = self._active_configserver.iocs_changed()
+        iocs_to_start, iocs_to_restart, iocs_to_stop = self._active_configserver.iocs_changed()
+
+        self._ioc_control.stop_iocs(iocs_to_stop)
 
         if len(iocs_to_start) > 0 or len(iocs_to_restart) > 0:
             self._stop_iocs_and_start_config_iocs(iocs_to_start, iocs_to_restart)


### PR DESCRIPTION
### Description of work

IOCs removed from the active configuration are stopped upon saving the changes.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2447

### Acceptance criteria

Removing IOCs from the active configuration stops them.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [x] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
