### PR TITLE
Ticket 3240: ZOOM no longer creating putlogs

### DIFF
--- a/server_common/loggers/isis_logger.py
+++ b/server_common/loggers/isis_logger.py
@@ -16,7 +16,7 @@
 
 import datetime
 import socket
-import xml.etree.ElementTree as ET
+from lxml import etree
 import re
 
 IOCLOG_ADDR = ("127.0.0.1", 7004)
@@ -49,17 +49,17 @@ class IsisLogger(object):
         if msg_time.utcoffset() is None:
             msg_time_str += "Z"
 
-        xml_message = ET.Element("message")
-        ET.SubElement(xml_message, "clientName").text = src
-        ET.SubElement(xml_message, "severity").text = severity
-        ET.SubElement(xml_message, "contents").text = "![CDATA[{}]".format(escape_xml_illegal_chars(message))
-        ET.SubElement(xml_message, "type").text = "ioclog"
-        ET.SubElement(xml_message, "eventTime").text = msg_time_str
+        xml_message = etree.Element("message")
+        etree.SubElement(xml_message, "clientName").text = src
+        etree.SubElement(xml_message, "severity").text = severity
+        etree.SubElement(xml_message, "contents").text = etree.CDATA(escape_xml_illegal_chars(message))
+        etree.SubElement(xml_message, "type").text = "ioclog"
+        etree.SubElement(xml_message, "eventTime").text = msg_time_str
 
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect(IOCLOG_ADDR)
-            sock.sendall(ET.tostring(xml_message, "utf-8", "xml"))
+            sock.sendall(etree.tostring(xml_message, encoding="utf-8"))
         except Exception as err:
             print("Could not send message to IOC log: %s" % err)
         finally:

--- a/server_common/loggers/isis_logger.py
+++ b/server_common/loggers/isis_logger.py
@@ -25,6 +25,7 @@ _illegal_xml_chars_RE = re.compile(u'[\x00-\x08\x0b\x0c\x0e-\x1F\uD800-\uDFFF\uF
 
 def escape_xml_illegal_chars(text):
     """Escapes illegal XML unicode characters to their python representation.
+    See https://www.w3.org/TR/xml/#charsets
     Args:
         text (str): The text to escape.
     Returns:
@@ -33,10 +34,34 @@ def escape_xml_illegal_chars(text):
     return _illegal_xml_chars_RE.sub(lambda match: repr(match.group(0)), text)
 
 
+def create_xml_string(message, severity, src):
+    """Creates the xml string to send to the server.
+
+    Args:
+        message (string): The message to write.
+        severity (string): Gives the severity of the message. Expected severities are MAJOR, MINOR and INFO.
+        src (string): Gives the source of the message
+    """
+    msg_time = datetime.datetime.utcnow()
+    msg_time_str = msg_time.isoformat()
+    if msg_time.utcoffset() is None:
+        msg_time_str += "Z"
+
+    xml_message = etree.Element("message")
+    etree.SubElement(xml_message, "clientName").text = src
+    etree.SubElement(xml_message, "severity").text = severity
+    etree.SubElement(xml_message, "contents").text = etree.CDATA(escape_xml_illegal_chars(message))
+    etree.SubElement(xml_message, "type").text = "ioclog"
+    etree.SubElement(xml_message, "eventTime").text = msg_time_str
+
+    return etree.tostring(xml_message, encoding="utf-8")
+
+
 class IsisLogger(object):
     def write_to_log(self, message, severity="INFO", src="BLOCKSVR"):
         """Writes a message to the IOC log. It is preferable to use print_and_log for easier debugging.
         Args:
+            message (string): The message to write.
             severity (string, optional): Gives the severity of the message. Expected severities are MAJOR, MINOR and INFO.
                                         Default severity is INFO
             src (string, optional): Gives the source of the message. Default source is BLOCKSVR
@@ -44,22 +69,13 @@ class IsisLogger(object):
         if severity not in ['INFO', 'MINOR', 'MAJOR', 'FATAL']:
             print("write_to_ioc_log: invalid severity ", severity)
             return
-        msg_time = datetime.datetime.utcnow()
-        msg_time_str = msg_time.isoformat()
-        if msg_time.utcoffset() is None:
-            msg_time_str += "Z"
 
-        xml_message = etree.Element("message")
-        etree.SubElement(xml_message, "clientName").text = src
-        etree.SubElement(xml_message, "severity").text = severity
-        etree.SubElement(xml_message, "contents").text = etree.CDATA(escape_xml_illegal_chars(message))
-        etree.SubElement(xml_message, "type").text = "ioclog"
-        etree.SubElement(xml_message, "eventTime").text = msg_time_str
+        xml_string = create_xml_string(message, severity, src)
 
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect(IOCLOG_ADDR)
-            sock.sendall(etree.tostring(xml_message, encoding="utf-8"))
+            sock.sendall(xml_string)
         except Exception as err:
             print("Could not send message to IOC log: %s" % err)
         finally:

--- a/server_common/test_modules/test_isis_logger.py
+++ b/server_common/test_modules/test_isis_logger.py
@@ -1,0 +1,20 @@
+import unittest
+from server_common.loggers.isis_logger import create_xml_string
+
+
+class TestISISLogger(unittest.TestCase):
+    def test_WHEN_message_contains_invalid_unicode_THEN_xml_contains_string_repr(self):
+        message = u"\u0002"
+
+        xml_string = create_xml_string(message, "INFO", "BS")
+
+        self.assertIn(r"'\x02'", xml_string)
+        self.assertNotIn(message, xml_string)
+
+    def test_WHEN_message_contains_valid_unicode_THEN_xml_contains_unicode(self):
+        message = u"\t"
+
+        xml_string = create_xml_string(message, "INFO", "BS")
+
+        self.assertNotIn(r"'\x09'", xml_string)
+        self.assertIn(message, xml_string)


### PR DESCRIPTION
### Description of work

Modified the ISIS logger to only send valid XML to the log server
See https://github.com/ISISComputingGroup/IBEX/issues/3240

### To Test

* Make sure you have a running instrument
* Create a new ISISLogger and send unicode chars to it
* Confirm that no error messages like the original ticket are seen in the IOC LOG
* Confirm that the message ends up in the msg_log

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
