### PR TITLE
Ticket3539 do not move unchanged components

### DIFF
--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -343,13 +343,19 @@ class Beamline(object):
         for key, value in self._active_mode.initial_setpoints.items():
             self._beamline_parameters[key].sp_no_move = value
 
+    def _get_drivers_not_at_setpoint(self):
+        """
+        Returns: A list of all drivers that are not already at their set point, i.e. need to be moved.
+        """
+        return [driver for driver in self._drivers if not driver.at_target_setpoint()]
+
     def _move_drivers(self, move_duration):
-        for driver in self._drivers:
+        for driver in self._get_drivers_not_at_setpoint():
             driver.perform_move(move_duration)
 
     def _get_max_move_duration(self):
         max_move_duration = 0.0
-        for driver in self._drivers:
+        for driver in self._get_drivers_not_at_setpoint():
             max_move_duration = max(max_move_duration, driver.get_max_move_duration())
 
         return max_move_duration

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -2,7 +2,6 @@
 The driving layer communicates between the component layer and underlying pvs.
 """
 
-from decimal import Decimal
 import math
 import logging
 

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -5,7 +5,6 @@ The driving layer communicates between the component layer and underlying pvs.
 from decimal import Decimal
 import math
 import logging
-from server_common.utilities import trunc_float
 
 logger = logging.getLogger(__name__)
 
@@ -96,13 +95,14 @@ class IocDriver(object):
 
     def at_target_setpoint(self):
         """
-        Returns: True if the setpoint on the component and the one on the motor PV differ, False if they are the same.
-            (Truncated to precision of the motor pv)
+        Returns: True if the setpoint on the component and the one on the motor PV are the same (within tolerance),
+            False if they differ.
         """
         if self._sp_cache is None:
             return False
-        pv_prec = abs(Decimal(str(self._sp_cache)).as_tuple().exponent)
-        return trunc_float(self._get_set_point_position(), pv_prec) == self._sp_cache
+
+        difference = abs(self._get_set_point_position() - self._sp_cache)
+        return difference < self._axis.resolution
 
 
 class DisplacementDriver(IocDriver):

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -28,6 +28,9 @@ class PVWrapper(object):
         self._after_rbv_change_listeners = set()
         self._after_sp_change_listeners = set()
 
+        self._monitor_pv(self._rbv_pv, self._trigger_after_rbv_change_listeners)
+        self._monitor_pv(self._sp_pv, self._trigger_after_sp_change_listeners)
+
     def _set_pvs(self):
         self._rbv_pv = ""
         self._sp_pv = ""
@@ -147,8 +150,6 @@ class MotorPVWrapper(PVWrapper):
         """
         super(MotorPVWrapper, self).__init__(base_pv)
 
-        self._monitor_pv(self._rbv_pv, self._trigger_after_rbv_change_listeners)
-
     def _set_pvs(self):
         self._sp_pv = self._prefixed_pv
         self._rbv_pv = "{}.RBV".format(self._prefixed_pv)
@@ -193,9 +194,6 @@ class AxisPVWrapper(PVWrapper):
         """
         super(AxisPVWrapper, self).__init__(base_pv)
 
-        self._monitor_pv(self._sp_pv, self._trigger_after_sp_change_listeners)
-        self._monitor_pv(self._rbv_pv, self._trigger_after_rbv_change_listeners)
-
     def _set_pvs(self):
         self._sp_pv = "{}:SP".format(self._prefixed_pv)
         self._rbv_pv = self._prefixed_pv
@@ -213,8 +211,6 @@ class VerticalJawsPVWrapper(PVWrapper):
         :param pv_name (string): The name of the PV
         """
         super(VerticalJawsPVWrapper, self).__init__(base_pv)
-
-        self._monitor_pv(self._rbv_pv, self._trigger_after_rbv_change_listeners)
 
     def _set_pvs(self):
         self._sp_pv = "{}:VCENT:SP".format(self._prefixed_pv)

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -114,6 +114,9 @@ class PVWrapper(object):
 
     @property
     def resolution(self):
+        """
+        Returns: The motor resolution for this axis.
+        """
         return self._resolution
 
     @property

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -223,8 +223,9 @@ class VerticalJawsPVWrapper(PVWrapper):
         self._rbv_pv = "{}:VCENT".format(self._prefixed_pv)
 
     def _set_resolution(self):
-        motor_resolutions = self._pv_names_for_directions("MTR.MRES")
-        self._resolution = float(sum(motor_resolutions)) / len(motor_resolutions)
+        motor_resolutions_pvs = self._pv_names_for_directions("MTR.MRES")
+        motor_resolutions = [self._read_pv(motor_resolutions_pv) for motor_resolutions_pv in motor_resolutions_pvs]
+        self._resolution = float(sum(motor_resolutions)) / len(motor_resolutions_pvs)
 
     @property
     def velocity(self):

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -23,6 +23,7 @@ class PVWrapper(object):
         """
         self._prefixed_pv = "{}{}".format(MYPVPREFIX, base_pv)
         self._set_pvs()
+        self._set_resolution()
 
         self._after_rbv_change_listeners = set()
         self._after_sp_change_listeners = set()
@@ -30,6 +31,9 @@ class PVWrapper(object):
     def _set_pvs(self):
         self._rbv_pv = ""
         self._sp_pv = ""
+
+    def _set_resolution(self):
+        self._resolution = 0
 
     @staticmethod
     def _monitor_pv(pv, call_back_function):
@@ -109,6 +113,10 @@ class PVWrapper(object):
         return self._prefixed_pv
 
     @property
+    def resolution(self):
+        return self._resolution
+
+    @property
     def sp(self):
         """
         Returns: the value of the underlying PV
@@ -141,6 +149,9 @@ class MotorPVWrapper(PVWrapper):
     def _set_pvs(self):
         self._sp_pv = self._prefixed_pv
         self._rbv_pv = "{}.RBV".format(self._prefixed_pv)
+
+    def _set_resolution(self):
+        self._resolution = self._read_pv("{}.MRES".format(self._prefixed_pv))
 
     @property
     def velocity(self):
@@ -205,6 +216,10 @@ class VerticalJawsPVWrapper(PVWrapper):
     def _set_pvs(self):
         self._sp_pv = "{}:VCENT:SP".format(self._prefixed_pv)
         self._rbv_pv = "{}:VCENT".format(self._prefixed_pv)
+
+    def _set_resolution(self):
+        motor_resolutions = self._pv_names_for_directions("MTR.MRES")
+        self._resolution = float(sum(motor_resolutions)) / len(motor_resolutions)
 
     @property
     def velocity(self):

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -1,14 +1,12 @@
 """
 Test data and classes.
 """
-from mock import MagicMock
 from utils import DEFAULT_TEST_TOLERANCE
 
 from ReflectometryServer.beamline import BeamlineMode, Beamline
 from ReflectometryServer.components import Component, TiltingComponent, ThetaComponent
-from ReflectometryServer.geometry import PositionAndAngle, PositionAndAngle
+from ReflectometryServer.geometry import PositionAndAngle
 from ReflectometryServer.ioc_driver import DisplacementDriver, AngleDriver
-from ReflectometryServer.pv_wrapper import MotorPVWrapper
 from ReflectometryServer.parameters import BeamlineParameter, TrackingPosition, AngleParameter
 
 

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -2,6 +2,7 @@
 Test data and classes.
 """
 from mock import MagicMock
+from utils import DEFAULT_TEST_TOLERANCE
 
 from ReflectometryServer.beamline import BeamlineMode, Beamline
 from ReflectometryServer.components import Component, TiltingComponent, ThetaComponent
@@ -125,6 +126,7 @@ class MockMotorPVWrapper(object):
         self._value = init_position
         self.max_velocity = max_velocity
         self.velocity = None
+        self.resolution = DEFAULT_TEST_TOLERANCE
         self.after_rbv_change_listener = set()
         self.after_sp_change_listener = set()
 

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -125,10 +125,14 @@ class MockMotorPVWrapper(object):
         self._value = init_position
         self.max_velocity = max_velocity
         self.velocity = None
-        self.after_value_change_listener = set()
+        self.after_rbv_change_listener = set()
+        self.after_sp_change_listener = set()
 
     def add_after_rbv_change_listener(self, listener):
-        self.after_value_change_listener.add(listener)
+        self.after_rbv_change_listener.add(listener)
+
+    def add_after_sp_change_listener(self, listener):
+        self.after_sp_change_listener.add(listener)
 
     @property
     def sp(self):
@@ -137,5 +141,5 @@ class MockMotorPVWrapper(object):
     @sp.setter
     def sp(self, new_value):
         self._value = new_value
-        for listener in self.after_value_change_listener:
+        for listener in self.after_rbv_change_listener:
             listener(new_value, None, None)

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -141,6 +141,8 @@ class MockMotorPVWrapper(object):
     @sp.setter
     def sp(self, new_value):
         self._value = new_value
+        for listener in self.after_sp_change_listener:
+            listener(new_value, None, None)
         for listener in self.after_rbv_change_listener:
             listener(new_value, None, None)
 

--- a/ReflectometryServer/test_modules/test_ioc_driving_layer.py
+++ b/ReflectometryServer/test_modules/test_ioc_driving_layer.py
@@ -234,6 +234,48 @@ class TestHeightDriverInAndOutOfBeam(unittest.TestCase):
         assert_that(self.jaws.beam_path_rbv.is_in_beam, is_(expected_value))
 
 
+class TestDriverChanged(unittest.TestCase):
+    def setUp(self):
+        start_position = 0.0
+        max_velocity = 10.0
+        self.height_axis = create_mock_axis("JAWS:HEIGHT", start_position, max_velocity)
+
+        self.jaws = Component("component", setup=PositionAndAngle(0.0, 10.0, 90.0))
+        self.jaws.beam_path_set_point.set_incoming_beam(PositionAndAngle(0.0, 0.0, 0.0))
+
+        self.jaws_driver = DisplacementDriver(self.jaws, self.height_axis)
+
+    def test_GIVEN_value_not_initialised_THEN_driver_reports_not_at_setpoint(self):
+        expected = False
+
+        actual = self.jaws_driver.at_target_setpoint()
+
+        assert_that(actual, is_(expected))
+
+    def test_GIVEN_sp_value_set_and_not_moved_to_THEN_driver_reports_not_at_setpoint(self):
+        expected = False
+
+        actual = self.jaws_driver.at_target_setpoint()
+
+        assert_that(actual, is_(expected))
+
+    def test_GIVEN_sp_value_set_and_moved_to_THEN_driver_reports_at_setpoint(self):
+        expected = True
+
+        self.jaws_driver.perform_move(1)
+        actual = self.jaws_driver.at_target_setpoint()
+
+        assert_that(actual, is_(expected))
+
+    def test_GIVEN_component_sp_is_more_precise_than_motor_sp_WHEN_comparing_THEN_component_sp_is_truncated_correctly(self):
+        expected = True
+
+        self.jaws_driver.perform_move(1)
+        actual = self.jaws_driver.at_target_setpoint()
+
+        assert_that(actual, is_(expected))
+
+
 class BeamlineMoveDurationTest(unittest.TestCase):
     def test_GIVEN_multiple_components_in_beamline_WHEN_triggering_move_THEN_components_move_at_speed_of_slowest_axis(self):
         sm_angle = 0.0

--- a/ReflectometryServer/test_modules/test_ioc_driving_layer.py
+++ b/ReflectometryServer/test_modules/test_ioc_driving_layer.py
@@ -254,8 +254,18 @@ class TestDriverChanged(unittest.TestCase):
 
         assert_that(actual, is_(expected))
 
+    def test_GIVEN_axis_and_component_position_match_THEN_driver_reports_at_setpoint(self):
+        expected = True
+        self.height_axis.sp = 0.0
+
+        actual = self.jaws_driver.at_target_setpoint()
+
+        assert_that(actual, is_(expected))
+
     def test_GIVEN_sp_value_set_and_not_moved_to_THEN_driver_reports_not_at_setpoint(self):
         expected = False
+        self.height_axis.sp = 0.0
+        self.jaws.beam_path_set_point.set_position_relative_to_beam(1.0)
 
         actual = self.jaws_driver.at_target_setpoint()
 
@@ -263,16 +273,20 @@ class TestDriverChanged(unittest.TestCase):
 
     def test_GIVEN_sp_value_set_and_moved_to_THEN_driver_reports_at_setpoint(self):
         expected = True
+        self.height_axis.sp = 0.0
+        self.jaws.beam_path_set_point.set_position_relative_to_beam(1.0)
 
         self.jaws_driver.perform_move(1)
         actual = self.jaws_driver.at_target_setpoint()
 
         assert_that(actual, is_(expected))
 
-    def test_GIVEN_component_sp_is_more_precise_than_motor_sp_WHEN_comparing_THEN_component_sp_is_truncated_correctly(self):
+    def test_GIVEN_component_sp_is_within_motor_resolution_WHEN_comparing_to_motor_setpoint_THEN_driver_reports_at_setpoint(self):
         expected = True
+        # DEFAULT_TEST_TOLERANCE is 1e-9
+        self.height_axis.sp = 0.123456789
+        self.jaws.beam_path_set_point.set_position_relative_to_beam(0.1234567890123456789)
 
-        self.jaws_driver.perform_move(1)
         actual = self.jaws_driver.at_target_setpoint()
 
         assert_that(actual, is_(expected))

--- a/server_common/utilities.py
+++ b/server_common/utilities.py
@@ -304,18 +304,3 @@ def remove_from_end(string, text_to_remove):
         return string[:-len(text_to_remove)]
     return string
 
-
-def trunc_float(f, precision=9):
-    """
-    Truncate a float value to a given decimal precision.
-
-    Args:
-        f: The float value to truncate
-        precision: The desired decimal precision
-
-    Returns: The truncated value
-    """
-    scalar = 10 ** precision
-    truncated = math.trunc(f * scalar)
-    truncated = float(truncated) / scalar
-    return truncated

--- a/server_common/utilities.py
+++ b/server_common/utilities.py
@@ -21,7 +21,6 @@ import time
 import zlib
 import re
 import json
-import math
 from xml.etree import ElementTree
 
 from server_common.loggers.logger import Logger
@@ -303,4 +302,3 @@ def remove_from_end(string, text_to_remove):
     if string is not None and string.endswith(text_to_remove):
         return string[:-len(text_to_remove)]
     return string
-

--- a/server_common/utilities.py
+++ b/server_common/utilities.py
@@ -21,6 +21,7 @@ import time
 import zlib
 import re
 import json
+import math
 from xml.etree import ElementTree
 
 from server_common.loggers.logger import Logger
@@ -302,3 +303,19 @@ def remove_from_end(string, text_to_remove):
     if string is not None and string.endswith(text_to_remove):
         return string[:-len(text_to_remove)]
     return string
+
+
+def trunc_float(f, precision=9):
+    """
+    Truncate a float value to a given decimal precision.
+
+    Args:
+        f: The float value to truncate
+        precision: The desired decimal precision
+
+    Returns: The truncated value
+    """
+    scalar = 10 ** precision
+    truncated = math.trunc(f * scalar)
+    truncated = float(truncated) / scalar
+    return truncated


### PR DESCRIPTION
### Description of work

Made changes so that no move instruction is issued to motors that are already in position. This is checked at the IOC driver level by comparing the component (beam path) level setpoint in the reflectometry IOC against the setpoint value of the relevant motor axis. If they are within tolerance (=motor resolution), it does not try to move them.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3539

### Acceptance criteria

- System issues move command if component setpoint and motor setpoint are out of step
    - [x] After beam path change (e.g. if just `theta` is moved --> `caput` to the motors for `s3`, `s4`, `detector`, ...height,  but not to the motors for `s1`, `s2`, `supermirror`, ...height)
    - [x] After parameter change, (e.g. moving just `track_s2` only issues a `caput` to the s2 height motor axis)
    - [x] When writing to the `:SP` of the underlying motor directly, this change is registered in the IOC driver.
    - [x] When stopping motors during a move, then issuing another move, the original move is completed

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
