### PR TITLE
Retry on failure to get valid autorestart setting

### DIFF
--- a/BlockServer/epics/procserv_utils.py
+++ b/BlockServer/epics/procserv_utils.py
@@ -13,9 +13,10 @@
 # along with this program; if not, you can obtain a copy from
 # https://www.eclipse.org/org/documents/epl-v10.php or
 # http://opensource.org/licenses/eclipse-1.0.php
+import time
 
 from server_common.channel_access import ChannelAccess
-from server_common.utilities import print_and_log, ioc_restart_pending
+from server_common.utilities import print_and_log, ioc_restart_pending, retry
 
 
 class ProcServWrapper(object):
@@ -102,6 +103,7 @@ class ProcServWrapper(object):
         print_and_log("Toggling auto-restart for IOC {}".format(ioc))
         ChannelAccess.caput(self.generate_prefix(prefix, ioc) + ":TOGGLE", 1)
 
+    @retry(50, 0.1, ValueError)  # Retry for 5 seconds to get a valid value on failure
     def get_autorestart(self, prefix, ioc):
         """Gets the current auto-restart setting of the specified IOC.
 
@@ -113,12 +115,9 @@ class ProcServWrapper(object):
             bool : Whether auto-restart is enabled
         """
         ioc_prefix = self.generate_prefix(prefix, ioc)
-        ans = ChannelAccess.caget(ioc_prefix + ":AUTORESTART", as_string=True)
-        if ans is None:
-            raise Exception("Could not find IOC (%s)" % ioc_prefix)
-        elif ans == "On":
-            return True
-        elif ans == "Off":
-            return False
-        else:
-            raise Exception("Could not get auto-restart property for IOC ({0}) got '{1}'".format(ioc_prefix, ans))
+
+        ans = ChannelAccess.caget("{}:AUTORESTART".format(ioc_prefix), as_string=True)
+        if ans not in ["On", "Off"]:
+            raise ValueError("Could not get auto-restart property for IOC {}, got '{}'".format(ioc_prefix, ans))
+
+        return ans == "On"

--- a/BlockServer/epics/procserv_utils.py
+++ b/BlockServer/epics/procserv_utils.py
@@ -13,8 +13,6 @@
 # along with this program; if not, you can obtain a copy from
 # https://www.eclipse.org/org/documents/epl-v10.php or
 # http://opensource.org/licenses/eclipse-1.0.php
-import time
-
 from server_common.channel_access import ChannelAccess
 from server_common.utilities import print_and_log, ioc_restart_pending, retry
 

--- a/server_common/channel_access.py
+++ b/server_common/channel_access.py
@@ -37,7 +37,7 @@ class ChannelAccess(object):
             return CaChannelWrapper.get_pv_value(name, as_string)
         except Exception as err:
             # Probably has timed out
-            print(err)
+            print_and_log(str(err))
             return None
 
     @staticmethod

--- a/server_common/utilities.py
+++ b/server_common/utilities.py
@@ -263,14 +263,15 @@ def retry(max_attempts, interval, exception):
     def _tags_decorator(func):
         def _wrapper(*args, **kwargs):
             attempts = 0
+            ex = ValueError("Max attempts should be > 0, it is {}".format(max_attempts))
             while attempts < max_attempts:
                 try:
                     return func(*args, **kwargs)
-                except exception:
+                except exception as ex:
                     attempts += 1
                     time.sleep(interval)
 
-            raise MaxAttemptsExceededException()
+            raise MaxAttemptsExceededException(ex)
         return _wrapper
     return _tags_decorator
 


### PR DESCRIPTION
### Description of work

Retry on failure to get valid value from `AUTOSTART` pv.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3335

### Acceptance criteria

- [x] Code works as before but is more robust against getting junk from get_pv

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
