### PR TITLE
Handle disconnected PVs

### DIFF
--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -5,8 +5,9 @@ from functools import partial
 
 from pcaspy import Driver, Alarm, Severity
 
-from ReflectometryServer.ChannelAccess.pv_manager import PvSort, BEAMLINE_MODE, VAL_FIELD, BEAMLINE_STATUS, SP_SUFFIX, \
-    FootprintSort, FP_TEMPLATE, DQQ_TEMPLATE, QMIN_TEMPLATE, QMAX_TEMPLATE, convert_from_epics_pv_value
+from ReflectometryServer.ChannelAccess.pv_manager import PvSort, BEAMLINE_MODE, VAL_FIELD, BEAMLINE_STATUS, \
+    BEAMLINE_MESSAGE, SP_SUFFIX, FootprintSort, FP_TEMPLATE, DQQ_TEMPLATE, QMIN_TEMPLATE, QMAX_TEMPLATE, \
+    convert_from_epics_pv_value
 from ReflectometryServer.parameters import BeamlineParameterGroup
 from server_common.utilities import compress_and_hex
 
@@ -39,6 +40,7 @@ class ReflectometryDriver(Driver):
 
         self.add_param_listeners()
         self.add_trigger_active_mode_change_listener()
+        self.add_trigger_status_change_listener()
         self.add_footprint_param_listeners()
 
     def read(self, reason):
@@ -185,7 +187,7 @@ class ReflectometryDriver(Driver):
 
     def add_trigger_active_mode_change_listener(self):
         """
-        Adds the monitor on the active mode, if this changes a monitor is posted.
+        Adds the monitor on the active mode, if this changes a monitor update is posted.
         """
         def _bl_mode_change(mode):
             mode_value = self._beamline_mode_value(mode)
@@ -193,6 +195,18 @@ class ReflectometryDriver(Driver):
             self._update_param(BEAMLINE_MODE + SP_SUFFIX, mode_value)
             self.updatePVs()
         self._beamline.add_active_mode_change_listener(_bl_mode_change)
+
+    def add_trigger_status_change_listener(self):
+        """
+        Adds the monitor on the beamline status, if this changes a monitor update is posted.
+        """
+        def _bl_status_change(status, message):
+            beamline_status_enums = self._pv_manager.PVDB[BEAMLINE_STATUS]["enums"]
+            status_id = beamline_status_enums.index(status.display_string)
+            self._update_param(BEAMLINE_STATUS, status_id)
+            self._update_param(BEAMLINE_MESSAGE, message)
+            self.updatePVs()
+        self._beamline.add_status_change_listener(_bl_status_change)
 
     def add_footprint_param_listeners(self):
         """

--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -64,7 +64,7 @@ class ReflectometryDriver(Driver):
 
         elif self._pv_manager.is_beamline_status(reason):
             beamline_status_enums = self._pv_manager.PVDB[BEAMLINE_STATUS]["enums"]
-            new_value = beamline_status_enums.index(self._beamline.status.name)
+            new_value = beamline_status_enums.index(self._beamline.status.display_string)
             #  Set the value so that the error condition is set
             self.setParam(reason, new_value)
             return new_value

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -307,7 +307,11 @@ class Beamline(object):
         for beamline_parameter in parameters:
             if beamline_parameter in parameters_in_mode or beamline_parameter.sp_changed:
                 beamline_parameter.move_to_sp_no_callback()
-        self._move_drivers(self._get_max_move_duration())
+        try:
+            self._move_drivers(self._get_max_move_duration())
+        except ValueError:
+            # TODO set error on server
+            pass
 
     def _move_for_single_beamline_parameters(self, source):
         """

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -309,8 +309,8 @@ class Beamline(object):
                 beamline_parameter.move_to_sp_no_callback()
         try:
             self._move_drivers(self._get_max_move_duration())
-        except ValueError:
-            # TODO set error on server
+        except ValueError as e:
+            self.set_status(STATUS.GENERAL_ERROR, e.message)
             pass
 
     def _move_for_single_beamline_parameters(self, source):

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -348,15 +348,17 @@ class Beamline(object):
 
     def _move_drivers(self):
         """
-        Move motor drivers at speed of slowest axis. Set server status to okay if move successful; set to error if not.
+        Issue move for all drivers at the speed of the slowest axis and set appropriate status for failure/success.
         """
         try:
-            move_duration = self._get_max_move_duration()
-            for driver in self._drivers:
-                driver.perform_move(move_duration)
-                self.set_status(STATUS.OKAY, "")
+            self._perform_move_for_all_drivers(self._get_max_move_duration())
+            self.set_status(STATUS.OKAY, "")
         except (ValueError, UnableToConnectToPVException) as e:
             self.set_status(STATUS.GENERAL_ERROR, e.message)
+
+    def _perform_move_for_all_drivers(self, move_duration):
+        for driver in self._drivers:
+            driver.perform_move(move_duration)
 
     def _get_max_move_duration(self):
         max_move_duration = 0.0

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -11,6 +11,8 @@ from ReflectometryServer.geometry import PositionAndAngle
 from ReflectometryServer.footprint_calc import BaseFootprintSetup
 from ReflectometryServer.footprint_manager import FootprintManager
 
+from server_common.channel_access import UnableToConnectToPVException
+
 logger = logging.getLogger(__name__)
 
 
@@ -309,9 +311,9 @@ class Beamline(object):
                 beamline_parameter.move_to_sp_no_callback()
         try:
             self._move_drivers(self._get_max_move_duration())
-        except ValueError as e:
+            self.set_status(STATUS.OKAY, "")
+        except (ValueError, UnableToConnectToPVException) as e:
             self.set_status(STATUS.GENERAL_ERROR, e.message)
-            pass
 
     def _move_for_single_beamline_parameters(self, source):
         """

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -21,7 +21,8 @@ class IocDriver(object):
         """
         self._component = component
         self._axis = axis
-        self._axis.add_after_rbv_change_listener(self._trigger_after_axis_value_change_listener)
+        self._rbv_cache = self._axis.rbv
+        self._axis.add_after_rbv_change_listener(self._rbv_change_listener)
 
     def __repr__(self):
         return "{} for axis pv {} and component {}".format(
@@ -56,11 +57,21 @@ class IocDriver(object):
 
         self._axis.sp = self._get_set_point_position()
 
+    def rbv_cache(self):
+        """
+        Return the last cached readback value of the underlying motor if one exists; throws an exception otherwise.
+
+        Returns: The cached readback value for the motor
+        """
+        if self._rbv_cache is None:
+            raise ValueError("Value for axis {} not initialised. Please check the PV exists.".format(self._axis))
+        return self._rbv_cache
+
     def _get_distance(self):
         """
         :return: The distance between the target component position and the actual motor position in y.
         """
-        return math.fabs(self._axis.sp - self._get_set_point_position())
+        return math.fabs(self.rbv_cache() - self._get_set_point_position())
 
     def _get_set_point_position(self):
         """
@@ -70,15 +81,28 @@ class IocDriver(object):
         """
         raise NotImplemented()
 
-    def _trigger_after_axis_value_change_listener(self, new_value, alarm_severity, alarm_status):
+    def _rbv_change_listener(self, new_value, alarm_severity, alarm_status):
         """
-        Trigger all listeners after an axis value change.
+        Listener to trigger on a change of the readback value of the underlying motor.
+
         Args:
             new_value: new axis value that is given
             alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
             alarm_status (server_common.channel_access.AlarmCondition): the alarm status
         """
+        self._rbv_cache = new_value
+        self._propagate_rbv_change(new_value, alarm_severity, alarm_status)
 
+    def _propagate_rbv_change(self, new_value, alarm_severity, alarm_status):
+        """
+        Signal that the motor readback value has changed to the middle component layer. Subclass must implement this
+        method.
+
+        Args:
+            new_value: new axis value that is given
+            alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
+            alarm_status (server_common.channel_access.AlarmCondition): the alarm status
+        """
         raise NotImplemented()
 
 
@@ -101,9 +125,10 @@ class DisplacementDriver(IocDriver):
         self._out_of_beam_position = out_of_beam_position
         self._tolerance_on_out_of_beam_position = tolerance_on_out_of_beam_position
 
-    def _trigger_after_axis_value_change_listener(self, new_value, alarm_severity, alarm_status):
+    def _propagate_rbv_change(self, new_value, alarm_severity, alarm_status):
         """
-        Trigger all listeners after a height change.
+        Propagate the new height to the middle component layer.
+
         Args:
             new_value: new height that is given
             alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
@@ -146,9 +171,10 @@ class AngleDriver(IocDriver):
         """
         super(AngleDriver, self).__init__(component, angle_axis)
 
-    def _trigger_after_axis_value_change_listener(self, new_value, alarm_severity, alarm_status):
+    def _propagate_rbv_change(self, new_value, alarm_severity, alarm_status):
         """
-        Trigger all listeners after a angle change.
+        Propagate the new angle to the middle component layer.
+
         Args:
             new_value: new angle given
             alarm_severity (CaChannel._ca.AlarmSeverity): severity of any alarm

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -64,7 +64,7 @@ class IocDriver(object):
         Returns: The cached readback value for the motor
         """
         if self._rbv_cache is None:
-            raise ValueError("Axis {} not initialised.".format(self._axis))
+            raise ValueError("Axis {} not initialised. Check configuration is correct and motor IOC is running.".format(self._axis.name))
         return self._rbv_cache
 
     def _get_distance(self):

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -64,7 +64,7 @@ class IocDriver(object):
         Returns: The cached readback value for the motor
         """
         if self._rbv_cache is None:
-            raise ValueError("Value for axis {} not initialised. Please check the PV exists.".format(self._axis))
+            raise ValueError("Axis {} not initialised.".format(self._axis))
         return self._rbv_cache
 
     def _get_distance(self):

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -111,18 +111,27 @@ class PVWrapper(object):
     @property
     def sp(self):
         """
-        Returns: the value of the underlying PV
+        Returns: the value of the underlying setpoint PV
         """
         return self._read_pv(self._sp_pv)
 
     @sp.setter
     def sp(self, value):
         """
-        Writes a value to the underlying PV's VAL field.
+        Writes a value to the underlying setpoint PV
+
         Args:
             value: The value to set
         """
         self._write_pv(self._sp_pv, value)
+
+    @property
+    def rbv(self):
+        """
+        Returns: the value of the underlying readback PV
+        """
+        return self._read_pv(self._rbv_pv)
+
 
 
 class MotorPVWrapper(PVWrapper):

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -54,11 +54,12 @@ class PVWrapper(object):
         Args:
             pv(String): The pv to read
         """
-        try:
-            return ChannelAccess.caget(pv)
-        except UnableToConnectToPVException:
-            logger.error("Error reading value from {}: PV does not exist".format(pv))
-            return None
+        value = ChannelAccess.caget(pv)
+        if value is not None:
+            return value
+        else:
+            logger.error("Could not connect to PV {}.".format(pv))
+            raise UnableToConnectToPVException(pv, "Check configuration is correct and IOC is running.")
 
     @staticmethod
     def _write_pv(pv, value):
@@ -69,10 +70,7 @@ class PVWrapper(object):
             pv(String): The PV to write to
             value: The new value
         """
-        try:
-            ChannelAccess.caput(pv, value)
-        except UnableToConnectToPVException:
-            logger.error("Error writing value to {}: PV does not exist".format(pv))
+        ChannelAccess.caput(pv, value)
 
     def add_after_rbv_change_listener(self, listener):
         """
@@ -133,7 +131,6 @@ class PVWrapper(object):
         return self._read_pv(self._rbv_pv)
 
 
-
 class MotorPVWrapper(PVWrapper):
     """
     Wrap the motor PVs to allow easy access to all motor PV values needed.
@@ -156,7 +153,7 @@ class MotorPVWrapper(PVWrapper):
         """
         Returns: the value of the underlying velocity PV
         """
-        return ChannelAccess.caget(self._prefixed_pv + ".VELO")
+        return self._read_pv(self._prefixed_pv + ".VELO")
 
     @velocity.setter
     def velocity(self, value):
@@ -166,14 +163,14 @@ class MotorPVWrapper(PVWrapper):
         Args:
             value: The value to set
         """
-        ChannelAccess.caput(self._prefixed_pv + ".VELO", value)
+        self._write_pv(self._prefixed_pv + ".VELO", value)
 
     @property
     def max_velocity(self):
         """
         Returns: the value of the underlying max velocity PV
         """
-        return ChannelAccess.caget(self._prefixed_pv + ".VMAX")
+        return self._read_pv(self._prefixed_pv + ".VMAX")
 
 
 class AxisPVWrapper(PVWrapper):
@@ -221,7 +218,7 @@ class VerticalJawsPVWrapper(PVWrapper):
         Returns: the value of the underlying velocity PV
         """
         motor_velocities = self._pv_names_for_directions("MTR.VELO")
-        return max([ChannelAccess.caget(pv) for pv in motor_velocities])
+        return max([self._read_pv(pv) for pv in motor_velocities])
 
     @velocity.setter
     def velocity(self, value):
@@ -233,7 +230,7 @@ class VerticalJawsPVWrapper(PVWrapper):
         """
         motor_velocities = self._pv_names_for_directions("MTR.VELO")
         for pv in motor_velocities:
-            ChannelAccess.caput(pv, value)
+            self._write_pv(pv, value)
 
     @property
     def max_velocity(self):
@@ -241,7 +238,7 @@ class VerticalJawsPVWrapper(PVWrapper):
         Returns: the value of the underlying max velocity PV
         """
         motor_velocities = self._pv_names_for_directions("MTR.VMAX")
-        return min([ChannelAccess.caget(pv) for pv in motor_velocities])
+        return min([self._read_pv(pv) for pv in motor_velocities])
 
     def _pv_names_for_directions(self, suffix):
         """

--- a/ReflectometryServer/reflectometry_server.py
+++ b/ReflectometryServer/reflectometry_server.py
@@ -29,7 +29,12 @@ logging.config.dictConfig({
             'handlers': ['default'],
             'level': 'DEBUG',
             'propagate': True
-        }
+        },
+    'pcaspy':{
+            'handlers': ['default'],
+            'level': 'INFO',
+            'propagate': True
+        },
     }
 })
 

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -139,3 +139,7 @@ class MockMotorPVWrapper(object):
         self._value = new_value
         for listener in self.after_value_change_listener:
             listener(new_value, None, None)
+
+    @property
+    def rbv(self):
+        return self._value

--- a/ReflectometryServer/test_modules/test_ioc_driving_layer.py
+++ b/ReflectometryServer/test_modules/test_ioc_driving_layer.py
@@ -283,7 +283,7 @@ class BeamlineMoveDurationTest(unittest.TestCase):
         expected_max_duration = 4.5
 
         smangle.sp_no_move = sm_angle_to_set
-        with patch.object(beamline, '_move_drivers') as mock:
+        with patch.object(beamline, '_perform_move_for_all_drivers') as mock:
             beamline.move = 1
 
             mock.assert_called_with(expected_max_duration)

--- a/ReflectometryServer/test_modules/test_ioc_driving_layer.py
+++ b/ReflectometryServer/test_modules/test_ioc_driving_layer.py
@@ -6,6 +6,8 @@ from mock import MagicMock, patch
 from hamcrest import *
 
 from ReflectometryServer import *
+from ReflectometryServer.beamline import STATUS
+from server_common.channel_access import UnableToConnectToPVException
 from ReflectometryServer.test_modules.data_mother import create_mock_axis
 
 FLOAT_TOLERANCE = 1e-9
@@ -235,9 +237,8 @@ class TestHeightDriverInAndOutOfBeam(unittest.TestCase):
 
 
 class BeamlineMoveDurationTest(unittest.TestCase):
-    def test_GIVEN_multiple_components_in_beamline_WHEN_triggering_move_THEN_components_move_at_speed_of_slowest_axis(self):
+    def setUp(self):
         sm_angle = 0.0
-        sm_angle_to_set = 22.5
         supermirror = ReflectingComponent("supermirror", setup=PositionAndAngle(y=0.0, z=10.0, angle=90.0))
         sm_height_axis = create_mock_axis("SM:HEIGHT", 0.0, 10.0)
         sm_angle_axis = create_mock_axis("SM:ANGLE", sm_angle, 10.0)
@@ -247,7 +248,7 @@ class BeamlineMoveDurationTest(unittest.TestCase):
 
         slit_2 = Component("slit_2", setup=PositionAndAngle(y=0.0, z=20.0, angle=90.0))
         slit_2_height_axis = create_mock_axis("SLIT2:HEIGHT", 0.0, 10.0)
-        slit_2_driver = DisplacementDriver(slit_2, slit_2_height_axis)
+        self.slit_2_driver = MagicMock(DisplacementDriver)
 
         slit_3 = Component("slit_3", setup=PositionAndAngle(y=0.0, z=30.0, angle=90.0))
         slit_3_height_axis = create_mock_axis("SLIT3:HEIGHT", 0.0, 10.0)
@@ -259,31 +260,42 @@ class BeamlineMoveDurationTest(unittest.TestCase):
         detector_driver_disp = DisplacementDriver(detector, detector_height_axis)
         detector_driver_ang = AngleDriver(detector, detector_tilt_axis)
 
-        smangle = AngleParameter("smangle", supermirror)
+        self.smangle = AngleParameter("smangle", supermirror)
         slit_2_pos = TrackingPosition("s2_pos", slit_2)
         slit_3_pos = TrackingPosition("s3_pos", slit_3)
         det_pos = TrackingPosition("det_pos", detector)
         det_ang = AngleParameter("det_ang", detector)
 
         components = [supermirror, slit_2, slit_3, detector]
-        beamline_parameters = [smangle, slit_2_pos, slit_3_pos, det_pos, det_ang]
-        drivers = [supermirror_driver_disp, supermirror_driver_ang, slit_2_driver, slit_3_driver, detector_driver_disp, detector_driver_ang]
-        mode = BeamlineMode("mode name", [smangle.name, slit_2_pos.name, slit_3_pos.name, det_pos.name, det_ang.name])
+        beamline_parameters = [self.smangle, slit_2_pos, slit_3_pos, det_pos, det_ang]
+        self.drivers = [supermirror_driver_disp, supermirror_driver_ang, self.slit_2_driver, slit_3_driver, detector_driver_disp, detector_driver_ang]
+        mode = BeamlineMode("mode name", [self.smangle.name, slit_2_pos.name, slit_3_pos.name, det_pos.name, det_ang.name])
         beam_start = PositionAndAngle(0.0, 0.0, 0.0)
-        beamline = Beamline(components, beamline_parameters, drivers, [mode], beam_start)
+        self.beamline = Beamline(components, beamline_parameters, self.drivers, [mode], beam_start)
 
-        beamline.active_mode = mode.name
+        self.beamline.active_mode = mode.name
 
         slit_2_pos.sp_no_move = 0.0
         slit_3_pos.sp_no_move = 0.0
         det_pos.sp_no_move = 0.0
         det_ang.sp_no_move = 0
 
+    def test_GIVEN_multiple_components_in_beamline_WHEN_triggering_move_THEN_components_move_at_speed_of_slowest_axis(self):
         # detector angle axis takes longest
         expected_max_duration = 4.5
+        sm_angle_to_set = 22.5
 
-        smangle.sp_no_move = sm_angle_to_set
-        with patch.object(beamline, '_perform_move_for_all_drivers') as mock:
-            beamline.move = 1
+        self.smangle.sp_no_move = sm_angle_to_set
+        with patch.object(self.beamline, '_perform_move_for_all_drivers') as mock:
+            self.beamline.move = 1
 
             mock.assert_called_with(expected_max_duration)
+
+    def test_GIVEN_driver_contains_disconnected_pv_WHEN_beamline_moves_THEN_status_set(self):
+        sm_angle_to_set = 22.5
+
+        self.smangle.sp_no_move = sm_angle_to_set
+        self.slit_2_driver.perform_move.side_effect = UnableToConnectToPVException("A_PV", "ERROR")
+        self.beamline.move = 1
+        assert_that(self.beamline.status, is_(STATUS.GENERAL_ERROR))
+


### PR DESCRIPTION
### Description of work

- [x] Server handles exception instead of crashing when trying to read a disconnected PV in the IOC driving layer.
- [x] When calculating move distance, motor readback value is used as current position instead of last setpoint. Also, readback value is cached via monitor so that not another separate `caget` needs to be issued.
- [x] Monitors for `REFL:BL:STAT` and `REFL:BL:MSG` now get updated so changes propagate e.g. to front panel.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4046

### Acceptance criteria

- [x] Doing a beamline move involving a non-existent PV does not crash the server
- [x] A failed move will update the error status readback on the front panel
- [x] A successful move will clear the error status readback on the front panel

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
