### PR TITLE
Ticket3533 add reflectometry ioc

### DIFF
--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -13,18 +13,22 @@ SP_RBV_SUFFIX = ":SP:RBV"
 MOVE_SUFFIX = ":MOVE"
 CHANGED_SUFFIX = ":CHANGED"
 SET_AND_MOVE_SUFFIX = ":SETANDMOVE"
+VAL_FIELD = ".VAL"
 
-PARAMS_FIELDS = {
+PARAM_FIELDS_CHANGED = {'type': 'enum', 'enums': ["NO", "YES"]}
+
+PARAM_FIELDS_MOVE = {'type': 'int', 'count': 1, 'value': 0, }
+
+PARAMS_FIELDS_BEAMLINE_TYPES = {
     BeamlineParameterType.IN_OUT: {'enums': ["OUT", "IN"]},
     BeamlineParameterType.FLOAT: {'type': 'float', 'prec': 3, 'value': 0.0}}
 
-
 ARCHIVED = {
-    "archive": "",
+    "archive": "VAL",
 }
 
 INTERESTING_AND_ARCHIVED = {
-    "archive": "",
+    "archive": "VAL",
     "INTEREST": "HIGH"
 }
 
@@ -41,27 +45,24 @@ class PVManager:
             mode_names: names of the modes
         """
 
+        mode_fields = {'type': 'enum', 'enums': mode_names, PV_INFO_FIELD_NAME: INTERESTING_AND_ARCHIVED}
         self.PVDB = {
-            BEAMLINE_MOVE: {
-                'type': 'int',
-                'count': 1,
-                'value': 0,
-            },
-            BEAMLINE_MODE: {
-                'type': 'enum',
-                'enums': mode_names,
-                PV_INFO_FIELD_NAME: INTERESTING_AND_ARCHIVED
-            }
+            BEAMLINE_MOVE: PARAM_FIELDS_MOVE,
+            BEAMLINE_MOVE + VAL_FIELD: PARAM_FIELDS_MOVE,
+            BEAMLINE_MODE: mode_fields,
+            BEAMLINE_MODE + VAL_FIELD: mode_fields,
+            BEAMLINE_MODE + SP_SUFFIX: mode_fields,
+            BEAMLINE_MODE + SP_SUFFIX + VAL_FIELD: mode_fields
         }
 
         self._pv_lookup = {}
         for param, param_type in param_types.items():
-            self._add_parameter_pvs(param, **PARAMS_FIELDS[param_type])
+            self._add_parameter_pvs(param, "", **PARAMS_FIELDS_BEAMLINE_TYPES[param_type])
 
         for pv_name in self.PVDB.keys():
             print("creating pv: {}".format(pv_name))
 
-    def _add_parameter_pvs(self, param_name, **fields):
+    def _add_parameter_pvs(self, param_name, field_name, **fields):
         """
         Adds all PVs needed for one beamline parameter to the PV database.
 
@@ -70,22 +71,39 @@ class PVManager:
         """
         try:
             param_alias = create_pv_name(param_name, self.PVDB.keys(), "PARAM")
+            self._pv_lookup[param_alias + field_name] = param_name
+
             prepended_alias = PARAM_PREFIX + param_alias
             field_with_intrest_and_archiving = fields.copy()
             field_with_intrest_and_archiving[PV_INFO_FIELD_NAME] = INTERESTING_AND_ARCHIVED
+
+            field_with_intrest_and_archiving[PV_INFO_FIELD_NAME + VAL_FIELD] = fields
             fields_with_archiving = fields.copy()
             fields_with_archiving[PV_INFO_FIELD_NAME] = ARCHIVED
-            self.PVDB[prepended_alias] = field_with_intrest_and_archiving
-            self.PVDB[prepended_alias + SP_SUFFIX] = fields_with_archiving
-            self.PVDB[prepended_alias + SP_RBV_SUFFIX] = fields
-            self.PVDB[prepended_alias + SET_AND_MOVE_SUFFIX] = fields
-            self.PVDB[prepended_alias + CHANGED_SUFFIX] = {'type': 'enum',
-                                                           'enums': ["NO", "YES"]}
-            self.PVDB[prepended_alias + MOVE_SUFFIX] = {'type': 'int',
-                                                        'count': 1,
-                                                        'value': 0,
-                                                        }
-            self._pv_lookup[param_alias] = param_name
+            # Readback PV
+            self.PVDB[prepended_alias + field_name] = field_with_intrest_and_archiving
+            self.PVDB[prepended_alias + field_name + VAL_FIELD] = fields
+
+            # Setpoint PV
+            self.PVDB[prepended_alias + SP_SUFFIX + field_name] = fields_with_archiving
+            self.PVDB[prepended_alias + SP_SUFFIX + field_name + VAL_FIELD] = fields
+
+            # Setpoint readback PV
+            self.PVDB[prepended_alias + SP_RBV_SUFFIX + field_name] = fields
+            self.PVDB[prepended_alias + SP_RBV_SUFFIX + field_name + VAL_FIELD] = fields
+
+            # Set value and move PV
+            self.PVDB[prepended_alias + SET_AND_MOVE_SUFFIX + field_name] = fields
+            self.PVDB[prepended_alias + SET_AND_MOVE_SUFFIX + field_name + VAL_FIELD] = fields
+
+            # Changed PV
+            self.PVDB[prepended_alias + CHANGED_SUFFIX + field_name] = PARAM_FIELDS_CHANGED
+            self.PVDB[prepended_alias + CHANGED_SUFFIX + field_name + VAL_FIELD] = PARAM_FIELDS_CHANGED
+
+            # Move  PV
+            self.PVDB[prepended_alias + MOVE_SUFFIX + field_name] = PARAM_FIELDS_MOVE
+            self.PVDB[prepended_alias + MOVE_SUFFIX + field_name + VAL_FIELD] = PARAM_FIELDS_MOVE
+
         except Exception as err:
             print("Error adding parameter PV: " + err.message)
 

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -2,6 +2,7 @@
 Reflectometry pv manager
 """
 from ReflectometryServer.parameters import BeamlineParameterType
+from server_common.ioc_data_source import PV_INFO_FIELD_NAME
 from server_common.utilities import create_pv_name
 
 PARAM_PREFIX = "PARAM:"
@@ -15,7 +16,17 @@ SET_AND_MOVE_SUFFIX = ":SETANDMOVE"
 
 PARAMS_FIELDS = {
     BeamlineParameterType.IN_OUT: {'enums': ["OUT", "IN"]},
-    BeamlineParameterType.FLOAT: {'prec': 3, 'value': 0.0}}
+    BeamlineParameterType.FLOAT: {'type': 'float', 'prec': 3, 'value': 0.0}}
+
+
+ARCHIVED = {
+    "archive": "",
+}
+
+INTERESTING_AND_ARCHIVED = {
+    "archive": "",
+    "INTEREST": "HIGH"
+}
 
 
 class PVManager:
@@ -29,6 +40,7 @@ class PVManager:
             param_types (dict[str, str]): The types for which to create PVs, keyed by name.
             mode_names: names of the modes
         """
+
         self.PVDB = {
             BEAMLINE_MOVE: {
                 'type': 'int',
@@ -37,7 +49,8 @@ class PVManager:
             },
             BEAMLINE_MODE: {
                 'type': 'enum',
-                'enums': mode_names
+                'enums': mode_names,
+                PV_INFO_FIELD_NAME: INTERESTING_AND_ARCHIVED
             }
         }
 
@@ -58,8 +71,12 @@ class PVManager:
         try:
             param_alias = create_pv_name(param_name, self.PVDB.keys(), "PARAM")
             prepended_alias = PARAM_PREFIX + param_alias
-            self.PVDB[prepended_alias] = fields
-            self.PVDB[prepended_alias + SP_SUFFIX] = fields
+            field_with_intrest_and_archiving = fields.copy()
+            field_with_intrest_and_archiving[PV_INFO_FIELD_NAME] = INTERESTING_AND_ARCHIVED
+            fields_with_archiving = fields.copy()
+            fields_with_archiving[PV_INFO_FIELD_NAME] = ARCHIVED
+            self.PVDB[prepended_alias] = field_with_intrest_and_archiving
+            self.PVDB[prepended_alias + SP_SUFFIX] = fields_with_archiving
             self.PVDB[prepended_alias + SP_RBV_SUFFIX] = fields
             self.PVDB[prepended_alias + SET_AND_MOVE_SUFFIX] = fields
             self.PVDB[prepended_alias + CHANGED_SUFFIX] = {'type': 'enum',

--- a/ReflectometryServer/reflectometry_server.py
+++ b/ReflectometryServer/reflectometry_server.py
@@ -15,6 +15,8 @@ except ImportError:
 from ReflectometryServer.beamline_configuration import create_beamline_from_configuration
 from ReflectometryServer.ChannelAccess.constants import REFLECTOMETRY_PREFIX
 from ReflectometryServer.ChannelAccess.pv_manager import PVManager
+from server_common.ioc_data_source import IocDataSource
+from server_common.mysql_abstraction_layer import SQLAbstraction
 
 
 beamline = create_beamline_from_configuration()
@@ -26,6 +28,9 @@ print("Prefix: {}".format(REFLECTOMETRY_PREFIX))
 SERVER.createPV(REFLECTOMETRY_PREFIX, pv_db.PVDB)
 
 DRIVER = ReflectometryDriver(SERVER, beamline, pv_db)
+
+ioc_data_source = IocDataSource(SQLAbstraction("iocdb", "iocdb", "$iocdb"))
+ioc_data_source.insert_ioc_start("REFL", os.getpid(), sys.argv[0], pv_db.PVDB, REFLECTOMETRY_PREFIX)
 
 # Process CA transactions
 while True:

--- a/server_common/ioc_data_source.py
+++ b/server_common/ioc_data_source.py
@@ -1,5 +1,11 @@
+"""
+Data source for ioc data
+"""
+from server_common.mysql_abstraction_layer import DatabaseError
 from server_common.utilities import print_and_log
 
+PV_INFO_FIELD_NAME = "info_field"
+"""name of the info field on a pv to express its interest level and archive status"""
 
 GET_PV_INFO_QUERY = """
 SELECT s.iocname, p.pvname, lower(p.infoname), p.value
@@ -49,6 +55,25 @@ GET_IOCS_AND_RUNNING_STATUS = """
    WHERE iocname NOT LIKE 'PSCTRL_%'"""
 """Sql query for getting iocnames and their running status"""
 
+UPDATE_IOC_IS_RUNNING = "UPDATE iocrt SET running=%s WHERE iocname=%s"
+"""Update whether an ioc is running"""
+
+UPDATE_PV_INFO = "INSERT INTO pvinfo (pvname, infoname, value) VALUES (%s,%s,%s)"
+"""Update the pv info"""
+
+INSERT_PV_DETAILS = "INSERT INTO pvs (pvname, record_type, record_desc, iocname) VALUES (%s,%s,%s,%s)"
+"""Insert PV details into the pvs table"""
+
+INSERT_IOC_STARTED_DETAILS = "INSERT INTO iocrt (iocname, pid, start_time, stop_time, running, exe_path) " \
+                 "VALUES (%s,%s,NOW(),'0000-00-00 00:00:00',1,%s)"
+"""Insert details about the start of an IOC"""
+
+DELETE_IOC_RUN_STATE = "DELETE FROM iocrt WHERE iocname=%s"
+"""Delete ioc run state"""
+
+DELETE_IOC_PV_DETAILS = "DELETE FROM pvs WHERE iocname=%s"
+"""Delete ioc pv details, this cascades to pv info details"""
+
 
 class IocDataSource(object):
     """
@@ -59,7 +84,7 @@ class IocDataSource(object):
         Constructor.
 
         Args:
-            mysql_abstraction_layer: contact database with sql
+            mysql_abstraction_layer(server_common.mysql_abstraction_layer.AbstratSQLCommands): contact database with sql
         """
         self.mysql_abstraction_layer = mysql_abstraction_layer
 
@@ -194,7 +219,95 @@ class IocDataSource(object):
             running: the new running state
         """
         try:
-            self.mysql_abstraction_layer.update("UPDATE iocrt SET running=%s WHERE iocname=%s", (running, ioc_name))
+            self.mysql_abstraction_layer.update(UPDATE_IOC_IS_RUNNING, (running, ioc_name))
         except Exception as err:
             print_and_log("Failed to update ioc running state in database ({ioc_name},{running}): {error}"
                           .format(ioc_name=ioc_name, running=running, error=err), "MAJOR", "DBSVR")
+
+    def insert_ioc_start(self, ioc_name, pid, exe_path, pv_database, prefix):
+        """
+        Insert ioc start information into the database. This does a similar task to pvdump but for python server.
+        Args:
+            ioc_name: name of the ioc
+            pid: process id of the program
+            exe_path: executable's path
+            pv_database: pv database used to construct the pv. To add a pv info field use entries in the pv for
+                PV_INFO_FIELD_NAME.
+                For example: {'pv name': {'info_field': {'archive': '', 'INTEREST': 'HIGH'}, 'type': 'float'}}
+            prefix: prefix for the pv server
+        """
+        print(pv_database)
+        self._remove_ioc_from_db(ioc_name)
+        self._add_ioc_start_to_db(exe_path, ioc_name, pid)
+
+        for pvname, pv in pv_database.items():
+            pv_fullname = "{}{}".format(prefix, pvname)
+            self._add_pv_to_db(ioc_name, pv, pv_fullname)
+
+            for info_field_name, info_field_value in pv.get(PV_INFO_FIELD_NAME, {}).items():
+                self._add_pv_info_to_db(info_field_name, info_field_value, pv_fullname)
+
+    def _add_pv_info_to_db(self, info_field_name, info_field_value, pv_fullname):
+        """
+        Add pv info to the database.
+        Args:
+            info_field_name: name of the info field
+            info_field_value: value of the info field
+            pv_fullname: full pv name with prefix
+
+        Returns:
+
+        """
+        try:
+            self.mysql_abstraction_layer.update(UPDATE_PV_INFO, (pv_fullname, info_field_name, info_field_value))
+        except Exception as err:
+            print_and_log("Failed to insert pv info for pv '{pvname}' with name '{name}' and value "
+                          "'{value}': {error}".format(pvname=pv_fullname, name=info_field_name,
+                                                      value=info_field_value, error=err), "MAJOR", "DBSVR")
+
+    def _add_pv_to_db(self, ioc_name, pv, pv_fullname):
+        """
+        Add a pv to the database
+        Args:
+            ioc_name: name of the ioc
+            pv: pv information
+            pv_fullname: pv's full name
+        """
+        try:
+            pv_type = pv.get('type', "float")
+            self.mysql_abstraction_layer.update(INSERT_PV_DETAILS, (pv_fullname, pv_type, "", ioc_name))
+        except DatabaseError as err:
+            print_and_log("Failed to insert pv data for pv '{pvname}' with contents '{pv}': {error}"
+                          .format(ioc_name=ioc_name, pvname=pv_fullname, pv=pv, error=err), "MAJOR", "DBSVR")
+
+    def _add_ioc_start_to_db(self, exe_path, ioc_name, pid):
+        """
+        Add the ioc start to the database
+        Args:
+            exe_path: the path to the executab;e
+            ioc_name: the ioc name
+            pid: the process id
+        """
+        try:
+
+            self.mysql_abstraction_layer.update(INSERT_IOC_STARTED_DETAILS, (ioc_name, pid, exe_path))
+        except DatabaseError as err:
+            print_and_log("Failed to insert ioc into database ({ioc_name},{pid},{exepath}): {error}"
+                          .format(ioc_name=ioc_name, pid=pid, exepath=exe_path, error=err), "MAJOR", "DBSVR")
+
+    def _remove_ioc_from_db(self, ioc_name):
+        """
+        Remove the ioc data from the database
+        Args:
+            ioc_name: name of the ioc
+        """
+        try:
+            self.mysql_abstraction_layer.update(DELETE_IOC_RUN_STATE, (ioc_name,))
+        except DatabaseError as err:
+            print_and_log("Failed to delete ioc, '{ioc_name}', from iocrt: {error}"
+                          .format(ioc_name=ioc_name, error=err), "MAJOR", "DBSVR")
+        try:
+            self.mysql_abstraction_layer.update(DELETE_IOC_PV_DETAILS, (ioc_name,))
+        except DatabaseError as err:
+            print_and_log("Failed to delete ioc, '{ioc_name}', from pvs: {error}"
+                          .format(ioc_name=ioc_name, error=err), "MAJOR", "DBSVR")

--- a/server_common/ioc_data_source.py
+++ b/server_common/ioc_data_source.py
@@ -236,7 +236,6 @@ class IocDataSource(object):
                 For example: {'pv name': {'info_field': {'archive': '', 'INTEREST': 'HIGH'}, 'type': 'float'}}
             prefix: prefix for the pv server
         """
-        print(pv_database)
         self._remove_ioc_from_db(ioc_name)
         self._add_ioc_start_to_db(exe_path, ioc_name, pid)
 

--- a/server_common/test_modules/test_common_utilities.py
+++ b/server_common/test_modules/test_common_utilities.py
@@ -1,5 +1,5 @@
 import unittest
-from server_common.utilities import create_pv_name
+from server_common.utilities import create_pv_name, remove_from_end
 
 
 class TestCreatePVName(unittest.TestCase):
@@ -92,3 +92,47 @@ class TestCreatePVName(unittest.TestCase):
         # Assert
         self.assertEquals(pv_01, "CONFIG")
         self.assertEquals(pv_02, "CONF01")
+
+    def test_WHEN_string_contains_ending_THEN_ending_removed(self):
+        # Arrange
+        ending = "END"
+        text = "text"
+
+        # Act
+        result = remove_from_end(text + ending, ending)
+
+        # Assert
+        self.assertEquals(text, result)
+
+    def test_WHEN_string_does_not_contains_ending_THEN_text_returned(self):
+        # Arrange
+        ending = "END"
+        text = "text"
+
+        # Act
+        result = remove_from_end(text, ending)
+
+        # Assert
+        self.assertEquals(text, result)
+
+    def test_WHEN_string_is_empty_THEN_empty_text_returned(self):
+        # Arrange
+        ending = "END"
+        text = ""
+
+        # Act
+        result = remove_from_end(text, ending)
+
+        # Assert
+        self.assertEquals(text, result)
+
+    def test_WHEN_string_is_None_THEN_None_returned(self):
+        # Arrange
+        ending = "END"
+        text = None
+
+        # Act
+        result = remove_from_end(text, ending)
+
+        # Assert
+        self.assertIsNone(result)

--- a/server_common/test_modules/test_ioc_data_source.py
+++ b/server_common/test_modules/test_ioc_data_source.py
@@ -19,20 +19,27 @@ from hamcrest import *
 from mock import Mock
 
 from server_common.ioc_data_source import IocDataSource
-from server_common.mysql_abstraction_layer import DatabaseError
+from server_common.mysql_abstraction_layer import DatabaseError, AbstratSQLCommands
 
 
-class SQLAbstractionStubForIOC(object):
+class SQLAbstractionStubForIOC(AbstratSQLCommands):
+    """Testing stub."""
     def __init__(self, query_return):
+        self.sql_param = []
+        self.sql = []
         self.query_return = []
-        for ioc, values in query_return.iteritems():
+        for ioc, values in query_return.items():
             for value in values:
                 pv_info = [ioc]
                 pv_info.extend(value)
                 self.query_return.append(pv_info)
 
-    def query(self, sql, param=None):
-        return self.query_return
+    def _execute_command(self, command, is_query, bound_variables):
+        self.sql.append(command)
+        self.sql_param.append(bound_variables)
+        if is_query:
+            return self.query_return
+        return None
 
 
 class TestIocDataSource(unittest.TestCase):
@@ -66,7 +73,7 @@ class TestIocDataSource(unittest.TestCase):
         }
 
         mysql_abstraction_layer = SQLAbstractionStubForIOC(expected_result)
-        data_source=IocDataSource(mysql_abstraction_layer)
+        data_source = IocDataSource(mysql_abstraction_layer)
 
         result = data_source.get_pv_logging_info()
 
@@ -75,6 +82,75 @@ class TestIocDataSource(unittest.TestCase):
     def test_GIVEN_database_error_WHEN_get_values_THEN_error(self):
         mysql_abstraction_layer = SQLAbstractionStubForIOC({})
         mysql_abstraction_layer.query = Mock(side_effect=DatabaseError("DB Error"))
-        data_source=IocDataSource(mysql_abstraction_layer)
+        data_source = IocDataSource(mysql_abstraction_layer)
 
         assert_that(calling(data_source.get_pv_logging_info), raises(DatabaseError))
+
+    def test_GIVEN_ioc_with_pvs_WHEN_pvdump_THEN_calls_are_made_to_delete_previous_entries(self):
+        mysql_abstraction_layer = SQLAbstractionStubForIOC({})
+        data_source = IocDataSource(mysql_abstraction_layer)
+
+        data_source.insert_ioc_start("name", 12, "path", {}, "prefix")
+
+        assert_that(mysql_abstraction_layer.sql[0], contains_string("DELETE FROM iocrt"))
+        assert_that(mysql_abstraction_layer.sql[1], contains_string("DELETE FROM pvs"))
+
+    def test_GIVEN_ioc_with_pvs_WHEN_pvdump_has_database_error_THEN_no_exception_raised(self):
+        mysql_abstraction_layer = SQLAbstractionStubForIOC({})
+        mysql_abstraction_layer.update = Mock(side_effect=DatabaseError("DB Error"))
+        data_source = IocDataSource(mysql_abstraction_layer)
+
+        data_source.insert_ioc_start("name", 12, "path", {}, "prefix")
+
+    def test_GIVEN_ioc_with_pvs_WHEN_pvdump_THEN_calls_are_made_to_add_ioc_started(self):
+        mysql_abstraction_layer = SQLAbstractionStubForIOC({})
+        data_source = IocDataSource(mysql_abstraction_layer)
+
+        data_source.insert_ioc_start("name", 12, "path", {}, "prefix")
+
+        assert_that(mysql_abstraction_layer.sql[2], contains_string("INSERT INTO iocrt"))
+
+    def test_GIVEN_ioc_with_pvs_WHEN_pvdump_THEN_calls_are_made_to_add_pvs_with_correct_types_and_names_and_default_type_is_float(self):
+        mysql_abstraction_layer = SQLAbstractionStubForIOC({})
+        data_source = IocDataSource(mysql_abstraction_layer)
+
+        expected_type1 = "int"
+        expected_type2 = "float"
+        prefix = "prefix"
+        pv_name_1 = "pv_name_1"
+        pv_name_2 = "pv_name_2"
+        expected_name1 = "{}{}".format(prefix, pv_name_1)
+        expected_name2 = "{}{}".format(prefix, pv_name_2)
+        pvs = {pv_name_1: {"type": expected_type1},
+               pv_name_2: {}}
+
+        iocname = "name"
+        data_source.insert_ioc_start(iocname, 12, "path", pvs, prefix)
+
+        for sql in mysql_abstraction_layer.sql[3:5]:
+            assert_that(sql, contains_string("INSERT INTO pvs"))
+
+        assert_that(mysql_abstraction_layer.sql_param[3:5], contains_inanyorder(
+                (expected_name1, expected_type1, "", iocname),
+                (expected_name2, expected_type2, "", iocname)))
+
+    def test_GIVEN_ioc_with_pvs_with_pv_info_WHEN_pvdump_THEN_calls_are_made_to_add_pv_info_with_correct_pv_names_info_names_and_values(self):
+        mysql_abstraction_layer = SQLAbstractionStubForIOC({})
+        data_source = IocDataSource(mysql_abstraction_layer)
+        name1 = "archive"
+        value1 = ""
+        name2 = "INTEREST"
+        value2 = "HIGH"
+        prefix = "prefix"
+        pv_name = "pv_name"
+        expected_name1 = "{}{}".format(prefix, pv_name)
+        pvs = {pv_name: {"info_field": {name1: value1, name2: value2}}}
+
+        data_source.insert_ioc_start("name", 12, "path", pvs, prefix)
+
+        for sql in mysql_abstraction_layer.sql[4:]:
+            assert_that(sql, contains_string("INSERT INTO pvinfo"))
+
+        assert_that(mysql_abstraction_layer.sql_param[4:], contains_inanyorder(
+                (expected_name1, name1, value1),
+                (expected_name1, name2, value2)))

--- a/server_common/utilities.py
+++ b/server_common/utilities.py
@@ -273,3 +273,18 @@ def retry(max_attempts, interval, exception):
             raise MaxAttemptsExceededException()
         return _wrapper
     return _tags_decorator
+
+
+def remove_from_end(string, text_to_remove):
+    """
+    Remove a String from the end of a string if it exists
+    Args:
+        string (str): string to edit
+        text_to_remove (str): the text to remove
+
+    Returns: the string with the text removed
+
+    """
+    if string is not None and string.endswith(text_to_remove):
+        return string[:-len(text_to_remove)]
+    return string


### PR DESCRIPTION
### Description of work

Make IOC act like EPICS IOC not special

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3586

### Acceptance criteria

If the reflectometry server is running the IOC list shows it running.
If not running it shows it not running
Parameter readback and modes PVs are shown as interesting
Parameter readback and Setpoint PVs along with mode vs are archived.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
