### PR TITLE
Ticket4264 reflectometry ordered positions

### DIFF
--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -247,13 +247,13 @@ class PVManager:
                 keyed by name.
         """
         for param, (param_type, group_names, description) in param_types.items():
-            self._add_parameter_pvs(param, group_names, description, **PARAMS_FIELDS_BEAMLINE_TYPES[param_type])
+            self._add_parameter_pvs(param, group_names, description, param_type)
         self.PVDB[TRACKING_AXES] = {'type': 'char',
                                     'count': 300,
                                     'value': json.dumps(self._tracking_positions)
                                     }
     
-    def _add_parameter_pvs(self, param_name, group_names, description, **fields):
+    def _add_parameter_pvs(self, param_name, group_names, description, param_type):
         """
         Adds all PVs needed for one beamline parameter to the PV database.
 
@@ -266,10 +266,18 @@ class PVManager:
         try:
             param_alias = create_pv_name(param_name, self.PVDB.keys(), "PARAM", limit=10)
             prepended_alias = "{}:{}".format(PARAM_PREFIX, param_alias)
-            if BeamlineParameterGroup.TRACKING in group_names:
-                item = {}
-                item[prepended_alias] = param_name
-                self._tracking_positions.append(item) 
+           
+            fields = PARAMS_FIELDS_BEAMLINE_TYPES[param_type]
+            #if BeamlineParameterGroup.TRACKING in group_names:
+            item = {}
+            item["param_name"] = param_name
+            item["prepended_alias"] = prepended_alias
+            if param_type is BeamlineParameterType.FLOAT:
+                item["type"] = "float"
+            elif param_type is BeamlineParameterType.IN_OUT:
+                item["type"] = "in_out"
+
+            self._tracking_positions.append(item) 
 
             self.PVDB["{}.DESC".format(prepended_alias)] = {'type': 'string',
                                                             'value': description

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -148,9 +148,6 @@ class PvSort(Enum):
             return parameter.sp_changed
         elif self == PvSort.MOVE:
             return parameter.move
-        #elif self == PvSort.IN_MODE:
-           # return 1
-
         return float("NaN")
 
 
@@ -267,7 +264,7 @@ class PVManager:
 
         Args:
             param_name: The name of the beamline parameter
-            fields: The fields of the parameter PV
+            param_type: The type of the parameter
             group_names: list of groups to which this parameter belong
             description: description of the pv
         """
@@ -276,6 +273,7 @@ class PVManager:
             prepended_alias = "{}:{}".format(PARAM_PREFIX, param_alias)
            
             fields = PARAMS_FIELDS_BEAMLINE_TYPES[param_type]
+            # generate a dictionary to store metadata about tracking positions
             item = {}
             item["param_name"] = param_name
             item["prepended_alias"] = prepended_alias

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -254,9 +254,9 @@ class PVManager:
         for param, (param_type, group_names, description) in param_types.items():
             self._add_parameter_pvs(param, group_names, description, param_type)
         self.PVDB[PARAM_INFO] = {'type': 'char',
-                                    'count': 300,
-                                    'value': json.dumps(self._param_info)
-                                    }
+                                 'count': 2048,
+                                 'value': json.dumps(self._param_info)
+                                 }
     
     def _add_parameter_pvs(self, param_name, group_names, description, param_type):
         """

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -7,6 +7,7 @@ from ReflectometryServer.parameters import BeamlineParameterType, BeamlineParame
 from server_common.ioc_data_source import PV_INFO_FIELD_NAME, PV_DESCRIPTION_NAME
 from server_common.utilities import create_pv_name, remove_from_end, print_and_log, SEVERITY
 import json
+from collections import OrderedDict
 
 
 PARAM_PREFIX = "PARAM"
@@ -185,8 +186,8 @@ class PVManager:
         """
 
         self.PVDB = {}
-        self._params_pv_lookup = {}
-        self._tracking_positions = {}
+        self._params_pv_lookup = OrderedDict()
+        self._tracking_positions = []
         self._footprint_parameters = {}
 
         self._add_global_pvs(mode_names, status_codes)
@@ -251,7 +252,7 @@ class PVManager:
                                     'count': 300,
                                     'value': json.dumps(self._tracking_positions)
                                     }
-
+    
     def _add_parameter_pvs(self, param_name, group_names, description, **fields):
         """
         Adds all PVs needed for one beamline parameter to the PV database.
@@ -266,7 +267,9 @@ class PVManager:
             param_alias = create_pv_name(param_name, self.PVDB.keys(), "PARAM", limit=10)
             prepended_alias = "{}:{}".format(PARAM_PREFIX, param_alias)
             if BeamlineParameterGroup.TRACKING in group_names:
-                self._tracking_positions[prepended_alias] = param_name
+                item = {}
+                item[prepended_alias] = param_name
+                self._tracking_positions.append(item) 
 
             self.PVDB["{}.DESC".format(prepended_alias)] = {'type': 'string',
                                                             'value': description

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -148,8 +148,8 @@ class PvSort(Enum):
             return parameter.sp_changed
         elif self == PvSort.MOVE:
             return parameter.move
-        elif self == PvSort.IN_MODE:
-            return parameter.in_mode
+        #elif self == PvSort.IN_MODE:
+           # return 1
 
         return float("NaN")
 
@@ -314,7 +314,7 @@ class PVManager:
 
             # In mode PV
             self._add_pv_with_val(prepended_alias + IN_MODE_SUFFIX, param_name, PARAM_IN_MODE, description,
-                                  PvSort.MOVE)
+                                  PvSort.IN_MODE)
 
         except Exception as err:
             print("Error adding parameter PV: " + err.message)

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -22,6 +22,7 @@ SP_RBV_SUFFIX = ":SP:RBV"
 MOVE_SUFFIX = ":MOVE"
 CHANGED_SUFFIX = ":CHANGED"
 SET_AND_NO_MOVE_SUFFIX = ":SP_NO_MOVE"
+IN_MODE_SUFFIX = ":IN_MODE"
 VAL_FIELD = ".VAL"
 
 FOOTPRINT_PREFIX = "FP"
@@ -39,6 +40,8 @@ FP_RBV_PREFIX = "RBV"
 FOOTPRINT_PREFIXES = [FP_SP_PREFIX, FP_SP_RBV_PREFIX, FP_RBV_PREFIX]
 
 PARAM_FIELDS_CHANGED = {'type': 'enum', 'enums': ["NO", "YES"]}
+
+PARAM_IN_MODE = {'type': 'enum', 'enums': ["NO", "YES"]}
 
 PARAM_FIELDS_MOVE = {'type': 'int', 'count': 1, 'value': 0}
 
@@ -97,6 +100,7 @@ class PvSort(Enum):
     SP = 3
     SET_AND_NO_MOVE = 4
     CHANGED = 6
+    IN_MODE = 7
 
     @staticmethod
     def what(pv_sort):
@@ -118,6 +122,8 @@ class PvSort(Enum):
             return "(Set point with no move afterwards)"
         elif pv_sort == PvSort.CHANGED:
             return "(is changed)"
+        elif pv_sort == PvSort.IN_MODE:
+            return "(is in mode)"
         else:
             print_and_log("Unknown pv sort!! {}".format(pv_sort), severity=SEVERITY.MAJOR, src="REFL")
             return "(unknown)"
@@ -142,6 +148,8 @@ class PvSort(Enum):
             return parameter.sp_changed
         elif self == PvSort.MOVE:
             return parameter.move
+        elif self == PvSort.IN_MODE:
+            return parameter.in_mode
 
         return float("NaN")
 
@@ -260,7 +268,7 @@ class PVManager:
         Args:
             param_name: The name of the beamline parameter
             fields: The fields of the parameter PV
-            group_names: list fo groups to which this parameter belong
+            group_names: list of groups to which this parameter belong
             description: description of the pv
         """
         try:
@@ -268,7 +276,6 @@ class PVManager:
             prepended_alias = "{}:{}".format(PARAM_PREFIX, param_alias)
            
             fields = PARAMS_FIELDS_BEAMLINE_TYPES[param_type]
-            #if BeamlineParameterGroup.TRACKING in group_names:
             item = {}
             item["param_name"] = param_name
             item["prepended_alias"] = prepended_alias
@@ -303,6 +310,10 @@ class PVManager:
 
             # Move PV
             self._add_pv_with_val(prepended_alias + MOVE_SUFFIX, param_name, PARAM_FIELDS_MOVE, description,
+                                  PvSort.MOVE)
+
+            # In mode PV
+            self._add_pv_with_val(prepended_alias + IN_MODE_SUFFIX, param_name, PARAM_IN_MODE, description,
                                   PvSort.MOVE)
 
         except Exception as err:

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -16,7 +16,7 @@ BEAMLINE_MODE = BEAMLINE_PREFIX + "MODE"
 BEAMLINE_MOVE = BEAMLINE_PREFIX + "MOVE"
 BEAMLINE_STATUS = BEAMLINE_PREFIX + "STAT"
 BEAMLINE_MESSAGE = BEAMLINE_PREFIX + "MSG"
-TRACKING_AXES = "TRACKING_AXES"
+PARAM_INFO = "PARAM_INFO"
 SP_SUFFIX = ":SP"
 SP_RBV_SUFFIX = ":SP:RBV"
 MOVE_SUFFIX = ":MOVE"
@@ -192,7 +192,7 @@ class PVManager:
 
         self.PVDB = {}
         self._params_pv_lookup = OrderedDict()
-        self._tracking_positions = []
+        self._param_info = []
         self._footprint_parameters = {}
 
         self._add_global_pvs(mode_names, status_codes)
@@ -253,9 +253,9 @@ class PVManager:
         """
         for param, (param_type, group_names, description) in param_types.items():
             self._add_parameter_pvs(param, group_names, description, param_type)
-        self.PVDB[TRACKING_AXES] = {'type': 'char',
+        self.PVDB[PARAM_INFO] = {'type': 'char',
                                     'count': 300,
-                                    'value': json.dumps(self._tracking_positions)
+                                    'value': json.dumps(self._param_info)
                                     }
     
     def _add_parameter_pvs(self, param_name, group_names, description, param_type):
@@ -273,16 +273,16 @@ class PVManager:
             prepended_alias = "{}:{}".format(PARAM_PREFIX, param_alias)
            
             fields = PARAMS_FIELDS_BEAMLINE_TYPES[param_type]
-            # generate a dictionary to store metadata about tracking positions
-            item = {}
-            item["param_name"] = param_name
-            item["prepended_alias"] = prepended_alias
+            # generate a dictionary to store metadata about parameters
+            param_info = {}
+            param_info["param_name"] = param_name
+            param_info["prepended_alias"] = prepended_alias
             if param_type is BeamlineParameterType.FLOAT:
-                item["type"] = "float"
+                param_info["type"] = "float"
             elif param_type is BeamlineParameterType.IN_OUT:
-                item["type"] = "in_out"
+                param_info["type"] = "in_out"
 
-            self._tracking_positions.append(item) 
+            self._param_info.append(param_info)
 
             self.PVDB["{}.DESC".format(prepended_alias)] = {'type': 'string',
                                                             'value': description
@@ -407,7 +407,7 @@ class PVManager:
 
         Returns: True if this the beamline tracking axis pv
         """
-        return self._is_pv_name_this_field(TRACKING_AXES, pv_name)
+        return self._is_pv_name_this_field(PARAM_INFO, pv_name)
 
     def is_beamline_status(self, pv_name):
         """

--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -200,8 +200,8 @@ class ReflectometryDriver(Driver):
         Beamline mode change in driver
         Args:
             mode (str): to change to
+            params_in_mode : list of parameters in the mode given
         """
-        print(params_in_mode)
 
         for pv_name, (param_name, param_sort) in self._pv_manager.param_names_pvnames_and_sort():
             if param_sort is PvSort.RBV:

--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -108,7 +108,7 @@ class ReflectometryDriver(Driver):
                 beamline_mode_enums = self._pv_manager.PVDB[BEAMLINE_MODE]["enums"]
                 new_mode_name = beamline_mode_enums[value]
                 self._beamline.active_mode = new_mode_name
-                self._bl_mode_change(new_mode_name)
+                self._bl_mode_change(new_mode_name, self._beamline.get_param_names_in_mode())
             except ValueError:
                 logger.error("Invalid value entered for mode. (Possible modes: {})".format(
                     ",".join(self._beamline.mode_names)))
@@ -190,12 +190,13 @@ class ReflectometryDriver(Driver):
             if param_sort == PvSort.SP_RBV:
                 parameter.add_sp_rbv_change_listener(partial(self._update_param_listener, pv_name))
 
-    def _bl_mode_change(self, mode):
+    def _bl_mode_change(self, mode, params_in_mode):
         """
         Beamline mode change in driver
         Args:
             mode (str): to change to
         """
+        print(params_in_mode)
         mode_value = self._beamline_mode_value(mode)
         self._update_param_both_pv_and_pv_val(BEAMLINE_MODE, mode_value)
         self._update_param_both_pv_and_pv_val(BEAMLINE_MODE + SP_SUFFIX, mode_value)
@@ -206,7 +207,7 @@ class ReflectometryDriver(Driver):
         Adds the monitor on the active mode, if this changes a monitor update is posted.
         """
         self._beamline.add_active_mode_change_listener(self._bl_mode_change)
-        self._bl_mode_change(self._beamline.active_mode)
+        self._bl_mode_change(self._beamline.active_mode, self._beamline.get_param_names_in_mode())
 
     def add_trigger_status_change_listener(self):
         """

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -288,6 +288,16 @@ class Beamline(object):
         """
         return self._components[item]
 
+    def get_param_names_in_mode(self):
+        """ Returns a list of the name of params in the current mode.
+        """
+
+        param_names_in_mode = []
+        parameters = self._beamline_parameters.values()
+        for param in self._active_mode.get_parameters_in_mode(parameters):
+            param_names_in_mode.append(param.name)
+        return param_names_in_mode
+
     def update_next_beam_component(self, source_component, calc_path_list):
         """
         Updates the next component in the beamline.
@@ -474,7 +484,7 @@ class Beamline(object):
 
         """
         for listener in self._active_mode_change_listeners:
-            listener(self.active_mode)
+            listener(self.active_mode, self.get_param_names_in_mode())
 
     def add_active_mode_change_listener(self, listener):
         """

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -222,7 +222,7 @@ class Beamline(object):
             dict[str, ReflectometryServer.parameters.BeamlineParameterType]: a dictionary of parameter type,
                 keyed by their name
         """
-        types = {}
+        types = OrderedDict()
         for beamline_parameter in self._beamline_parameters.values():
             types[beamline_parameter.name] = (beamline_parameter.parameter_type, beamline_parameter.group_names,
                                               beamline_parameter.description)

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -61,10 +61,11 @@ class BeamlineParameter(object):
         self._rbv_change_listeners = set()
         self._sp_rbv_change_listeners = set()
         self._init_listeners = set()
+        #self._in_mode = init
 
     def __repr__(self):
         return "{} '{}': sp={}, sp_rbv={}, rbv={}, changed={}".format(__name__, self.name, self._set_point,
-                                                                      self._set_point_rbv, self.rbv, self.sp_changed)
+                                                                      self._set_point_rbv, self.rbv, self.sp_changed)# self.in_mode)
 
     def _initialise_sp_from_file(self):
         """

--- a/ReflectometryServer/reflectometry_server.py
+++ b/ReflectometryServer/reflectometry_server.py
@@ -66,6 +66,8 @@ ioc_data_source = IocDataSource(SQLAbstraction("iocdb", "iocdb", "$iocdb"))
 ioc_data_source.insert_ioc_start("REFL", os.getpid(), sys.argv[0], pv_db.PVDB, REFLECTOMETRY_PREFIX)
 
 logger.info("Reflectometry IOC started")
+
+logger.info(pv_db.PVDB["TRACKING_AXES"])
 # Process CA transactions
 
 while True:

--- a/ReflectometryServer/reflectometry_server.py
+++ b/ReflectometryServer/reflectometry_server.py
@@ -67,7 +67,6 @@ ioc_data_source.insert_ioc_start("REFL", os.getpid(), sys.argv[0], pv_db.PVDB, R
 
 logger.info("Reflectometry IOC started")
 
-logger.info(pv_db.PVDB["TRACKING_AXES"])
 # Process CA transactions
 
 while True:


### PR DESCRIPTION
### Description of work

This ticket is part of the work to provide the parameters found on the 'Components: Positions relative to beam' screen on the opi in the same order in which they are found in the config. The work also provides an indication as to whether the parameter is in the mode or not. 

### To test

[#4264](https://github.com/ISISComputingGroup/IBEX/issues/4264)

### Acceptance criteria

- [x] All parameters have an IN_MODE PV.

- [x] When the mode is changed, the appropriate parameters in that mode are set to being IN_MODE = YES.

- [x] The parameters retain the order in which they are provided in the config on the opi. 

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [x] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
