### PR TITLE
Ticket3890 disable mode

### DIFF
--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -2,8 +2,6 @@
 Reflectometry pv manager
 """
 from enum import Enum
-from pcaspy import Severity
-
 from ReflectometryServer.parameters import BeamlineParameterType, BeamlineParameterGroup
 from server_common.ioc_data_source import PV_INFO_FIELD_NAME, PV_DESCRIPTION_NAME
 from server_common.utilities import create_pv_name, remove_from_end, print_and_log, SEVERITY
@@ -28,7 +26,7 @@ PARAM_FIELDS_CHANGED = {'type': 'enum', 'enums': ["NO", "YES"]}
 PARAM_FIELDS_MOVE = {'type': 'int', 'count': 1, 'value': 0}
 
 PARAMS_FIELDS_BEAMLINE_TYPES = {
-    BeamlineParameterType.IN_OUT: {'enums': ["OUT", "IN"]},
+    BeamlineParameterType.IN_OUT: {'type': 'enum', 'enums': ["OUT", "IN"]},
     BeamlineParameterType.FLOAT: {'type': 'float', 'prec': 3, 'value': 0.0}}
 
 

--- a/ReflectometryServer/beam_path_calc.py
+++ b/ReflectometryServer/beam_path_calc.py
@@ -25,7 +25,7 @@ class TrackingBeamPathCalc(object):
         self._incoming_beam = None
         self._after_beam_path_update_listeners = set()
         self._after_physical_move_listeners = set()
-        self._enabled = True
+        self._is_in_beam = True
         self._movement_strategy = movement_strategy
 
     def add_after_beam_path_update_listener(self, listener):
@@ -113,20 +113,20 @@ class TrackingBeamPathCalc(object):
         return self._movement_strategy.sp_position()
 
     @property
-    def enabled(self):
+    def is_in_beam(self):
         """
         Returns: the enabled status
         """
-        return self._enabled
+        return self._is_in_beam
 
-    @enabled.setter
-    def enabled(self, enabled):
+    @is_in_beam.setter
+    def is_in_beam(self, is_in_beam):
         """
-        Updates the component enabled status and notifies the beam path update listener
+        Updates the components in_beam status and notifies the beam path update listener
         Args:
-            enabled: The modified enabled status
+            is_in_beam: True if set the component to be in the beam; False otherwise
         """
-        self._enabled = enabled
+        self._is_in_beam = is_in_beam
         self._trigger_after_beam_path_update()
         self._trigger_after_physical_move_listener()
 
@@ -211,7 +211,7 @@ class _BeamPathCalcReflecting(_BeamPathCalcWithAngle):
         """
         Returns: the outgoing beam based on the last set incoming beam and any interaction with the component
         """
-        if not self._enabled:
+        if not self._is_in_beam:
             return self._incoming_beam
 
         target_position = self.calculate_beam_interception()
@@ -280,7 +280,7 @@ class BeamPathCalcTheta(_BeamPathCalcReflecting):
         Returns: half the angle to the next enabled beam path calc, or nan if there isn't one.
         """
         for readback_beam_path_calc in self._angle_to:
-            if readback_beam_path_calc.enabled:
+            if readback_beam_path_calc.is_in_beam:
                 other_pos = readback_beam_path_calc.sp_position()
                 this_pos = self._movement_strategy.calculate_interception(incoming_beam)
 

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -132,6 +132,7 @@ class Beamline(object):
             modes(list[BeamlineMode])
             incoming_beam (ReflectometryServer.geometry.PositionAndAngle): the incoming beam point
         """
+
         self._components = components
         self._beam_path_calcs_set_point = []
         self._beam_path_calcs_rbv = []
@@ -139,6 +140,7 @@ class Beamline(object):
         self._drivers = drivers
         self._status = STATUS.OKAY
         self._message = ""
+        self._active_mode_change_listeners = set()
 
         for beamline_parameter in beamline_parameters:
             if beamline_parameter.name in self._beamline_parameters:
@@ -205,6 +207,7 @@ class Beamline(object):
         try:
             self._active_mode = self._modes[mode]
             self.init_setpoints()
+            self._trigger_active_mode_change()
         except KeyError:
             raise ValueError("Not a valid mode name: '{}'".format(mode))
 
@@ -352,3 +355,20 @@ class Beamline(object):
         Returns: the status codes which have display properties and alarm severities
         """
         return [status.value for status in STATUS]
+
+    def _trigger_active_mode_change(self):
+        """
+        Triggers all listeners after a mode change.
+
+        """
+        for listener in self._active_mode_change_listeners:
+            listener(self.active_mode)
+
+    def add_active_mode_change_listener(self, listener):
+        """
+        Add the listener for mode changes to this beamline
+        Args:
+            listener: the listener to add function with mode as new mode
+
+        """
+        self._active_mode_change_listeners.add(listener)

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -43,7 +43,7 @@ class BeamlineMode(object):
     Beamline mode definition; which components and parameters are calculated on move.
     """
 
-    def __init__(self, name, beamline_parameters_to_calculate, sp_inits=None):
+    def __init__(self, name, beamline_parameters_to_calculate, sp_inits=None, is_disabled=False):
         """
         Initialize.
         Args:
@@ -52,6 +52,7 @@ class BeamlineMode(object):
                 which should be automatically moved to whenever a preceding parameter is changed
             sp_inits (dict[str, object]): The initial beamline parameter values that should be set when switching
                 to this mode
+            is_disabled (Boolean): True components allow input beamline to be changed; False they don't
         """
         self.name = name
         self._beamline_parameters_to_calculate = beamline_parameters_to_calculate
@@ -59,6 +60,7 @@ class BeamlineMode(object):
             self._sp_inits = {}
         else:
             self._sp_inits = sp_inits
+        self.is_disabled = is_disabled
 
     def has_beamline_parameter(self, beamline_parameter):
         """
@@ -233,6 +235,8 @@ class Beamline(object):
         """
         try:
             self._active_mode = self._modes[mode]
+            for component in self._components:
+                component.set_incoming_beam_can_change(not self._active_mode.is_disabled)
             self.init_setpoints()
             self._trigger_active_mode_change()
         except KeyError:

--- a/ReflectometryServer/components.py
+++ b/ReflectometryServer/components.py
@@ -2,7 +2,7 @@
 Components on a beam
 """
 from ReflectometryServer.beam_path_calc import TrackingBeamPathCalc, BeamPathTilting, BeamPathCalcAngleReflecting, \
-    BeamPathCalcTheta
+    BeamPathCalcThetaRBV, BeamPathCalcThetaSP
 from ReflectometryServer.movement_strategy import LinearMovementCalc
 import logging
 
@@ -40,10 +40,8 @@ class Component(object):
         """
         The beam path calculation for the set points. This is readonly and can only be set during construction
         Returns:
-            (TrackingBeamPathCalc|BeamPathTilting|BeamPathCalcTheta|BeamPathCalcAngleReflecting): set points beam path
-                calculation
-
-
+            (TrackingBeamPathCalc|BeamPathTilting|BeamPathCalcThetaRBV|BeamPathCalcThetaSP|BeamPathCalcAngleReflecting):
+                set points beam path calculation
         """
         return self._beam_path_set_point
 
@@ -52,11 +50,21 @@ class Component(object):
         """
         The beam path calculation for the read backs. This is readonly and can only be set during construction
         Returns:
-            (TrackingBeamPathCalc|BeamPathTilting|BeamPathCalcTheta|BeamPathCalcAngleReflecting): read backs beam path
-                calculation
+            (TrackingBeamPathCalc|BeamPathTilting|BeamPathCalcThetaRBV|BeamPathCalcThetaSP|BeamPathCalcAngleReflecting):
+                read backs beam path calculation
 
         """
         return self._beam_path_rbv
+
+    def set_incoming_beam_can_change(self, can_change):
+        """
+        Set whether the incoming beam can be changed on a component. This is used in disable mode where the incoming
+        beam can not be changed.
+        Args:
+            can_change: True if the incoming beam can changed; False if it is static
+        """
+        self._beam_path_set_point.incoming_beam_can_change = can_change
+        self._beam_path_rbv.incoming_beam_can_change = can_change
 
 
 class TiltingComponent(Component):
@@ -111,10 +119,12 @@ class ThetaComponent(ReflectingComponent):
                 angle should calculated to, ordered by preference. First enabled component is used.
         """
         super(ReflectingComponent, self).__init__(name, setup)
-        self._beam_path_rbv = BeamPathCalcTheta(LinearMovementCalc(setup), [comp.beam_path_rbv for comp in angle_to])
+        self._beam_path_rbv = BeamPathCalcThetaRBV(LinearMovementCalc(setup), [comp.beam_path_rbv for comp in angle_to])
+        self._beam_path_set_point = BeamPathCalcThetaSP(LinearMovementCalc(setup),
+                                                        [comp.beam_path_set_point for comp in angle_to])
 
     def _init_beam_path_calcs(self, setup):
-        self._beam_path_set_point = BeamPathCalcAngleReflecting(LinearMovementCalc(setup))
+        pass
 
 
 # class Bench(Component):

--- a/ReflectometryServer/example_beamline.py
+++ b/ReflectometryServer/example_beamline.py
@@ -15,14 +15,14 @@ def create_beamline():
     s0 = Component("s0", setup=PositionAndAngle(0, 0, perp_to_floor))
     s1 = Component("s1", setup=PositionAndAngle(0, 1, perp_to_floor))
     frame_overlap_mirror = ReflectingComponent("FOM", setup=PositionAndAngle(0, 2, perp_to_floor))
-    frame_overlap_mirror.beam_path_set_point.enabled = False
+    frame_overlap_mirror.beam_path_set_point.is_in_beam = False
     polarising_mirror = ReflectingComponent("Polarising mirror", setup=PositionAndAngle(0, 3, perp_to_floor))
-    polarising_mirror.beam_path_set_point.enabled = False
+    polarising_mirror.beam_path_set_point.is_in_beam = False
     s2 = Component("s2", setup=PositionAndAngle(0, 4, perp_to_floor))
     ideal_sample_point = ReflectingComponent("Ideal Sample Point", setup=PositionAndAngle(0, 5, perp_to_floor))
     s3 = Component("s3", setup=PositionAndAngle(0, 6, perp_to_floor))
     analyser = ReflectingComponent("analyser", setup=PositionAndAngle(0, 7, perp_to_floor))
-    analyser.beam_path_set_point.enabled = False
+    analyser.beam_path_set_point.is_in_beam = False
     s4 = Component("s4", setup=PositionAndAngle(0, 8, perp_to_floor))
     detector = Component("detector", setup=PositionAndAngle(0, 10, perp_to_floor))
 
@@ -52,7 +52,7 @@ def generate_theta_movement():
         positions_y.insert(0, "theta {}".format(theta))
         positions.append(positions_y)
 
-    beamline[3].beam_path_set_point.enabled = True
+    beamline[3].beam_path_set_point.is_in_beam = True
     sm_angle = 5
     beamline[3].beam_path_set_point.angle = sm_angle
     for theta in range(0, 20, 1):

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -30,6 +30,16 @@ class IocDriver(object):
         return "{} for axis pv {} and component {}".format(
             self.__class__.__name__, self._axis.name, self._component.name)
 
+    def is_for_component(self, component):
+        """
+        Does this driver use the component given.
+        Args:
+            component: the component to check
+
+        Returns: True if this ioc driver uses the component; false otherwise
+        """
+        return component == self._component
+
     def get_max_move_duration(self):
         """
         Returns: The maximum duration of the requested move for all associated axes
@@ -116,8 +126,14 @@ class DisplacementDriver(IocDriver):
                 displacement = self._out_of_beam_position
         return displacement
 
+    def has_out_of_beam_position(self):
+        """
+        Returns: True if this Displacement driver has out of beam position set; False otherwise.
+        """
+        return self._out_of_beam_position is not None
 
-class AngleDriver(DisplacementDriver):
+
+class AngleDriver(IocDriver):
     """
     Drives a component that has variable angle.
     """

--- a/ReflectometryServer/movement_strategy.py
+++ b/ReflectometryServer/movement_strategy.py
@@ -1,10 +1,10 @@
 """
 Classes and objects decribing the movement of items
 """
-
 from math import fabs, tan, radians, sin, cos, sqrt
 
 from ReflectometryServer.geometry import PositionAndAngle, Position
+
 
 # Tolerance to use when comparing an angle with another angle
 ANGULAR_TOLERANCE = 1e-12

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -260,7 +260,7 @@ class ComponentEnabled(BeamlineParameter):
         self.parameter_type = BeamlineParameterType.IN_OUT
 
     def _move_component(self):
-        self._component.beam_path_set_point.enabled = self._set_point_rbv
+        self._component.beam_path_set_point.is_in_beam = self._set_point_rbv
 
     def _rbv(self):
-        return self._component.beam_path_rbv.enabled
+        return self._component.beam_path_rbv.is_in_beam

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -93,7 +93,8 @@ class DataMother(object):
         # MODES
         nr_inits = {}
         nr_mode = BeamlineMode("NR", [param.name for param in params], nr_inits)
-        modes = [nr_mode]
+        disabled_mode = BeamlineMode("DISABLED", [param.name for param in params], nr_inits, is_disabled=True)
+        modes = [nr_mode, disabled_mode]
         beam_start = PositionAndAngle(0.0, 0.0, 0.0)
         bl = Beamline(comps, params, drives, modes, beam_start)
         bl.active_mode = nr_mode.name

--- a/ReflectometryServer/test_modules/test_actual_positions.py
+++ b/ReflectometryServer/test_modules/test_actual_positions.py
@@ -15,15 +15,15 @@ class TestComponentBeamline(unittest.TestCase):
         s0 = Component("s0", setup=PositionAndAngle(0, 0, 90))
         s1 = Component("s1", setup=PositionAndAngle(0, 1, 90))
         frame_overlap_mirror = ReflectingComponent("FOM", setup=PositionAndAngle(0, 2, 90))
-        frame_overlap_mirror.beam_path_set_point.enabled = False
+        frame_overlap_mirror.beam_path_set_point.is_in_beam = False
         self.polarising_mirror = ReflectingComponent("Polariser", setup=PositionAndAngle(0, 3, 90))
-        self.polarising_mirror.beam_path_set_point.enabled = False
+        self.polarising_mirror.beam_path_set_point.is_in_beam = False
         self.polarising_mirror.angle = 0
         s2 = Component("s2", setup=PositionAndAngle(0, 4, 90))
         self.ideal_sample_point = ReflectingComponent("ideal sample point", setup=PositionAndAngle(0, 5, 90))
         s3 = Component("s3", setup=PositionAndAngle(0, 6, 90))
         analyser = ReflectingComponent("analyser", setup=PositionAndAngle(0, 7, 90))
-        analyser.beam_path_set_point.enabled = False
+        analyser.beam_path_set_point.is_in_beam = False
         s4 = Component("s4", setup=PositionAndAngle(0, 8, 90))
         detector = Component("detector", setup=PositionAndAngle(0, 10, 90))
 
@@ -55,7 +55,7 @@ class TestComponentBeamline(unittest.TestCase):
     def test_GIVEN_beam_line_contains_active_super_mirror_WHEN_set_theta_THEN_angle_between_incoming_and_outgoing_beam_is_correct(self):
         self.beamline.active_mode = self.polarised_mode.name
         theta_set = 10.0
-        self.polarising_mirror.beam_path_set_point.enabled = True
+        self.polarising_mirror.beam_path_set_point.is_in_beam = True
         self.beamline.parameter("smangle").sp = 10
 
         self.beamline.parameter("theta").sp = theta_set
@@ -67,7 +67,7 @@ class TestComponentBeamline(unittest.TestCase):
         self.beamline.active_mode = self.polarised_mode.name
         theta_set = 10.0
         self.beamline.parameter("theta").sp = theta_set
-        self.polarising_mirror.beam_path_set_point.enabled = True
+        self.polarising_mirror.beam_path_set_point.is_in_beam = True
 
         self.beamline.parameter("smangle").sp = 10
 

--- a/ReflectometryServer/test_modules/test_actual_positions.py
+++ b/ReflectometryServer/test_modules/test_actual_positions.py
@@ -33,7 +33,7 @@ class TestComponentBeamline(unittest.TestCase):
         smangle.sp_no_move = 0
 
         self.nr_mode = BeamlineMode("NR Mode", [theta.name])
-        self.polarised_mode = BeamlineMode("NR Mode", [smangle.name, theta.name])
+        self.polarised_mode = BeamlineMode("Polarised Mode", [smangle.name, theta.name])
 
         self.beamline = Beamline(
             [s0, s1, frame_overlap_mirror, self.polarising_mirror, s2, self.ideal_sample_point, s3, analyser, s4, detector],

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -74,7 +74,7 @@ class TestComponentBeamline(unittest.TestCase):
         beamline, mirror = self.setup_beamline(initial_mirror_angle, mirror_position, beam_start)
         expected_beams = [beam_start, beam_start, beam_start]
 
-        mirror.beam_path_set_point.enabled = False
+        mirror.beam_path_set_point.is_in_beam = False
         results = [component.beam_path_set_point.get_outgoing_beam() for component in beamline]
 
         for index, (result, expected_beam) in enumerate(zip(results, expected_beams)):

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -180,6 +180,26 @@ class TestRealistic(unittest.TestCase):
 
         assert_that(drives["det_angle_axis"].value, is_(2*theta_angle))
 
+    def test_GIVEN_beam_line_which_is_in_disabled_mode_WHEN_set_theta_THEN_nothing_else_moves(self):
+        spacing = 2.0
+        bl, drives = DataMother.beamline_s1_s3_theta_detector(spacing)
+        bl.parameter("s1").sp = 0
+        bl.parameter("s3").sp = 0
+        bl.parameter("det").sp = 0
+        bl.parameter("det_angle").sp = 0
+        bl.active_mode = "DISABLED"
+
+        theta_angle = 2
+        bl.parameter("theta").sp = theta_angle
+
+        assert_that(drives["s1_axis"].value, is_(0))
+        assert_that(drives["s3_axis"].value, is_(0.0))
+
+        expected_det_value = 2 * spacing * tan(radians(theta_angle * 2.0))
+        assert_that(drives["det_axis"].value, is_(expected_det_value))
+
+        assert_that(drives["det_angle_axis"].value, is_(2*theta_angle))
+
 
 class TestBeamlineValidation(unittest.TestCase):
 

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -180,5 +180,6 @@ class TestRealistic(unittest.TestCase):
 
         assert_that(drives["det_angle_axis"].value, is_(2*theta_angle))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -552,5 +552,75 @@ class TestBeamlineParameterReadback(unittest.TestCase):
         assert_that(result, is_(45/2.0))
 
 
+class TestBeamlineThetaComponetWhenDisabled(unittest.TestCase):
+
+    def test_GIVEN_theta_with_0_deg_beam_and_next_component_in_beam_but_disabled_WHEN_set_theta_to_45_THEN_component_sp_is_at_45_degrees(self):
+
+        detector = Component("detector", setup=PositionAndAngle(0, 10, 90))
+        detector.beam_path_set_point.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        sample = ThetaComponent("sample", setup=PositionAndAngle(0, 0, 90), angle_to=[detector])
+        sample.beam_path_set_point.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        theta = AngleParameter("param", sample)
+        detector.set_incoming_beam_can_change(False)
+
+        theta.sp = 22.5
+        result = detector.beam_path_set_point.get_position_relative_to_beam()
+
+        assert_that(result, is_(close_to(-10.0, 1e-6)))  # the beam is now above the current position. The beam line parameter needs to be triggered to make is move
+
+    def test_GIVEN_theta_with_0_deg_beam_and_next_component_in_beam_is_not_disabled_WHEN_set_theta_to_45_THEN_component_sp_is_not_altered(self):
+        # this calculation will be done via the beamline not the forced copy of output beam
+        detector = Component("detector", setup=PositionAndAngle(0, 10, 90))
+        detector.beam_path_set_point.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        sample = ThetaComponent("sample", setup=PositionAndAngle(0, 0, 90), angle_to=[detector])
+        sample.beam_path_set_point.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        theta = AngleParameter("param", sample)
+        detector.set_incoming_beam_can_change(True)
+
+        theta.sp = 22.5
+        result = detector.beam_path_set_point.get_position_relative_to_beam()
+
+        assert_that(result, is_(close_to(0, 1e-6)))
+
+    def test_GIVEN_theta_with_0_deg_beam_and_next_two_component_in_beam_and_are_disabled_WHEN_set_theta_to_45_THEN_first_component_altered_second_one_not(self):
+        # this calculation will be done via the beamline not the forced copy of output beam
+        detector = Component("detector", setup=PositionAndAngle(0, 10, 90))
+        detector.beam_path_set_point.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        detector2 = Component("detector", setup=PositionAndAngle(0, 20, 90))
+        detector2.beam_path_set_point.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        sample = ThetaComponent("sample", setup=PositionAndAngle(0, 0, 90), angle_to=[detector, detector2])
+        sample.beam_path_set_point.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        theta = AngleParameter("param", sample)
+        detector.set_incoming_beam_can_change(False)
+        detector2.set_incoming_beam_can_change(False)
+
+        theta.sp = 22.5
+        result1 = detector.beam_path_set_point.get_position_relative_to_beam()
+        result2 = detector2.beam_path_set_point.get_position_relative_to_beam()
+
+        assert_that(result1, is_(close_to(-10, 1e-6)))
+        assert_that(result2, is_(close_to(0, 1e-6)))
+
+    def test_GIVEN_theta_with_0_deg_beam_and_next_first_component_out_of_beam_second_in_beam_and_are_disabled_WHEN_set_theta_to_45_THEN_first_component_not_altered_second_one_is(self):
+        # this calculation will be done via the beamline not the forced copy of output beam
+        detector = Component("detector", setup=PositionAndAngle(0, 10, 90))
+        detector.beam_path_set_point.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        detector2 = Component("detector", setup=PositionAndAngle(0, 20, 90))
+        detector2.beam_path_set_point.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        sample = ThetaComponent("sample", setup=PositionAndAngle(0, 0, 90), angle_to=[detector, detector2])
+        sample.beam_path_set_point.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        theta = AngleParameter("param", sample)
+        detector.set_incoming_beam_can_change(False)
+        detector.beam_path_set_point.is_in_beam = False
+        detector2.set_incoming_beam_can_change(False)
+
+        theta.sp = 22.5
+        result1 = detector.beam_path_set_point.get_position_relative_to_beam()
+        result2 = detector2.beam_path_set_point.get_position_relative_to_beam()
+
+        assert_that(result1, is_(close_to(0, 1e-6)))
+        assert_that(result2, is_(close_to(-20, 1e-6)))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -123,7 +123,7 @@ class TestBeamlineParameter(unittest.TestCase):
 
     def test_GIVEN_component_parameter_enabled_in_mode_WHEN_parameter_moved_to_THEN_component_is_enabled(self):
         super_mirror = ReflectingComponent("super mirror", PositionAndAngle(z=10, y=0, angle=90))
-        super_mirror.beam_path_set_point.enabled = False
+        super_mirror.beam_path_set_point.is_in_beam = False
         sm_enabled = ComponentEnabled("smenabled", super_mirror)
         enabled_sp = True
 
@@ -131,11 +131,11 @@ class TestBeamlineParameter(unittest.TestCase):
         sm_enabled.move = 1
 
         assert_that(sm_enabled.sp_rbv, is_(enabled_sp))
-        assert_that(super_mirror.beam_path_set_point.enabled, is_(enabled_sp))
+        assert_that(super_mirror.beam_path_set_point.is_in_beam, is_(enabled_sp))
 
     def test_GIVEN_component_parameter_disabled_in_mode_WHEN_parameter_moved_to_THEN_component_is_disabled(self):
         super_mirror = ReflectingComponent("super mirror", PositionAndAngle(z=10, y=0, angle=90))
-        super_mirror.beam_path_set_point.enabled = True
+        super_mirror.beam_path_set_point.is_in_beam = True
         sm_enabled = ComponentEnabled("smenabled", super_mirror)
         enabled_sp = False
 
@@ -143,7 +143,7 @@ class TestBeamlineParameter(unittest.TestCase):
         sm_enabled.move = 1
 
         assert_that(sm_enabled.sp_rbv, is_(enabled_sp))
-        assert_that(super_mirror.beam_path_set_point.enabled, is_(enabled_sp))
+        assert_that(super_mirror.beam_path_set_point.is_in_beam, is_(enabled_sp))
 
 class TestBeamlineModes(unittest.TestCase):
 
@@ -521,7 +521,7 @@ class TestBeamlineParameterReadback(unittest.TestCase):
         beamline_position = ComponentEnabled("param", sample)
         listener = Mock()
         beamline_position.add_rbv_change_listener(listener)
-        sample.beam_path_rbv.enabled = state
+        sample.beam_path_rbv.is_in_beam = state
 
         listener.assert_called_once_with(state)
 

--- a/ReflectometryServer/test_modules/test_components.py
+++ b/ReflectometryServer/test_modules/test_components.py
@@ -86,7 +86,7 @@ class TestActiveComponents(unittest.TestCase):
         mirror = ReflectingComponent("component", setup=PositionAndAngle(0, mirror_z_position, 90))
         mirror.beam_path_set_point.angle = mirror_angle
         mirror.beam_path_set_point.set_incoming_beam(beam_start)
-        mirror.beam_path_set_point.enabled = False
+        mirror.beam_path_set_point.is_in_beam = False
 
         result = mirror.beam_path_set_point.get_outgoing_beam()
 
@@ -229,7 +229,7 @@ class TestThetaComponent(unittest.TestCase):
 
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
-        next_component.beam_path_rbv.enabled = False
+        next_component.beam_path_rbv.is_in_beam = False
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -241,7 +241,7 @@ class TestThetaComponent(unittest.TestCase):
 
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
-        next_component.beam_path_rbv.enabled = True
+        next_component.beam_path_rbv.is_in_beam = True
         next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
@@ -254,7 +254,7 @@ class TestThetaComponent(unittest.TestCase):
 
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
-        next_component.beam_path_rbv.enabled = True
+        next_component.beam_path_rbv.is_in_beam = True
         next_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
@@ -267,7 +267,7 @@ class TestThetaComponent(unittest.TestCase):
 
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 5, 90))
-        next_component.beam_path_rbv.enabled = True
+        next_component.beam_path_rbv.is_in_beam = True
         next_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
@@ -280,10 +280,10 @@ class TestThetaComponent(unittest.TestCase):
 
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp1", setup=PositionAndAngle(0, 10, 90))
-        next_component.beam_path_rbv.enabled = False
+        next_component.beam_path_rbv.is_in_beam = False
 
         next_but_one_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
-        next_but_one_component.beam_path_rbv.enabled = True
+        next_but_one_component.beam_path_rbv.is_in_beam = True
         next_but_one_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component, next_but_one_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
@@ -296,7 +296,7 @@ class TestThetaComponent(unittest.TestCase):
 
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
-        next_component.beam_path_rbv.enabled = True
+        next_component.beam_path_rbv.is_in_beam = True
         next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
@@ -311,7 +311,7 @@ class TestThetaComponent(unittest.TestCase):
 
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
-        next_component.beam_path_rbv.enabled = True
+        next_component.beam_path_rbv.is_in_beam = True
         next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
@@ -326,7 +326,7 @@ class TestThetaComponent(unittest.TestCase):
 
         beam_start = PositionAndAngle(y=10, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
-        next_component.beam_path_rbv.enabled = True
+        next_component.beam_path_rbv.is_in_beam = True
         next_component.beam_path_rbv.set_displacement(15, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)

--- a/ReflectometryServer/test_modules/test_config/error_config/refl/config.py
+++ b/ReflectometryServer/test_modules/test_config/error_config/refl/config.py
@@ -29,7 +29,7 @@ def get_beamline():
     comps = [s1, super_mirror, s2, sample, s3, s4, point_det]
 
     # BEAMLINE PARAMETERS
-    sm_enabled = ComponentEnabled("smenabled", super_mirror, True)
+    sm_enabled = InBeamParameter("smenabled", super_mirror, True)
     sm_angle = AngleParameter("smangle", super_mirror, True)
     slit2_pos = TrackingPosition("slit2pos", s2, True)
     sample_pos = TrackingPosition("samplepos", sample, True)

--- a/ReflectometryServer/test_modules/test_config/good_config/refl/config.py
+++ b/ReflectometryServer/test_modules/test_config/good_config/refl/config.py
@@ -4,8 +4,10 @@
 from ReflectometryServer.components import *
 from ReflectometryServer.geometry import *
 from ReflectometryServer.beamline import Beamline, BeamlineMode
+from ReflectometryServer.ioc_driver import DisplacementDriver
 from ReflectometryServer.parameters import *
 from ReflectometryServer.geometry import PositionAndAngle
+from ReflectometryServer.test_modules.data_mother import create_mock_axis
 
 
 def get_beamline():
@@ -29,7 +31,7 @@ def get_beamline():
     comps = [s1, super_mirror, s2, sample, s3, s4, point_det]
 
     # BEAMLINE PARAMETERS
-    sm_enabled = ComponentEnabled("smenabled", super_mirror, True)
+    sm_enabled = InBeamParameter("smenabled", super_mirror, True)
     sm_angle = AngleParameter("smangle", super_mirror, True)
     slit2_pos = TrackingPosition("slit2pos", s2, True)
     sample_pos = TrackingPosition("samplepos", sample, True)
@@ -46,6 +48,10 @@ def get_beamline():
               slit4_pos,
               det]
 
+    # Drivers
+
+    drivers = [DisplacementDriver(super_mirror, create_mock_axis("MOT:MTR0101", 0, 1), out_of_beam_position=-10)]
+
     # MODES
     nr_inits = {"smenabled": False, "smangle": 0.0}
     pnr_inits = {"smenabled": True, "smangle": 0.5}
@@ -55,6 +61,6 @@ def get_beamline():
     modes = [nr_mode, pnr_mode, disabled_mode]
 
     beam_start = PositionAndAngle(0.0, 0.0, beam_angle_natural)
-    bl = Beamline(comps, params, [], modes, beam_start)
+    bl = Beamline(comps, params, drivers, modes, beam_start)
 
     return bl


### PR DESCRIPTION
### Description of work

Disable beam calculation for certain modes

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3890

### Acceptance criteria

When a disable mode is introduced the components act as if they were no longer linked. Changing the value is changing with reference to where it was. E.g. change theta no longer change the following slit height. Changing the slit height is with reference to where it was when it entered disable mode.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
