### PR TITLE
Ticket 4347: Push dev data to test cluster

### DIFF
--- a/start_bs_to_kafka_cmd.bat
+++ b/start_bs_to_kafka_cmd.bat
@@ -3,12 +3,18 @@ REM @echo off
 set MYDIRCD=%~dp0
 call %MYDIRCD%..\..\..\config_env_base.bat
 
-rem %HIDEWINDOW% h
+%HIDEWINDOW% h
 
 set EPICS_CAS_INTF_ADDR_LIST=127.0.0.1
 set EPICS_CAS_BEACON_ADDR_LIST=127.255.255.255
 
 set PYTHONUNBUFFERED=TRUE
 
-echo on
-%PYTHON% %MYDIRCD%\BlockServerToKafka\main.py -d %INSTRUMENT%_sampleEnv -c forwarder_config -b livedata.isis.cclrc.ac.uk:9092 -p %MYPVPREFIX%
+if "%ISIS_INSTRUMENT%" == "1" (
+    set BROKER=livedata.isis.cclrc.ac.uk
+) else (
+    REM point at the test server
+    set BROKER=tenten.isis.cclrc.ac.uk
+)
+
+%PYTHON% %MYDIRCD%\BlockServerToKafka\main.py -d %INSTRUMENT%_sampleEnv -c forwarder_config -b %BROKER%:9092 -p %MYPVPREFIX%


### PR DESCRIPTION

### Description of work

See https://github.com/ISISComputingGroup/IBEX/issues/4347

### To test

* Start an instrument/switch config on your dev machine
* Do the same on DEMO
* Run the attached [python code](https://github.com/ISISComputingGroup/EPICS-inst_servers/files/3192114/test_4347.zip) looking at the test server (tenten.isis.cclrc.ac.uk:9092) confirm that there is a message about your local blocks on the server but not about DEMO's
* Run the script against livedata.isis.cclrc.ac.uk:9092, confirm there is data from DEMO but not from your machine

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
