### PR TITLE
Make independent of genie_python and CaChannel

### DIFF
--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -61,8 +61,8 @@ class IocDriver(object):
         Trigger all listeners after an axis value change.
         Args:
             new_value: new axis value that is given
-            alarm_severity (CaChannel._ca.AlarmSeverity): severity of any alarm
-            alarm_status (CaChannel._ca.AlarmCondition): the alarm status
+            alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
+            alarm_status (server_common.channel_access.AlarmCondition): the alarm status
         """
 
         raise NotImplemented()
@@ -86,8 +86,8 @@ class DisplacementDriver(IocDriver):
         Trigger all listeners after a height change.
         Args:
             new_value: new height that is given
-            alarm_severity (CaChannel._ca.AlarmSeverity): severity of any alarm
-            alarm_status (CaChannel._ca.AlarmCondition): the alarm status
+            alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
+            alarm_status (server_common.channel_access.AlarmCondition): the alarm status
         """
 
         self._component.beam_path_rbv.set_displacement(new_value, alarm_severity, alarm_status)

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -319,8 +319,8 @@ class SlitGapParameter(BeamlineParameter):
 
         Args:
             new_value: new given value
-            alarm_severity (CaChannel._ca.AlarmSeverity): severity of any alarm
-            alarm_status (CaChannel._ca.AlarmCondition): the alarm status
+            alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
+            alarm_status (server_common.channel_access.AlarmCondition): the alarm status
         """
         self._set_point_rbv = new_value
         self._trigger_sp_rbv_listeners(self)
@@ -331,8 +331,8 @@ class SlitGapParameter(BeamlineParameter):
 
         Args:
             new_value: new readback value that is given
-            alarm_severity (CaChannel._ca.AlarmSeverity): severity of any alarm
-            alarm_status (CaChannel._ca.AlarmCondition): the alarm status
+            alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
+            alarm_status (server_common.channel_access.AlarmCondition): the alarm status
         """
         self._rbv_value = new_value
         self._trigger_rbv_listeners(self)

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -1,16 +1,10 @@
 """
 Wrapper for motor PVs
 """
-from genie_python.genie_cachannel_wrapper import CaChannelWrapper
-from genie_python.channel_access_exceptions import UnableToConnectToPVException
-
-# Export these with better names
-from CaChannel._ca import AlarmSeverity
-from CaChannel._ca import AlarmCondition as AlarmStatus
-
-
 from ReflectometryServer.ChannelAccess.constants import MYPVPREFIX
 import logging
+
+from server_common.channel_access import ChannelAccess, UnableToConnectToPVException
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +40,8 @@ class PVWrapper(object):
             pv(String): The pv to monitor
             call_back_function: The function to execute on a pv value change
         """
-        if CaChannelWrapper.pv_exists(pv):
-            CaChannelWrapper.add_monitor(pv, call_back_function)
+        if ChannelAccess.pv_exists(pv):
+            ChannelAccess.add_monitor(pv, call_back_function)
             logger.debug("Monitoring {} for changes.".format(pv))
         else:
             logger.error("Error adding monitor to {}: PV does not exist".format(pv))
@@ -61,7 +55,7 @@ class PVWrapper(object):
             pv(String): The pv to read
         """
         try:
-            return CaChannelWrapper.get_pv_value(pv)
+            return ChannelAccess.caget(pv)
         except UnableToConnectToPVException:
             logger.error("Error reading value from {}: PV does not exist".format(pv))
             return None
@@ -76,7 +70,7 @@ class PVWrapper(object):
             value: The new value
         """
         try:
-            CaChannelWrapper.set_pv_value(pv, value)
+            ChannelAccess.caput(pv, value)
         except UnableToConnectToPVException:
             logger.error("Error writing value to {}: PV does not exist".format(pv))
 
@@ -153,7 +147,7 @@ class MotorPVWrapper(PVWrapper):
         """
         Returns: the value of the underlying velocity PV
         """
-        return CaChannelWrapper.get_pv_value(self._prefixed_pv + ".VELO")
+        return ChannelAccess.caget(self._prefixed_pv + ".VELO")
 
     @velocity.setter
     def velocity(self, value):
@@ -163,14 +157,14 @@ class MotorPVWrapper(PVWrapper):
         Args:
             value: The value to set
         """
-        CaChannelWrapper.set_pv_value(self._prefixed_pv + ".VELO", value)
+        ChannelAccess.caput(self._prefixed_pv + ".VELO", value)
 
     @property
     def max_velocity(self):
         """
         Returns: the value of the underlying max velocity PV
         """
-        return CaChannelWrapper.get_pv_value(self._prefixed_pv + ".VMAX")
+        return ChannelAccess.caget(self._prefixed_pv + ".VMAX")
 
 
 class AxisPVWrapper(PVWrapper):

--- a/ReflectometryServer/reflectometry_server.py
+++ b/ReflectometryServer/reflectometry_server.py
@@ -5,7 +5,6 @@ Reflectometry Server
 import sys
 import os
 
-from genie_python.genie_cachannel_wrapper import CaChannelWrapper
 from pcaspy import SimpleServer
 import logging.config
 
@@ -44,6 +43,7 @@ from ReflectometryServer.beamline_configuration import create_beamline_from_conf
 from ReflectometryServer.ChannelAccess.constants import REFLECTOMETRY_PREFIX
 from ReflectometryServer.ChannelAccess.pv_manager import PVManager
 from server_common.ioc_data_source import IocDataSource
+from server_common.channel_access import ChannelAccess
 from server_common.mysql_abstraction_layer import SQLAbstraction
 
 logger.info("Initialising...")
@@ -66,7 +66,7 @@ logger.info("Reflectometry IOC started")
 while True:
     try:
         SERVER.process(0.1)
-        CaChannelWrapper.poll()
+        ChannelAccess.poll()
     except Exception as err:
         print(err)
         break

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -89,7 +89,7 @@ class TestComponentBeamlineReadbacks(unittest.TestCase):
 
         callback = Mock()
         comp2.beam_path_rbv.set_incoming_beam = callback
-        comp1.beam_path_rbv.set_displacement(1.0, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        comp1.beam_path_rbv.set_displacement(1.0, AlarmSeverity.No, AlarmStatus.No)
 
         assert_that(callback.called, is_(True))
 

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -4,14 +4,13 @@ from math import tan, radians
 from hamcrest import *
 from mock import Mock
 
-from ReflectometryServer.components import ReflectingComponent, Component, TiltingComponent, ThetaComponent
-from ReflectometryServer.ioc_driver import DisplacementDriver, AngleDriver
-from ReflectometryServer.geometry import PositionAndAngle, PositionAndAngle
-from ReflectometryServer.beamline import Beamline, BeamlineMode
-from ReflectometryServer.parameters import TrackingPosition, AngleParameter
-from ReflectometryServer.test_modules.data_mother import DataMother, create_mock_axis
+from ReflectometryServer.components import ReflectingComponent, Component
+from ReflectometryServer.geometry import PositionAndAngle
+from ReflectometryServer.beamline import Beamline
+from ReflectometryServer.test_modules.data_mother import DataMother
+
+from server_common.channel_access import AlarmSeverity, AlarmStatus
 from utils import position_and_angle
-from ReflectometryServer.pv_wrapper import AlarmSeverity, AlarmStatus, MotorPVWrapper
 
 
 
@@ -90,7 +89,7 @@ class TestComponentBeamlineReadbacks(unittest.TestCase):
 
         callback = Mock()
         comp2.beam_path_rbv.set_incoming_beam = callback
-        comp1.beam_path_rbv.set_displacement(1.0, AlarmSeverity.No, AlarmStatus.No)
+        comp1.beam_path_rbv.set_displacement(1.0, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
 
         assert_that(callback.called, is_(True))
 
@@ -170,15 +169,16 @@ class TestRealistic(unittest.TestCase):
         bl.parameter("theta").sp_no_move = theta_angle
         bl.move = 1
 
-        assert_that(drives["s1_axis"].value, is_(0))
+        assert_that(drives["s1_axis"].sp, is_(0))
 
         expected_s3_value = spacing * tan(radians(theta_angle * 2.0))
-        assert_that(drives["s3_axis"].value, is_(expected_s3_value))
+        assert_that(drives["s3_axis"].sp, is_(expected_s3_value))
 
         expected_det_value = 2 * spacing * tan(radians(theta_angle * 2.0))
-        assert_that(drives["det_axis"].value, is_(expected_det_value))
+        assert_that(drives["det_axis"].sp, is_(expected_det_value))
 
-        assert_that(drives["det_angle_axis"].value, is_(2*theta_angle))
+        assert_that(drives["det_angle_axis"].sp, is_(2*theta_angle))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -10,8 +10,8 @@ from ReflectometryServer.components import ReflectingComponent, Component, Theta
 from ReflectometryServer.geometry import Position, PositionAndAngle
 from ReflectometryServer.parameters import AngleParameter, TrackingPosition, ComponentEnabled, SlitGapParameter
 from data_mother import DataMother, EmptyBeamlineParameter
+from server_common.channel_access import AlarmSeverity, AlarmStatus
 from utils import position, DEFAULT_TEST_TOLERANCE
-from ReflectometryServer.pv_wrapper import AlarmSeverity, AlarmStatus
 
 
 class TestBeamlineParameter(unittest.TestCase):
@@ -481,7 +481,7 @@ class TestBeamlineParameterReadback(unittest.TestCase):
         beam_height = 1.0
         sample.beam_path_rbv.set_incoming_beam(PositionAndAngle(beam_height, 0, 0))
         beamline_position = TrackingPosition("param", sample)
-        sample.beam_path_rbv.set_displacement(displacement, AlarmSeverity.No, AlarmStatus.No)
+        sample.beam_path_rbv.set_displacement(displacement, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
 
         result = beamline_position.rbv
 
@@ -496,7 +496,7 @@ class TestBeamlineParameterReadback(unittest.TestCase):
         beamline_position = TrackingPosition("param", sample)
         listener = Mock()
         beamline_position.add_rbv_change_listener(listener)
-        sample.beam_path_rbv.set_displacement(displacement, AlarmSeverity.No, AlarmStatus.No)
+        sample.beam_path_rbv.set_displacement(displacement, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
 
         listener.assert_called_once_with(displacement - beam_height)
 

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -481,7 +481,7 @@ class TestBeamlineParameterReadback(unittest.TestCase):
         beam_height = 1.0
         sample.beam_path_rbv.set_incoming_beam(PositionAndAngle(beam_height, 0, 0))
         beamline_position = TrackingPosition("param", sample)
-        sample.beam_path_rbv.set_displacement(displacement, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        sample.beam_path_rbv.set_displacement(displacement, AlarmSeverity.No, AlarmStatus.No)
 
         result = beamline_position.rbv
 
@@ -496,7 +496,7 @@ class TestBeamlineParameterReadback(unittest.TestCase):
         beamline_position = TrackingPosition("param", sample)
         listener = Mock()
         beamline_position.add_rbv_change_listener(listener)
-        sample.beam_path_rbv.set_displacement(displacement, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        sample.beam_path_rbv.set_displacement(displacement, AlarmSeverity.No, AlarmStatus.No)
 
         listener.assert_called_once_with(displacement - beam_height)
 

--- a/ReflectometryServer/test_modules/test_components.py
+++ b/ReflectometryServer/test_modules/test_components.py
@@ -176,7 +176,7 @@ class TestObservationOfComponentReadback(unittest.TestCase):
     def test_GIVEN_listener_WHEN_readback_changes_THEN_listener_is_informed(self):
         expected_value = 10
         self.component.beam_path_rbv.add_after_beam_path_update_listener(self.listen_for_value)
-        self.component.beam_path_rbv.set_displacement(1, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        self.component.beam_path_rbv.set_displacement(1, AlarmSeverity.No, AlarmStatus.No)
 
         result = self.component.beam_path_rbv.get_displacement()
 
@@ -187,7 +187,7 @@ class TestObservationOfComponentReadback(unittest.TestCase):
         expected_value = 10
         self.component.beam_path_rbv.add_after_beam_path_update_listener(self.listen_for_value)
         self.component.beam_path_rbv.add_after_beam_path_update_listener(self.listen_for_value2)
-        self.component.beam_path_rbv.set_displacement(1, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        self.component.beam_path_rbv.set_displacement(1, AlarmSeverity.No, AlarmStatus.No)
 
         result = self.component.beam_path_rbv.get_displacement()
 
@@ -196,7 +196,7 @@ class TestObservationOfComponentReadback(unittest.TestCase):
         assert_that(result, expected_value)
 
     def test_GIVEN_no_listener_WHEN_readback_changes_THEN_no_listeners_are_informed(self):
-        self.component.beam_path_rbv.set_displacement(1, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        self.component.beam_path_rbv.set_displacement(1, AlarmSeverity.No, AlarmStatus.No)
 
         assert_that(self._value, is_(0))
 
@@ -204,7 +204,7 @@ class TestObservationOfComponentReadback(unittest.TestCase):
         expected_value = 10
         self.component.beam_path_rbv.add_after_beam_path_update_listener(self.listen_for_value)
         beam_y = 1
-        self.component.beam_path_rbv.set_displacement(expected_value + beam_y, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        self.component.beam_path_rbv.set_displacement(expected_value + beam_y, AlarmSeverity.No, AlarmStatus.No)
 
         self.component.beam_path_rbv.set_incoming_beam(PositionAndAngle(beam_y, 0, 0))
         result = self.component.beam_path_rbv.get_displacement()
@@ -242,7 +242,7 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.enabled = True
-        next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -255,7 +255,7 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.enabled = True
-        next_component.beam_path_rbv.set_displacement(5, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        next_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -268,7 +268,7 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 5, 90))
         next_component.beam_path_rbv.enabled = True
-        next_component.beam_path_rbv.set_displacement(5, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        next_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -284,7 +284,7 @@ class TestThetaComponent(unittest.TestCase):
 
         next_but_one_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_but_one_component.beam_path_rbv.enabled = True
-        next_but_one_component.beam_path_rbv.set_displacement(5, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        next_but_one_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component, next_but_one_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -297,13 +297,13 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.enabled = True
-        next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
         listener = Mock()
         theta.beam_path_rbv.add_after_beam_path_update_listener(listener)
 
-        next_component.beam_path_rbv.set_displacement(1, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        next_component.beam_path_rbv.set_displacement(1, AlarmSeverity.No, AlarmStatus.No)
 
         listener.assert_called_once_with(theta.beam_path_rbv)
 
@@ -312,7 +312,7 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.enabled = True
-        next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
         listener = Mock()
@@ -327,7 +327,7 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=10, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.enabled = True
-        next_component.beam_path_rbv.set_displacement(15, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
+        next_component.beam_path_rbv.set_displacement(15, AlarmSeverity.No, AlarmStatus.No)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 

--- a/ReflectometryServer/test_modules/test_components.py
+++ b/ReflectometryServer/test_modules/test_components.py
@@ -7,8 +7,8 @@ from parameterized import parameterized
 
 from ReflectometryServer.components import Component, ReflectingComponent, TiltingComponent, ThetaComponent
 from ReflectometryServer.geometry import Position, PositionAndAngle, PositionAndAngle
+from server_common.channel_access import AlarmSeverity, AlarmStatus
 from utils import position_and_angle, position
-from ReflectometryServer.pv_wrapper import AlarmSeverity, AlarmStatus
 
 
 class TestComponent(unittest.TestCase):
@@ -176,7 +176,7 @@ class TestObservationOfComponentReadback(unittest.TestCase):
     def test_GIVEN_listener_WHEN_readback_changes_THEN_listener_is_informed(self):
         expected_value = 10
         self.component.beam_path_rbv.add_after_beam_path_update_listener(self.listen_for_value)
-        self.component.beam_path_rbv.set_displacement(1, AlarmSeverity.No, AlarmStatus.No)
+        self.component.beam_path_rbv.set_displacement(1, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
 
         result = self.component.beam_path_rbv.get_displacement()
 
@@ -187,7 +187,7 @@ class TestObservationOfComponentReadback(unittest.TestCase):
         expected_value = 10
         self.component.beam_path_rbv.add_after_beam_path_update_listener(self.listen_for_value)
         self.component.beam_path_rbv.add_after_beam_path_update_listener(self.listen_for_value2)
-        self.component.beam_path_rbv.set_displacement(1, AlarmSeverity.No, AlarmStatus.No)
+        self.component.beam_path_rbv.set_displacement(1, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
 
         result = self.component.beam_path_rbv.get_displacement()
 
@@ -196,7 +196,7 @@ class TestObservationOfComponentReadback(unittest.TestCase):
         assert_that(result, expected_value)
 
     def test_GIVEN_no_listener_WHEN_readback_changes_THEN_no_listeners_are_informed(self):
-        self.component.beam_path_rbv.set_displacement(1, AlarmSeverity.No, AlarmStatus.No)
+        self.component.beam_path_rbv.set_displacement(1, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
 
         assert_that(self._value, is_(0))
 
@@ -204,7 +204,7 @@ class TestObservationOfComponentReadback(unittest.TestCase):
         expected_value = 10
         self.component.beam_path_rbv.add_after_beam_path_update_listener(self.listen_for_value)
         beam_y = 1
-        self.component.beam_path_rbv.set_displacement(expected_value + beam_y, AlarmSeverity.No, AlarmStatus.No)
+        self.component.beam_path_rbv.set_displacement(expected_value + beam_y, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
 
         self.component.beam_path_rbv.set_incoming_beam(PositionAndAngle(beam_y, 0, 0))
         result = self.component.beam_path_rbv.get_displacement()
@@ -242,7 +242,7 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.enabled = True
-        next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.No, AlarmStatus.No)
+        next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -255,7 +255,7 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.enabled = True
-        next_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
+        next_component.beam_path_rbv.set_displacement(5, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -268,7 +268,7 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 5, 90))
         next_component.beam_path_rbv.enabled = True
-        next_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
+        next_component.beam_path_rbv.set_displacement(5, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -284,7 +284,7 @@ class TestThetaComponent(unittest.TestCase):
 
         next_but_one_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_but_one_component.beam_path_rbv.enabled = True
-        next_but_one_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
+        next_but_one_component.beam_path_rbv.set_displacement(5, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component, next_but_one_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -297,13 +297,13 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.enabled = True
-        next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.No, AlarmStatus.No)
+        next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
         listener = Mock()
         theta.beam_path_rbv.add_after_beam_path_update_listener(listener)
 
-        next_component.beam_path_rbv.set_displacement(1, AlarmSeverity.No, AlarmStatus.No)
+        next_component.beam_path_rbv.set_displacement(1, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
 
         listener.assert_called_once_with(theta.beam_path_rbv)
 
@@ -312,7 +312,7 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.enabled = True
-        next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.No, AlarmStatus.No)
+        next_component.beam_path_rbv.set_displacement(0, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
         listener = Mock()
@@ -327,7 +327,7 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=10, z=0, angle=0)
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.enabled = True
-        next_component.beam_path_rbv.set_displacement(15, AlarmSeverity.No, AlarmStatus.No)
+        next_component.beam_path_rbv.set_displacement(15, AlarmSeverity.NoAlarm, AlarmStatus.NoAlarm)
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 

--- a/ReflectometryServer/test_modules/test_ioc_driving_layer.py
+++ b/ReflectometryServer/test_modules/test_ioc_driving_layer.py
@@ -7,10 +7,9 @@ from hamcrest import *
 
 from ReflectometryServer.beamline import Beamline, BeamlineMode
 from ReflectometryServer.components import TiltingComponent, Component, ReflectingComponent
-from ReflectometryServer.geometry import PositionAndAngle, PositionAndAngle
+from ReflectometryServer.geometry import PositionAndAngle
 from ReflectometryServer.ioc_driver import DisplacementDriver, AngleDriver
 from ReflectometryServer.parameters import AngleParameter, TrackingPosition
-from ReflectometryServer.pv_wrapper import AlarmSeverity, AlarmStatus
 from ReflectometryServer.test_modules.data_mother import create_mock_axis
 
 FLOAT_TOLERANCE = 1e-9

--- a/server_common/channel_access.py
+++ b/server_common/channel_access.py
@@ -1,3 +1,6 @@
+"""
+Make channel access not dependent on genie_python.
+"""
 # This file is part of the ISIS IBEX application.
 # Copyright (C) 2012-2016 Science & Technology Facilities Council.
 # All rights reserved.
@@ -13,12 +16,94 @@
 # along with this program; if not, you can obtain a copy from
 # https://www.eclipse.org/org/documents/epl-v10.php or
 # http://opensource.org/licenses/eclipse-1.0.php
-import time
+from enum import Enum
+
 from server_common.utilities import print_and_log
 import threading
+try:
+    from genie_python.channel_access_exceptions import UnableToConnectToPVException
+except ImportError:
+    class UnableToConnectToPVException(IOError):
+        """
+        The system is unable to connect to a PV for some reason.
+        """
+        def __init__(self, pv_name, err):
+            super(UnableToConnectToPVException, self).__init__("Unable to connect to PV {0}: {1}".format(pv_name, err))
+
+
+class AlarmSeverity(Enum):
+    """
+    Enum for severity of alarm
+    """
+    NoAlarm = 0
+    Minor = 1
+    Major = 2
+    invalid = 3
+
+    @staticmethod
+    def from_ca_channel(severity):
+        """
+        Convert from a ca channel severity.
+        Isolates code from CaChannel internal.
+        Args:
+            severity (CaChannel._ca.AlarmSeverity): ca channel severity
+        Returns: severity
+
+        """
+        # noinspection PyTypeChecker
+        for alarm_severity in AlarmSeverity:
+            if alarm_severity.value == severity.value:
+                return alarm_severity
+
+
+class AlarmStatus(Enum):
+    """
+    Enum for status of alarm
+    """
+    BadSub = 16
+    Calc = 12
+    Comm = 9
+    Cos = 8
+    Disable = 18
+    High = 4
+    HiHi = 3
+    HwLimit = 11
+    Link = 14
+    Lolo = 5
+    Low = 6
+    NoAlarm = 0
+    Read = 1
+    ReadAccess = 20
+    Scam = 13
+    Simm = 19
+    Soft = 15
+    State = 7
+    Timeout = 10
+    UDF = 17
+    Write = 2
+    WriteAccess = 21
+
+    @staticmethod
+    def from_ca_channel(status):
+        """
+        Convert from a ca channel status.
+        Isolates code from CaChannel internal.
+        Args:
+            status (CaChannel._ca.AlarmStatus): ca channel status
+        Returns: severity
+
+        """
+        # noinspection PyTypeChecker
+        for alarm_status in AlarmStatus:
+            if alarm_status == status.value:
+                return alarm_status
 
 
 class ChannelAccess(object):
+    """
+    Channel access methods. Items from genie_python are imported locally so that this module can be imported without
+    installing genie_python.
+    """
     @staticmethod
     def caget(name, as_string=False):
         """Uses CaChannelWrapper from genie_python to get a pv value. We import CaChannelWrapper when used as this means
@@ -50,15 +135,58 @@ class ChannelAccess(object):
             value (object): The data to send to the PV
             wait (bool, optional): Wait for the PV t set before returning
         """
-        def put_value():
+        def _put_value():
             from genie_python.genie_cachannel_wrapper import CaChannelWrapper
             CaChannelWrapper.set_pv_value(name, value, wait)
 
         if wait:
             # If waiting then run in this thread.
-            put_value()
+            _put_value()
         else:
             # If not waiting, run in a different thread.
             # Even if not waiting genie_python sometimes takes a while to return from a set_pv_value call.
-            thread = threading.Thread(target=put_value)
+            thread = threading.Thread(target=_put_value)
             thread.start()
+
+    @staticmethod
+    def pv_exists(name, timeout=None):
+        """
+        See if the PV exists.
+
+        Args:
+            name (string): The PV name.
+            timeout(optional): How long to wait for the PV to "appear".
+
+        Returns:
+            True if exists, otherwise False.
+        """
+        from genie_python.genie_cachannel_wrapper import CaChannelWrapper, EXIST_TIMEOUT
+        if timeout is None:
+            timeout = EXIST_TIMEOUT
+        return CaChannelWrapper.pv_exists(name, timeout)
+
+    @staticmethod
+    def add_monitor(name, call_back_function):
+        """
+        Add a callback to a pv which responds on a monitor (i.e. value change). This currently only tested for
+        numbers.
+        Args:
+            name: name of the pv
+            call_back_function: the callback function, arguments are value,
+                alarm severity (AlarmSeverity),
+                alarm status (AlarmStatus)
+        """
+        from genie_python.genie_cachannel_wrapper import CaChannelWrapper
+
+        def _intermediate_callback(value, severity, status):
+            call_back_function(value, AlarmSeverity.from_ca_channel(severity), AlarmStatus.from_ca_channel(status))
+        CaChannelWrapper.add_monitor(name, _intermediate_callback)
+
+    @staticmethod
+    def poll():
+        """
+        Flush the send buffer and execute any outstanding background activity for all connected pvs.
+        NB Connected pv is one which is in the cache
+        """
+        from genie_python.genie_cachannel_wrapper import CaChannelWrapper
+        CaChannelWrapper.poll()

--- a/server_common/channel_access.py
+++ b/server_common/channel_access.py
@@ -30,73 +30,51 @@ except ImportError:
         def __init__(self, pv_name, err):
             super(UnableToConnectToPVException, self).__init__("Unable to connect to PV {0}: {1}".format(pv_name, err))
 
+try:
+    # noinspection PyUnresolvedReferences
+    from genie_python.genie_cachannel_wrapper import CaChannelWrapper, EXIST_TIMEOUT
+except ImportError:
+    print("ERROR: No genie_python on the system can not import CaChannelWrapper!")
 
-class AlarmSeverity(Enum):
-    """
-    Enum for severity of alarm
-    """
-    NoAlarm = 0
-    Minor = 1
-    Major = 2
-    invalid = 3
-
-    @staticmethod
-    def from_ca_channel(severity):
+try:
+    from genie_python.genie_cachannel_wrapper import AlarmSeverity, AlarmCondition as AlarmStatus
+except ImportError:
+    class AlarmSeverity(Enum):
         """
-        Convert from a ca channel severity.
-        Isolates code from CaChannel internal.
-        Args:
-            severity (CaChannel._ca.AlarmSeverity): ca channel severity
-        Returns: severity
-
+        Enum for severity of alarm
         """
-        # noinspection PyTypeChecker
-        for alarm_severity in AlarmSeverity:
-            if alarm_severity.value == severity.value:
-                return alarm_severity
+        NoAlarm = 0
+        Minor = 1
+        Major = 2
+        invalid = 3
 
 
-class AlarmStatus(Enum):
-    """
-    Enum for status of alarm
-    """
-    BadSub = 16
-    Calc = 12
-    Comm = 9
-    Cos = 8
-    Disable = 18
-    High = 4
-    HiHi = 3
-    HwLimit = 11
-    Link = 14
-    Lolo = 5
-    Low = 6
-    NoAlarm = 0
-    Read = 1
-    ReadAccess = 20
-    Scam = 13
-    Simm = 19
-    Soft = 15
-    State = 7
-    Timeout = 10
-    UDF = 17
-    Write = 2
-    WriteAccess = 21
-
-    @staticmethod
-    def from_ca_channel(status):
+    class AlarmStatus(Enum):
         """
-        Convert from a ca channel status.
-        Isolates code from CaChannel internal.
-        Args:
-            status (CaChannel._ca.AlarmStatus): ca channel status
-        Returns: severity
-
+        Enum for status of alarm
         """
-        # noinspection PyTypeChecker
-        for alarm_status in AlarmStatus:
-            if alarm_status == status.value:
-                return alarm_status
+        BadSub = 16
+        Calc = 12
+        Comm = 9
+        Cos = 8
+        Disable = 18
+        High = 4
+        HiHi = 3
+        HwLimit = 11
+        Link = 14
+        Lolo = 5
+        Low = 6
+        NoAlarm = 0
+        Read = 1
+        ReadAccess = 20
+        Scam = 13
+        Simm = 19
+        Soft = 15
+        State = 7
+        Timeout = 10
+        UDF = 17
+        Write = 2
+        WriteAccess = 21
 
 
 class ChannelAccess(object):
@@ -116,8 +94,6 @@ class ChannelAccess(object):
         Returns:
             obj : The value of the requested PV, None if no value was read
         """
-
-        from genie_python.genie_cachannel_wrapper import CaChannelWrapper
         try:
             return CaChannelWrapper.get_pv_value(name, as_string)
         except Exception as err:
@@ -136,7 +112,6 @@ class ChannelAccess(object):
             wait (bool, optional): Wait for the PV t set before returning
         """
         def _put_value():
-            from genie_python.genie_cachannel_wrapper import CaChannelWrapper
             CaChannelWrapper.set_pv_value(name, value, wait)
 
         if wait:
@@ -160,7 +135,6 @@ class ChannelAccess(object):
         Returns:
             True if exists, otherwise False.
         """
-        from genie_python.genie_cachannel_wrapper import CaChannelWrapper, EXIST_TIMEOUT
         if timeout is None:
             timeout = EXIST_TIMEOUT
         return CaChannelWrapper.pv_exists(name, timeout)
@@ -176,11 +150,7 @@ class ChannelAccess(object):
                 alarm severity (AlarmSeverity),
                 alarm status (AlarmStatus)
         """
-        from genie_python.genie_cachannel_wrapper import CaChannelWrapper
-
-        def _intermediate_callback(value, severity, status):
-            call_back_function(value, AlarmSeverity.from_ca_channel(severity), AlarmStatus.from_ca_channel(status))
-        CaChannelWrapper.add_monitor(name, _intermediate_callback)
+        CaChannelWrapper.add_monitor(name, call_back_function)
 
     @staticmethod
     def poll():
@@ -188,5 +158,4 @@ class ChannelAccess(object):
         Flush the send buffer and execute any outstanding background activity for all connected pvs.
         NB Connected pv is one which is in the cache
         """
-        from genie_python.genie_cachannel_wrapper import CaChannelWrapper
         CaChannelWrapper.poll()


### PR DESCRIPTION
Remove genie_python as a global import to avoid test failures if genie_python is not installed. It is only needed when accessing actual pvs,
