### PR TITLE
Add listener at driver level

### DIFF
--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -180,6 +180,8 @@ class ReflectometryDriver(Driver):
             parameter = self._beamline.parameter(param_name)
             if param_sort == PvSort.RBV:
                 parameter.add_rbv_change_listener(partial(self._update_param_listener, pv_name))
+            if param_sort == PvSort.SP_RBV:
+                parameter.add_sp_rbv_change_listener(partial(self._update_param_listener, pv_name))
 
     def add_trigger_active_mode_change_listener(self):
         """


### PR DESCRIPTION
### Description of work

Fixes a bug where parameters in the reflectometry IOC wrapping a motor would not get updated properly when an underlying PV is written to directly. Currently only relevant for slit gap parameters.

Required for testing:
- Set up a Jawset on a simulated Galil
- Set up a `config.py` configuration file in `<machine>\configurations\refl\` that contains a slit gap parameter pointing at the jaw set. Below is a minimal config that should work. (Talk to me if this gives you any problems)
- Start the `REFL` IOC

```
from ReflectometryServer import *


def get_beamline():
    vgap = SlitGapParameter("S1VG", AxisPVWrapper("MOT:JAWS:VGAP"), True, sim=True, init = 0)
    
    mode = BeamlineMode("mode", [])

    beam_start = PositionAndAngle(0.0, 0.0, 0.0)
    bl = Beamline([], [vgap], [mode], [], beam_start)

    return bl
```
### To test

https://github.com/ISISComputingGroup/IBEX/issues/4081

### Acceptance criteria

- [ ] Writing to Jaws PVs that affect the vgap should appropriately feed up to the beamline parameter defined in the reflectometry server. (you should be able to see this on the front panel)
- [ ] Same if you write to the underlying motor PV (e.g. `MOT:MTR0102` if `JAWS:JS` is mapped to `MTR0102` 
---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
