### PR TITLE
Changed logging level of "nothing to commit" message to DEBUG

### DIFF
--- a/ConfigVersionControl/git_version_control.py
+++ b/ConfigVersionControl/git_version_control.py
@@ -116,7 +116,6 @@ class GitVersionControl:
         """
         num_files_changed = len(self.repo.index.diff("HEAD"))
         if num_files_changed == 0:
-            print_and_log("GIT: Nothing to commit", "DEBUG")
             return  # nothing staged for commit
 
         commit_comment = self._message_provider.get_commit_message(self.repo.index.diff("HEAD"))

--- a/ConfigVersionControl/git_version_control.py
+++ b/ConfigVersionControl/git_version_control.py
@@ -116,7 +116,7 @@ class GitVersionControl:
         """
         num_files_changed = len(self.repo.index.diff("HEAD"))
         if num_files_changed == 0:
-            print_and_log("GIT: Nothing to commit")
+            print_and_log("GIT: Nothing to commit", "DEBUG")
             return  # nothing staged for commit
 
         commit_comment = self._message_provider.get_commit_message(self.repo.index.diff("HEAD"))


### PR DESCRIPTION
### Description of work

Changed the logging level of the version control "Nothing to commit" message to DEBUG, as it is being printed every 5 minutes and can bury more important information.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2980

### Acceptance criteria

Logging level of message is now DEBUG

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
