### PR TITLE
Update so moves after indiviual move

### DIFF
--- a/ReflectometryServer/beam_path_calc.py
+++ b/ReflectometryServer/beam_path_calc.py
@@ -282,7 +282,8 @@ class BeamPathCalcTheta(_BeamPathCalcReflecting):
         for readback_beam_path_calc in self._angle_to:
             if readback_beam_path_calc.enabled:
                 other_pos = readback_beam_path_calc.sp_position()
-                this_pos = self.sp_position()
+                this_pos = self._movement_strategy.calculate_interception(incoming_beam)
+
                 opp = other_pos.y - this_pos.y
                 adj = other_pos.z - this_pos.z
                 # x = degrees(atan2(opp, adj)) is angle in room co-ords to component

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -224,7 +224,6 @@ class Beamline(object):
             _: dummy can be anything
         """
         self._move_for_all_beamline_parameters()
-        self._move_drivers(self._get_max_move_duration())
 
     def __getitem__(self, item):
         """
@@ -258,7 +257,8 @@ class Beamline(object):
 
     def _move_for_all_beamline_parameters(self):
         """
-        Updates the beamline parameters to the latest set point value; reapplies if they are in the mode.
+        Updates the beamline parameters to the latest set point value; reapplies if they are in the mode. Then moves to
+        latest postions.
         """
         parameters = self._beamline_parameters.values()
         parameters_in_mode = self._active_mode.get_parameters_in_mode(parameters, None)
@@ -266,11 +266,13 @@ class Beamline(object):
         for beamline_parameter in parameters:
             if beamline_parameter in parameters_in_mode or beamline_parameter.sp_changed:
                 beamline_parameter.move_to_sp_no_callback()
+        self._move_drivers(self._get_max_move_duration())
 
     def _move_for_single_beamline_parameters(self, source):
         """
         Moves starts from a single beamline parameter and move is to parameters sp read backs. If the
-        source is not in the mode then don't update any other parameters.
+        source is not in the mode then don't update any other parameters. Move to latest position.
+
         the beamline.
         Args:
             source: source to start the update from; None start from the beginning.
@@ -281,6 +283,7 @@ class Beamline(object):
 
             for beamline_parameter in parameters_in_mode:
                 beamline_parameter.move_to_sp_rbv_no_callback()
+        self._move_drivers(self._get_max_move_duration())
 
     def parameter(self, key):
         """

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -57,7 +57,7 @@ class BeamlineParameter(object):
     @property
     def sp_rbv(self):
         """
-        Returns: the set point read back value, i.e. where the last move was instructed to go
+        Returns: the set point read back value, i.e. wherethe last move was instructed to go
         """
         return self._set_point_rbv
 

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -109,7 +109,6 @@ class TestRealistic(unittest.TestCase):
 
         theta_angle = 2
         bl.parameter("theta").sp = theta_angle
-        bl.move = 1
 
         assert_that(drives["s1_axis"].value, is_(0))
 
@@ -157,6 +156,29 @@ class TestRealistic(unittest.TestCase):
     #
     #     assert_that(bl.parameter("theta").rbv, is_(theta_angle))
 
+    def test_GIVEN_beam_line_where_all_items_track_WHEN_set_theta_no_move_and_move_beamline_THEN_motors_move_to_be_on_the_beam(self):
+        spacing = 2.0
+
+        bl, drives = DataMother.beamline_s1_s3_theta_detector(spacing)
+
+        bl.parameter("s1").sp = 0
+        bl.parameter("s3").sp = 0
+        bl.parameter("det").sp = 0
+        bl.parameter("det_angle").sp = 0
+
+        theta_angle = 2
+        bl.parameter("theta").sp_no_move = theta_angle
+        bl.move = 1
+
+        assert_that(drives["s1_axis"].value, is_(0))
+
+        expected_s3_value = spacing * tan(radians(theta_angle * 2.0))
+        assert_that(drives["s3_axis"].value, is_(expected_s3_value))
+
+        expected_det_value = 2 * spacing * tan(radians(theta_angle * 2.0))
+        assert_that(drives["det_axis"].value, is_(expected_det_value))
+
+        assert_that(drives["det_angle_axis"].value, is_(2*theta_angle))
 
 if __name__ == '__main__':
     unittest.main()

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -549,7 +549,7 @@ class TestBeamlineParameterReadback(unittest.TestCase):
 
     def test_GIVEN_theta_with_0_deg_beam_WHEN_next_component_is_at_45_THEN_value_is_22_5(self):
 
-        s3 = Component("s3", setup=PositionAndAngle(20, 10, 90))
+        s3 = Component("s3", setup=PositionAndAngle(10, 10, 90))
         sample = ThetaComponent("sample", setup=PositionAndAngle(10, 0, 90), angle_to=[s3])
         sample.beam_path_rbv.set_incoming_beam(PositionAndAngle(0, 0, 0))
         theta = AngleParameter("param", sample)

--- a/ReflectometryServer/test_modules/test_components.py
+++ b/ReflectometryServer/test_modules/test_components.py
@@ -322,6 +322,19 @@ class TestThetaComponent(unittest.TestCase):
 
         listener.assert_not_called()
 
+    def test_GIVEN_next_component_is_enabled_and_at_45_degrees_and_not_on_axis_WHEN_get_read_back_THEN_half_angle_to_component_is_readback(self):
+
+        beam_start = PositionAndAngle(y=10, z=0, angle=0)
+        next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
+        next_component.beam_path_rbv.enabled = True
+        next_component.beam_path_rbv.set_displacement(15, AlarmSeverity.No, AlarmStatus.No)
+        theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
+        theta.beam_path_rbv.set_incoming_beam(beam_start)
+
+        result = theta.beam_path_rbv.angle
+
+        assert_that(result, is_(close_to(45.0/2.0, 1e-6)))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description of work

1. a move triggered on a beamline parameter causes the motors to move
1. Theta readback is correct if super-mirror is before it

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3893

### Acceptance criteria

1. Set a parameter make sure move sets that parameter and moves the motors to it (readback should update)
1. Set a parameter in a mode make sure all parameters after this are set to set point not changed values
1. With a super mirror in check that that readback is theta at various super mirror angles.

Good setup:

```
# FOR TESTING
# Valid configuration script for a reflectometry beamline

from ReflectometryServer.components import *
from ReflectometryServer.geometry import *
from ReflectometryServer.beamline import Beamline, BeamlineMode
from ReflectometryServer.parameters import *
from ReflectometryServer.ioc_driver import *
from ReflectometryServer.motor_pv_wrapper import *
from ReflectometryServer.geometry import PositionAndAngle

def get_beamline():

    #components
    s1 = Component("s1", PositionAndAngle(0.0, 1, 90))
    s3 = Component("s3", PositionAndAngle(0.0, 3, 90))
    detector = TiltingComponent("Detector", PositionAndAngle(0.0, 4, 90))
    theta = ThetaComponent("ThetaComp", PositionAndAngle(0.0, 2, 90), [detector])
    sm = ReflectingComponent("SuperMirror", PositionAndAngle(0.0, 0.5, 90))
    
    comps = [sm, s1, theta, s3, detector]
    

    # BEAMLINE PARAMETERS
    sm_pos = TrackingPosition("sm", sm, True)
    slit1_pos = TrackingPosition("s1_pos", s1, True)
    slit3_pos = TrackingPosition("s3_pos", s3, True)
    theta_ang = AngleParameter("Theta", theta, True)
    detector_position = TrackingPosition("det_pos", detector, True)
    detector_angle = AngleParameter("det_angle", detector, True)
    sm_angle = AngleParameter("smangle", sm, True)
    sm_angle_in = ComponentEnabled("sm_enabled", sm, False)

    params = [sm_angle_in, sm_pos, sm_angle, slit1_pos, theta_ang, slit3_pos, detector_position, detector_angle]

    # DRIVES

    drives = [DisplacementDriver(s1, MotorPVWrapper("MOT:MTR0101")),
              DisplacementDriver(s3, MotorPVWrapper("MOT:MTR0102")),
              DisplacementDriver(detector, MotorPVWrapper("MOT:MTR0103")),
              AngleDriver(detector, MotorPVWrapper("MOT:MTR0104")),
              AngleDriver(sm, MotorPVWrapper("MOT:MTR0105"))]
    
    # MODES
    nr_inits = {sm_angle_in.name: False}
    nr_mode = BeamlineMode("NR", [param.name for param in params if not param.name.startswith("sm")], nr_inits)
    polerised_inits = {sm_angle_in.name: True}
    polerised_mode = BeamlineMode("POLERISED", [param.name for param in params], polerised_inits)
    modes = [polerised_mode, nr_mode]

    beam_start = PositionAndAngle(0.0, 0.0, 0.0)
    bl = Beamline(comps, params, drives, modes, beam_start)

    return bl

```

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
