### PR TITLE
Cache the last config on config change

### DIFF
--- a/BlockServer/core/active_config_holder.py
+++ b/BlockServer/core/active_config_holder.py
@@ -64,13 +64,13 @@ class ActiveConfigHolder(ConfigHolder):
         super(ActiveConfigHolder, self).set_config(conf, False)
         self.set_last_config(name)
 
-    def update_archiver(self):
+    def update_archiver(self, full_init=False):
         """ Update the archiver configuration.
 
         Args:
-            blocks_changed (bool): Have the blocks changed?
+            full_init: if True restart; if False only restart if blocks have changed
         """
-        if self.blocks_changed():
+        if self.blocks_changed() or full_init:
             self._archive_manager.update_archiver(MACROS["$(MYPVPREFIX)"] + BLOCK_PREFIX,
                                                   super(ActiveConfigHolder, self).get_block_details().values())
 
@@ -166,6 +166,10 @@ class ActiveConfigHolder(ConfigHolder):
         Returns:
             bool : True if blocks have changed, False otherwise
         """
+
+        # As a hotfix #4090 this will get round inconsitencies with cache config
+        return True
+
         blocks_changed = False
 
         # Check for any new or changed blocks

--- a/BlockServer/core/config_holder.py
+++ b/BlockServer/core/config_holder.py
@@ -423,6 +423,7 @@ class ConfigHolder(object):
             config (Configuration): A configuration
             is_component (bool, optional): Whether it is a component
         """
+        self._cache_config()
         self.clear_config()
         self._config = config
         self._is_component = is_component

--- a/BlockServer/epics/procserv_utils.py
+++ b/BlockServer/epics/procserv_utils.py
@@ -43,7 +43,7 @@ class ProcServWrapper(object):
             ioc (string): The name of the IOC
         """
         print_and_log("Stopping IOC %s" % ioc)
-        ChannelAccess.caput(self.procserv_prefix + ioc + ":STOP", 1)
+        ChannelAccess.caput(self.procserv_prefix + ioc + ":STOP", 1, wait=True)
 
     def restart_ioc(self, ioc):
         """Restarts the specified IOC.

--- a/BlockServer/test_modules/test_active_config_holder.py
+++ b/BlockServer/test_modules/test_active_config_holder.py
@@ -139,6 +139,28 @@ class TestActiveConfigHolderSequence(unittest.TestCase):
         self.assertTrue("SIMPLE1" in iocs)
         self.assertTrue("SIMPLE2" in iocs)
 
+    @unittest.skipIf(IS_LINUX, "Location of last_config.txt not correctly configured on Linux")
+    def test_GIVEN_load_config_WHEN_load_config_again_THEN_no_ioc_changes(self):
+        # This test is checking that a load will correctly cache the IOCs that are running so that a comparison will
+        # return no change
+        cs = self.activech
+        add_basic_blocks_and_iocs(cs)
+        cs.save_active("TEST_CONFIG")
+        cs.clear_config()
+        blocks = cs.get_blocknames()
+        self.assertEquals(len(blocks), 0)
+        iocs = cs.get_ioc_names()
+        self.assertEqual(len(iocs), 0)
+        cs.load_active("TEST_CONFIG")
+
+        cs.load_active("TEST_CONFIG")
+
+        iocs_to_start, iocs_to_restart, iocs_to_stop = cs.iocs_changed()
+        self.assertEqual(len(iocs_to_start), 0)
+        self.assertEqual(len(iocs_to_restart), 0)
+        self.assertEqual(len(iocs_to_stop), 0)
+
+
     def test_load_notexistant_config(self):
         cs = self.activech
         self.assertRaises(IOError, lambda: cs.load_active("DOES_NOT_EXIST"))
@@ -330,7 +352,7 @@ class TestActiveConfigHolderSequence(unittest.TestCase):
         ch.set_config_details(details)
         # Act
         ch.set_config_details(details)
-        ch.update_archiver()
+        ch.update_archiver(False)
         # Assert
         self.assertFalse(self.mock_archive.update_archiver.called)
 
@@ -343,7 +365,19 @@ class TestActiveConfigHolderSequence(unittest.TestCase):
         # Act
         details['blocks'].append(Block(name="TESTNAME2", pv="TESTPV2").to_dict())
         ch.set_config_details(details)
-        ch.update_archiver()
+        ch.update_archiver(False)
+        # Assert
+        self.assertTrue(self.mock_archive.update_archiver.called)
+
+    def test_given_no_blocks_changed_but_full_init_when_update_archiver_archiver_is_restarted(self):
+        # Arrange
+        ch = self.create_ach()
+        details = ch.get_config_details()
+        details['blocks'].append(Block(name="TESTNAME", pv="TESTPV").to_dict())
+        ch.set_config_details(details)
+        # Act
+        ch.set_config_details(details)
+        ch.update_archiver(True)
         # Assert
         self.assertTrue(self.mock_archive.update_archiver.called)
 

--- a/block_server.py
+++ b/block_server.py
@@ -339,7 +339,7 @@ class BlockServer(Driver):
         self.update_blocks_monitors()
 
         self.update_get_details_monitors()
-        self._active_configserver.update_archiver()
+        self._active_configserver.update_archiver(full_init)
         for h in self.on_the_fly_handlers:
                 h.on_config_change(full_init)
 


### PR DESCRIPTION
### Description of work

Config is not cached on change so that check if anything changed since last change does not work. Correctly cache config on change. Also remove check on blocks changed always restart block archiver, to be but right with more testing later.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4090

### Acceptance criteria

1. Workflow stated works
1. Test when IOC is in a component and not in a component
    1. Test on load of config and edit of current config 
        1. If macro changed then IOC reloaded
        1. If macro not changed IOC not reloaded
1. Code can be applied as a hot fix and details are in ticket #4107 (https://github.com/ISISComputingGroup/IBEX/issues/4107)

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
