### PR TITLE
Ticket3551 refl fix individual move

### DIFF
--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -108,7 +108,7 @@ class Beamline(object):
                 raise ValueError("Beamline parameters must be uniquely named. Duplicate '{}'".format(
                     beamline_parameter.name))
             self._beamline_parameters[beamline_parameter.name] = beamline_parameter
-            beamline_parameter.after_move_listener = self.update_beamline_parameters
+            beamline_parameter.after_move_listener = self.reset_beamline_parameters
 
         for component in components:
             component.after_beam_path_update_listener = self.update_beam_path
@@ -212,9 +212,6 @@ class Beamline(object):
         of from the beginning of the beamline. If the source is not in the mode then don't update the beamline.
         Args:
             source: source to start the update from; None start from the beginning.
-
-        Returns:
-
         """
         if source is None or self._active_mode.has_beamline_parameter(source):
             parameters = self._beamline_parameters.values()
@@ -223,6 +220,21 @@ class Beamline(object):
             for beamline_parameter in parameters:
                 if beamline_parameter in parameters_in_mode or beamline_parameter.sp_changed:
                     beamline_parameter.move_no_callback()
+
+    def reset_beamline_parameters(self, source=None):
+        """
+        Resets the beamline parameters in the current mode to their last setpoint. If given a source in the mode start
+        from this one instead of from the beginning of the beamline. If the source is not in the mode then don't update
+        the beamline.
+        Args:
+            source: source to start the update from; None start from the beginning.
+        """
+        if source is None or self._active_mode.has_beamline_parameter(source):
+            parameters = self._beamline_parameters.values()
+            parameters_in_mode = self._active_mode.get_parameters_in_mode(parameters, source)
+
+            for beamline_parameter in parameters_in_mode:
+                beamline_parameter.move_no_callback_reset()
 
     def parameter(self, key):
         """

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -206,30 +206,27 @@ class Beamline(object):
             component.set_incoming_beam(outgoing)
             outgoing = component.get_outgoing_beam()
 
-    def update_beamline_parameters(self, source=None):
+    def update_beamline_parameters(self):
         """
-        Updates the beamline parameters in the current mode. If given a source in the mode start from this one instead
-        of from the beginning of the beamline. If the source is not in the mode then don't update the beamline.
-        Args:
-            source: source to start the update from; None start from the beginning.
+        Updates the beamline parameters to the latest set point value if they have changed, or resets the last setpoint
+        if they have not but are in the mode.
         """
-        if source is None or self._active_mode.has_beamline_parameter(source):
-            parameters = self._beamline_parameters.values()
-            parameters_in_mode = self._active_mode.get_parameters_in_mode(parameters, source)
+        parameters = self._beamline_parameters.values()
+        parameters_in_mode = self._active_mode.get_parameters_in_mode(parameters, None)
 
-            for beamline_parameter in parameters:
-                if beamline_parameter in parameters_in_mode or beamline_parameter.sp_changed:
-                    beamline_parameter.move_no_callback()
+        for beamline_parameter in parameters:
+            if beamline_parameter in parameters_in_mode or beamline_parameter.sp_changed:
+                beamline_parameter.move_no_callback()
 
-    def reset_beamline_parameters(self, source=None):
+    def reset_beamline_parameters(self, source):
         """
-        Resets the beamline parameters in the current mode to their last setpoint. If given a source in the mode start
-        from this one instead of from the beginning of the beamline. If the source is not in the mode then don't update
+        Resets the beamline parameters in the current mode to their last setpoint starting from a given source. If the
+        source is not in the mode then don't update
         the beamline.
         Args:
             source: source to start the update from; None start from the beginning.
         """
-        if source is None or self._active_mode.has_beamline_parameter(source):
+        if self._active_mode.has_beamline_parameter(source):
             parameters = self._beamline_parameters.values()
             parameters_in_mode = self._active_mode.get_parameters_in_mode(parameters, source)
 

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -16,7 +16,8 @@ class BeamlineMode(object):
             name (str): name of the beam line mode
             beamline_parameters_to_calculate (list[str]): Beamline parameters in this mode
                 which should be automatically moved to whenever a preceding parameter is changed
-            sp_inits (dict[str, object]): The initial beamline parameter values that should be set when switching to this mode
+            sp_inits (dict[str, object]): The initial beamline parameter values that should be set when switching
+                to this mode
         """
         self.name = name
         self._beamline_parameters_to_calculate = beamline_parameters_to_calculate
@@ -108,7 +109,7 @@ class Beamline(object):
                 raise ValueError("Beamline parameters must be uniquely named. Duplicate '{}'".format(
                     beamline_parameter.name))
             self._beamline_parameters[beamline_parameter.name] = beamline_parameter
-            beamline_parameter.after_move_listener = self.reset_beamline_parameters
+            beamline_parameter.after_move_listener = self._move_for_single_beamline_parameters
 
         for component in components:
             component.after_beam_path_update_listener = self.update_beam_path
@@ -174,7 +175,7 @@ class Beamline(object):
         Args:
             _: dummy can be anything
         """
-        self.update_beamline_parameters()
+        self._move_for_all_beamline_parameters()
         self._move_drivers(self._get_max_move_duration())
 
     def __getitem__(self, item):
@@ -206,22 +207,21 @@ class Beamline(object):
             component.set_incoming_beam(outgoing)
             outgoing = component.get_outgoing_beam()
 
-    def update_beamline_parameters(self):
+    def _move_for_all_beamline_parameters(self):
         """
-        Updates the beamline parameters to the latest set point value if they have changed, or resets the last setpoint
-        if they have not but are in the mode.
+        Updates the beamline parameters to the latest set point value; reapplies if they are in the mode.
         """
         parameters = self._beamline_parameters.values()
         parameters_in_mode = self._active_mode.get_parameters_in_mode(parameters, None)
 
         for beamline_parameter in parameters:
             if beamline_parameter in parameters_in_mode or beamline_parameter.sp_changed:
-                beamline_parameter.move_no_callback()
+                beamline_parameter.move_to_sp_no_callback()
 
-    def reset_beamline_parameters(self, source):
+    def _move_for_single_beamline_parameters(self, source):
         """
-        Resets the beamline parameters in the current mode to their last setpoint starting from a given source. If the
-        source is not in the mode then don't update
+        Moves starts from a single beamline parameter and move is to parameters sp read backs. If the
+        source is not in the mode then don't update any other parameters.
         the beamline.
         Args:
             source: source to start the update from; None start from the beginning.
@@ -231,7 +231,7 @@ class Beamline(object):
             parameters_in_mode = self._active_mode.get_parameters_in_mode(parameters, source)
 
             for beamline_parameter in parameters_in_mode:
-                beamline_parameter.move_no_callback_reset()
+                beamline_parameter.move_to_sp_rbv_no_callback()
 
     def parameter(self, key):
         """

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -87,22 +87,22 @@ class BeamlineParameter(object):
         """
         Move to the setpoint, no matter what the value passed is.
         """
-        self.move_no_callback()
+        self.move_to_sp_no_callback()
         self.after_move_listener(self)
 
-    def move_no_callback(self):
+    def move_to_sp_no_callback(self):
         """
         Move the component but don't call a callback indicating a move has been performed.
         """
-        self._move_component(self._set_point)
         self._set_point_rbv = self._set_point
+        self._move_component()
         self._sp_is_changed = False
 
-    def move_no_callback_reset(self):
+    def move_to_sp_rbv_no_callback(self):
         """
         Repeat the move to the last set point.
         """
-        self._move_component(self._set_point_rbv)
+        self._move_component()
 
     @property
     def name(self):
@@ -118,7 +118,7 @@ class BeamlineParameter(object):
         """
         return self._sp_is_changed
 
-    def _move_component(self, value):
+    def _move_component(self):
         """
         Moves the component(s) associated with this parameter to the setpoint.
         """
@@ -142,8 +142,8 @@ class ReflectionAngle(BeamlineParameter):
         super(ReflectionAngle, self).__init__(name, sim, init)
         self._reflection_component = reflection_component
 
-    def _move_component(self, value):
-        self._reflection_component.set_angle_relative_to_beam(value)
+    def _move_component(self):
+        self._reflection_component.set_angle_relative_to_beam(self._set_point_rbv)
 
 
 class Theta(ReflectionAngle):
@@ -177,8 +177,8 @@ class TrackingPosition(BeamlineParameter):
         super(TrackingPosition, self).__init__(name, sim, init)
         self._component = component
 
-    def _move_component(self, value):
-        self._component.set_position_relative_to_beam(value)
+    def _move_component(self):
+        self._component.set_position_relative_to_beam(self._set_point_rbv)
 
 
 class ComponentEnabled(BeamlineParameter):
@@ -197,5 +197,5 @@ class ComponentEnabled(BeamlineParameter):
         self._component = component
         self.parameter_type = BeamlineParameterType.IN_OUT
 
-    def _move_component(self, value):
-        self._component.enabled = value
+    def _move_component(self):
+        self._component.enabled = self._set_point_rbv

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -24,6 +24,7 @@ class BeamlineParameter(object):
             self._set_point_rbv = init
         else:
             self._set_point = None
+            self._set_point_rbv = None
         self._sp_is_changed = False
         self._name = name
         self.after_move_listener = lambda x: None
@@ -93,9 +94,15 @@ class BeamlineParameter(object):
         """
         Move the component but don't call a callback indicating a move has been performed.
         """
-        self._move_component()
+        self._move_component(self._set_point)
         self._set_point_rbv = self._set_point
         self._sp_is_changed = False
+
+    def move_no_callback_reset(self):
+        """
+        Repeat the move to the last set point.
+        """
+        self._move_component(self._set_point_rbv)
 
     @property
     def name(self):
@@ -111,7 +118,7 @@ class BeamlineParameter(object):
         """
         return self._sp_is_changed
 
-    def _move_component(self):
+    def _move_component(self, value):
         """
         Moves the component(s) associated with this parameter to the setpoint.
         """
@@ -135,8 +142,8 @@ class ReflectionAngle(BeamlineParameter):
         super(ReflectionAngle, self).__init__(name, sim, init)
         self._reflection_component = reflection_component
 
-    def _move_component(self):
-        self._reflection_component.set_angle_relative_to_beam(self._set_point)
+    def _move_component(self, value):
+        self._reflection_component.set_angle_relative_to_beam(value)
 
 
 class Theta(ReflectionAngle):
@@ -170,8 +177,8 @@ class TrackingPosition(BeamlineParameter):
         super(TrackingPosition, self).__init__(name, sim, init)
         self._component = component
 
-    def _move_component(self):
-        self._component.set_position_relative_to_beam(self._set_point)
+    def _move_component(self, value):
+        self._component.set_position_relative_to_beam(value)
 
 
 class ComponentEnabled(BeamlineParameter):
@@ -190,5 +197,5 @@ class ComponentEnabled(BeamlineParameter):
         self._component = component
         self.parameter_type = BeamlineParameterType.IN_OUT
 
-    def _move_component(self):
-        self._component.enabled = self._set_point
+    def _move_component(self, value):
+        self._component.enabled = value

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -10,7 +10,7 @@ class EmptyBeamlineParameter(BeamlineParameter):
         super(EmptyBeamlineParameter, self).__init__(name)
         self.move_component_count = 0
 
-    def _move_component(self):
+    def _move_component(self, value):
         self.move_component_count += 1
 
 

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -1,3 +1,6 @@
+"""
+Test data and classes.
+"""
 from ReflectometryServer.beamline import BeamlineMode, Beamline
 from ReflectometryServer.parameters import BeamlineParameter
 
@@ -10,7 +13,7 @@ class EmptyBeamlineParameter(BeamlineParameter):
         super(EmptyBeamlineParameter, self).__init__(name)
         self.move_component_count = 0
 
-    def _move_component(self, value):
+    def _move_component(self):
         self.move_component_count += 1
 
 

--- a/ReflectometryServer/test_modules/test_actual_positions.py
+++ b/ReflectometryServer/test_modules/test_actual_positions.py
@@ -28,9 +28,9 @@ class TestComponentBeamline(unittest.TestCase):
         s4 = Component("s4", movement_strategy=LinearMovement(0, 8, 90))
         detector = Component("detector", movement_strategy=LinearMovement(0, 10, 90))
 
-        theta = Theta("theta", self.ideal_sample_point)
+        theta = Theta("theta", self.ideal_sample_point, sim=True)
         theta.sp_no_move = 0
-        smangle = ReflectionAngle("smangle", self.polarising_mirror)
+        smangle = ReflectionAngle("smangle", self.polarising_mirror, sim=True)
         smangle.sp_no_move = 0
 
         self.nr_mode = BeamlineMode("NR Mode", [theta.name])

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -424,6 +424,7 @@ class TestBeamlineModes(unittest.TestCase):
 
         assert_that(s4.sp_position().y, is_(s4_height_initial))
 
+
 class TestBeamlineOnMove(unittest.TestCase):
 
     def test_GIVEN_two_beamline_parameters_with_same_name_WHEN_construct_THEN_error(self):

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -357,6 +357,73 @@ class TestBeamlineModes(unittest.TestCase):
 
         assert_that(s2.sp_position().y, is_(target_s2_height))
 
+    def test_GIVEN_two_changed_parameters_in_mode_WHEN_first_parameter_moved_to_SP_THEN_second_parameter_moved_to_SP_RBV(self):
+        beam_start = PositionAndAngle(0, 0, 0)
+        s4_height_initial = 0.0
+        s4_height_sp = 1.0
+        bounced_beam_angle = 45.0
+        sample_z = 10.0
+        sample_to_s4_z = 10.0
+        sample_point = ReflectingComponent("sm", LinearMovement(0, sample_z, 90))
+        s4 = Component("s4", LinearMovement(s4_height_initial, sample_z + sample_to_s4_z, 90))
+        theta = Theta("theta", sample_point, True)
+        slit4_pos = TrackingPosition("slit4pos", s4, True)
+        mode = BeamlineMode("both_params", [theta.name, slit4_pos.name])
+        beamline = Beamline([sample_point, s4], [theta, slit4_pos], [], [mode])
+        beamline.set_incoming_beam(beam_start)
+        beamline.active_mode = mode.name
+
+        theta.sp_no_move = bounced_beam_angle / 2
+        slit4_pos.sp_no_move = s4_height_sp
+        theta.move = 1
+
+        assert_that(s4.sp_position().y, is_(close_to(sample_to_s4_z + s4_height_initial, DEFAULT_TEST_TOLERANCE)))
+
+    def test_GIVEN_two_changed_parameters_with_second_not_in_mode_WHEN_first_parameter_moved_to_SP_THEN_second_parameter_unchanged(self):
+        beam_start = PositionAndAngle(0, 0, 0)
+        s4_height_initial = 0.0
+        s4_height_sp = 1.0
+        bounced_beam_angle = 45.0
+        sample_z = 10.0
+        sample_to_s4_z = 10.0
+        sample_point = ReflectingComponent("sm", LinearMovement(0, sample_z, 90))
+        s4 = Component("s4", LinearMovement(s4_height_initial, sample_z + sample_to_s4_z, 90))
+        theta = Theta("theta", sample_point, True)
+        slit4_pos = TrackingPosition("slit4pos", s4, True)
+        mode = BeamlineMode("first_param", [theta.name])
+        beamline = Beamline([sample_point, s4], [theta, slit4_pos], [], [mode])
+        beamline.set_incoming_beam(beam_start)
+        beamline.active_mode = mode.name
+
+        theta.sp_no_move = bounced_beam_angle / 2
+        slit4_pos.sp_no_move = s4_height_sp
+        theta.move = 1
+
+        assert_that(s4.sp_position().y, is_(s4_height_initial))
+
+    def test_GIVEN_two_changed_parameters_with_first_not_in_mode_WHEN_first_parameter_moved_to_SP_THEN_second_parameter_unchanged(
+            self):
+        beam_start = PositionAndAngle(0, 0, 0)
+        s4_height_initial = 0.0
+        s4_height_sp = 1.0
+        bounced_beam_angle = 45.0
+        sample_z = 10.0
+        sample_to_s4_z = 10.0
+        sample_point = ReflectingComponent("sm", LinearMovement(0, sample_z, 90))
+        s4 = Component("s4", LinearMovement(s4_height_initial, sample_z + sample_to_s4_z, 90))
+        theta = Theta("theta", sample_point, True)
+        slit4_pos = TrackingPosition("slit4pos", s4, True)
+        mode = BeamlineMode("second_params", [slit4_pos.name])
+        beamline = Beamline([sample_point, s4], [theta, slit4_pos], [], [mode])
+        beamline.set_incoming_beam(beam_start)
+        beamline.active_mode = mode.name
+
+        theta.sp_no_move = bounced_beam_angle / 2
+        slit4_pos.sp_no_move = s4_height_sp
+        theta.move = 1
+
+        assert_that(s4.sp_position().y, is_(s4_height_initial))
+
 class TestBeamlineOnMove(unittest.TestCase):
 
     def test_GIVEN_two_beamline_parameters_with_same_name_WHEN_construct_THEN_error(self):


### PR DESCRIPTION
### Description of work

Individual moves now do not apply any other changed setpoints, but simply reset the latest setpoint readback value for following beamline parameters in the mode.
To achieve this, I have split `update_beamline_parameters` into two methods: 
- one that gets called after an individual move and resets the sp_rbvs of subsequent parameters in the mode
- one that gets called on a beamline move and updates all parameters to their latest values

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3551

### Acceptance criteria

- Triggering an individual move on a parameter...
    - [x] Applies its new setpoint
    - [x] Does not apply any other changed setpoints
    - [x] Moves following parameters to their sp_rbv value if they are in the mode
    - [x] Does not move any parameters that are not in the mode
- Other functionality is unchanged.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [x] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
