### PR TITLE
Remove update of sp rbv from lower pvs

### DIFF
--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -172,6 +172,7 @@ class BeamlineParameter(object):
         self._sp_is_changed = False
         if self._autosave:
             file_io.write_autosave_param(self._name, self._set_point_rbv)
+        self._trigger_sp_rbv_listeners(self)
 
     def move_to_sp_rbv_no_callback(self):
         """
@@ -505,8 +506,8 @@ class SlitGapParameter(BeamlineParameter):
     def __init__(self, name, pv_wrapper, is_vertical, sim=False, init=0, description=None, autosave=False):
         """
         Args:
-            name: The name of the parameter
-            pv_wrapper: The motor pv this parameter talks to
+            name (str): The name of the parameter
+            pv_wrapper (ReflectometryServer.pv_wrapper.PVWrapper): The motor pv this parameter talks to
             is_vertical: Whether it is a vertical gap
             sim: Whether it is a simulated parameter
             init: Initialisation value if simulated
@@ -514,7 +515,6 @@ class SlitGapParameter(BeamlineParameter):
         """
         super(SlitGapParameter, self).__init__(name, sim, init, description, autosave)
         self._pv_wrapper = pv_wrapper
-        self._pv_wrapper.add_after_sp_change_listener(self.update_sp_rbv)
         self._pv_wrapper.add_after_rbv_change_listener(self.update_rbv)
         self._pv_wrapper.add_monitors()
         if is_vertical:
@@ -544,18 +544,6 @@ class SlitGapParameter(BeamlineParameter):
         Get the setpoint value for this parameter based on the motor setpoint position.
         """
         self._set_initial_sp(self._pv_wrapper.sp)
-
-    def update_sp_rbv(self, new_value, alarm_severity, alarm_status):
-        """
-        Update the setpoint readback value.
-
-        Args:
-            new_value: new given value
-            alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
-            alarm_status (server_common.channel_access.AlarmCondition): the alarm status
-        """
-        self._set_point_rbv = new_value
-        self._trigger_sp_rbv_listeners(self)
 
     def update_rbv(self, new_value, alarm_severity, alarm_status):
         """


### PR DESCRIPTION
### Description of work

Remove set of set point readback from lower PV in the slit gaps

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4307

### Acceptance criteria

1. Set the Jaws from the lower OPI, setpoint readback on reflectometry OPI does not change

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
