### PR TITLE
Ticket 4237: Run BlockserverToKafka as Default

### DIFF
--- a/server_common/constants.py
+++ b/server_common/constants.py
@@ -17,5 +17,6 @@
 """Contains constants used by multiple servers"""
 import os
 
-IOCS_NOT_TO_STOP = ('INSTETC', 'PSCTRL', 'ISISDAE', 'BLOCKSVR', 'ARINST', 'ARBLOCK', 'GWBLOCK', 'RUNCTRL', 'ALARM')
+IOCS_NOT_TO_STOP = ('INSTETC', 'PSCTRL', 'ISISDAE', 'BLOCKSVR', 'ARINST', 'ARBLOCK', 'GWBLOCK', 'RUNCTRL', 'ALARM',
+                    'BSKAFKA')
 IS_LINUX = os.name != "nt"

--- a/start_bs_to_kafka_cmd.bat
+++ b/start_bs_to_kafka_cmd.bat
@@ -1,0 +1,14 @@
+REM @echo off
+
+set MYDIRCD=%~dp0
+call %MYDIRCD%..\..\..\config_env_base.bat
+
+rem %HIDEWINDOW% h
+
+set EPICS_CAS_INTF_ADDR_LIST=127.0.0.1
+set EPICS_CAS_BEACON_ADDR_LIST=127.255.255.255
+
+set PYTHONUNBUFFERED=TRUE
+
+echo on
+%PYTHON% %MYDIRCD%\BlockServerToKafka\main.py -d %INSTRUMENT%_sampleEnv -c forwarder_config -b livedata.isis.cclrc.ac.uk:9092 -p %MYPVPREFIX%


### PR DESCRIPTION
### Description of work

Adds a script to run BlockserverToKafka, see https://github.com/ISISComputingGroup/IBEX/issues/4237

### To test

* Ensure you have the library installed in https://github.com/ISISComputingGroup/genie_python/pull/162
* Ensure you have the latest base config from https://control-svcs.isis.cclrc.ac.uk/git/?p=instconfigs/inst.git;a=shortlog;h=refs/heads/master
* Ensure you have https://github.com/ISISComputingGroup/EPICS/pull/167
* Start an instrument
* Confirm BSKAFKA has started and has logged in the normal IOC space
* Confirm that a valid forwarder configuration has been pushed to the forwarder_config topic. (to do this get in touch with @DominicOram, @matthew-d-jones or @rerpha)
* Change configuration and confirm the forwarder_config has appropriately changed

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
