### PR TITLE
Use the setpoint offset when calculating theta

### DIFF
--- a/ReflectometryServer/beam_path_calc.py
+++ b/ReflectometryServer/beam_path_calc.py
@@ -38,7 +38,7 @@ class TrackingBeamPathCalc(object):
         # This is the theta beam path and is used because this beam path calc is defining theta and therefore its offset
         #   will always be exact. So we use this to calculate the position of the component not the incoming beam.
         #  If it is None then this does not define theta
-        self.theta_calc_set_of_incoming_beam = None
+        self.substitute_incoming_beam_for_displacement = None
 
     def init_displacement_from_motor(self, value):
         """
@@ -170,10 +170,10 @@ class TrackingBeamPathCalc(object):
         Returns: theta incoming beam if this is not None; otherwise returns incoming beam
 
         """
-        if self.theta_calc_set_of_incoming_beam is None:
+        if self.substitute_incoming_beam_for_displacement is None:
             beam = self._incoming_beam
         else:
-            beam = self.theta_calc_set_of_incoming_beam
+            beam = self.substitute_incoming_beam_for_displacement
         return beam
 
     def set_displacement(self, displacement, alarm_severity, alarm_status):
@@ -423,7 +423,7 @@ class BeamPathCalcThetaRBV(_BeamPathCalcReflecting):
 
         # clear previous incoming theta beam on all components
         for readback_beam_path_calc, _ in self._angle_to:
-            readback_beam_path_calc.theta_calc_set_of_incoming_beam = None
+            readback_beam_path_calc.substitute_incoming_beam_for_displacement = None
 
         for readback_beam_path_calc, set_point_beam_path_calc in self._angle_to:
             if readback_beam_path_calc.is_in_beam:
@@ -440,7 +440,7 @@ class BeamPathCalcThetaRBV(_BeamPathCalcReflecting):
 
                 angle = (degrees(atan2(opp, adj)) - incoming_beam.angle) / 2.0 + incoming_beam.angle
 
-                readback_beam_path_calc.theta_calc_set_of_incoming_beam = \
+                readback_beam_path_calc.substitute_incoming_beam_for_displacement = \
                     self.theta_setpoint_beam_path_calc.get_outgoing_beam()
                 break
         else:

--- a/ReflectometryServer/components.py
+++ b/ReflectometryServer/components.py
@@ -122,8 +122,8 @@ class ThetaComponent(ReflectingComponent):
         super(ReflectingComponent, self).__init__(name, setup)
 
     def _init_beam_path_calcs(self, setup):
-        self._beam_path_rbv = BeamPathCalcThetaRBV(LinearMovementCalc(setup),
-                                                   [comp.beam_path_rbv for comp in self.angle_to_components])
+        beam_path_calcs = [(comp.beam_path_rbv, comp.beam_path_set_point) for comp in self.angle_to_components]
+        self._beam_path_rbv = BeamPathCalcThetaRBV(LinearMovementCalc(setup), beam_path_calcs)
         self._beam_path_set_point = BeamPathCalcThetaSP(LinearMovementCalc(setup),
                                                         [comp.beam_path_set_point for comp in self.angle_to_components])
 

--- a/ReflectometryServer/components.py
+++ b/ReflectometryServer/components.py
@@ -123,9 +123,10 @@ class ThetaComponent(ReflectingComponent):
 
     def _init_beam_path_calcs(self, setup):
         beam_path_calcs = [(comp.beam_path_rbv, comp.beam_path_set_point) for comp in self.angle_to_components]
-        self._beam_path_rbv = BeamPathCalcThetaRBV(LinearMovementCalc(setup), beam_path_calcs)
-        self._beam_path_set_point = BeamPathCalcThetaSP(LinearMovementCalc(setup),
+        linear_movement_calc = LinearMovementCalc(setup)
+        self._beam_path_set_point = BeamPathCalcThetaSP(linear_movement_calc,
                                                         [comp.beam_path_set_point for comp in self.angle_to_components])
+        self._beam_path_rbv = BeamPathCalcThetaRBV(linear_movement_calc, beam_path_calcs, self._beam_path_set_point)
 
 
 # class Bench(Component):

--- a/ReflectometryServer/geometry.py
+++ b/ReflectometryServer/geometry.py
@@ -1,6 +1,7 @@
 """
 Objects and classes that handle geometry
 """
+from math import radians, sin, cos
 
 
 class Position(object):
@@ -10,6 +11,9 @@ class Position(object):
     def __init__(self, y, z):
         self.z = float(z)
         self.y = float(y)
+
+    def __add__(self, other):
+        return Position(self.y + other.y, self.z + other.z)
 
     def __repr__(self):
         return "Position(x, {}, {})".format(self.y, self.z)
@@ -32,3 +36,22 @@ class PositionAndAngle(Position):
 
     def __repr__(self):
         return "PositionAndAngle({}, {}, {})".format(self.z, self.y, self.angle)
+
+
+def position_from_radial_coords(r, theta, angle=None):
+    """
+    Create a position based on radial coordinates. If angle included create a position and angle.
+    Args:
+        r: radius
+        theta: angle of the point position
+        angle: clockwise angle measured from the horizon (90 to -90 with 0 pointing away from the source); if None
+            return just position
+
+    Returns (Position): position object
+    """
+    x = r * sin(radians(theta))
+    y = r * cos(radians(theta))
+    if angle is None:
+        return Position(x, y)
+    else:
+        return PositionAndAngle(x, y, angle)

--- a/ReflectometryServer/movement_strategy.py
+++ b/ReflectometryServer/movement_strategy.py
@@ -1,10 +1,9 @@
 """
 Classes and objects decribing the movement of items
 """
-from math import fabs, tan, radians, sin, cos, sqrt
+from math import fabs, tan, radians, sqrt
 
-from ReflectometryServer.geometry import PositionAndAngle, Position
-
+from ReflectometryServer.geometry import PositionAndAngle, Position, position_from_radial_coords
 
 # Tolerance to use when comparing an angle with another angle
 ANGULAR_TOLERANCE = 1e-12
@@ -122,10 +121,8 @@ class LinearMovementCalc(object):
         displacement = given_displacement
         if displacement is None:
             displacement = self._displacement
-        y_value = self._position_at_zero.y + displacement * sin(radians(self._angle))
-        z_value = self._position_at_zero.z + displacement * cos(radians(self._angle))
 
-        return Position(y_value, z_value)
+        return self._position_at_zero + position_from_radial_coords(displacement, self._angle)
 
     def set_displacement(self, displacement):
         """
@@ -164,8 +161,7 @@ class LinearMovementCalc(object):
         Returns (ReflectometryServer.geometry.Position): distance to the beam in mantid coordinates as a vector
         """
         distance_relative_to_beam = self.get_distance_relative_to_beam(incoming_beam)
-        return Position(distance_relative_to_beam * sin(radians(self._angle)),
-                        distance_relative_to_beam * cos(radians(self._angle)))
+        return position_from_radial_coords(distance_relative_to_beam, self._angle)
 
     def get_displacement(self):
         """

--- a/ReflectometryServer/movement_strategy.py
+++ b/ReflectometryServer/movement_strategy.py
@@ -159,6 +159,14 @@ class LinearMovementCalc(object):
         """
         return self._displacement - self._dist_along_axis_from_zero_to_beam_intercept(beam)
 
+    def get_distance_relative_to_beam_in_mantid_coordinates(self, incoming_beam):
+        """
+        Returns (ReflectometryServer.geometry.Position): distance to the beam in mantid coordinates as a vector
+        """
+        distance_relative_to_beam = self.get_distance_relative_to_beam(incoming_beam)
+        return Position(distance_relative_to_beam * sin(radians(self._angle)),
+                        distance_relative_to_beam * cos(radians(self._angle)))
+
     def get_displacement(self):
         """
 

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -118,41 +118,38 @@ class TestRealistic(unittest.TestCase):
 
         assert_that(drives["det_angle_axis"].sp, is_(2*theta_angle))
 
+    def test_GIVEN_beam_line_where_all_items_have_offset_WHEN_set_theta_THEN_motors_move_to_be_correct_distance_from_the_beam_theta_readback_is_correct_and_does_not_include_offset(self):
+        spacing = 2.0
 
-    #TODO get question answered and then correct this test
-    # def test_GIVEN_beam_line_where_items_no_on_track_WHEN_set_theta_THEN_motors_move_to_be_correct_distance_from_the_beam(self):
-    #     spacing = 2.0
-    #
-    #     bl, drives = DataMother.beamline_s1_s3_theta_detector(spacing)
-    #
-    #     s1_offset = 1
-    #     bl.parameter("s1").sp = s1_offset
-    #     s3_offset = 2
-    #     bl.parameter("s3").sp = s3_offset
-    #     det_offset = 3
-    #     bl.parameter("det").sp = det_offset
-    #     det_ang_offset = 4
-    #     bl.parameter("det_angle").sp = det_ang_offset
-    #
-    #     theta_angle = 2
-    #     bl.parameter("theta").sp = theta_angle
-    #     bl.move = 1
-    #
-    #     assert_that(drives["s1_axis"].value, is_(s1_offset))
-    #     assert_that(bl.parameter("s1").rbv, is_(s1_offset))
-    #
-    #     expected_s3_value = spacing * tan(radians(theta_angle * 2.0)) + s3_offset
-    #     assert_that(drives["s3_axis"].value, is_(expected_s3_value))
-    #     assert_that(bl.parameter("s3").rbv, is_(s3_offset))
-    #
-    #     expected_det_value = 2 * spacing * tan(radians(theta_angle * 2.0)) + det_offset
-    #     assert_that(drives["det_axis"].value, is_(expected_det_value))
-    #     assert_that(bl.parameter("det").rbv, is_(det_offset))
-    #
-    #     assert_that(drives["det_angle_axis"].value, is_(2*theta_angle + det_ang_offset))
-    #     assert_that(bl.parameter("det_angle").rbv, is_(det_ang_offset))
-    #
-    #     assert_that(bl.parameter("theta").rbv, is_(theta_angle))
+        bl, drives = DataMother.beamline_s1_s3_theta_detector(spacing)
+
+        s1_offset = 1.0
+        bl.parameter("s1").sp = s1_offset
+        s3_offset = 2.0
+        bl.parameter("s3").sp = s3_offset
+        det_offset = 3.0
+        bl.parameter("det").sp = det_offset
+        det_ang_offset = 4.0
+        bl.parameter("det_angle").sp = det_ang_offset
+
+        theta_angle = 2.0
+        bl.parameter("theta").sp = theta_angle
+
+        assert_that(drives["s1_axis"].sp, is_(s1_offset))
+        assert_that(bl.parameter("s1").rbv, is_(s1_offset))
+
+        expected_s3_value = spacing * tan(radians(theta_angle * 2.0)) + s3_offset
+        assert_that(drives["s3_axis"].sp, is_(expected_s3_value))
+        assert_that(bl.parameter("s3").rbv, is_(s3_offset))
+
+        expected_det_value = 2 * spacing * tan(radians(theta_angle * 2.0)) + det_offset
+        assert_that(drives["det_axis"].sp, is_(expected_det_value))
+        assert_that(bl.parameter("det").rbv, is_(det_offset))
+
+        assert_that(drives["det_angle_axis"].sp, is_(2*theta_angle + det_ang_offset))
+        assert_that(bl.parameter("det_angle").rbv, close_to(det_ang_offset, 1e-6))
+
+        assert_that(bl.parameter("theta").rbv, close_to(theta_angle, 1e-6))
 
     def test_GIVEN_beam_line_where_all_items_track_WHEN_set_theta_no_move_and_move_beamline_THEN_motors_move_to_be_on_the_beam(self):
         spacing = 2.0

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -529,26 +529,39 @@ class TestBeamlineParameterReadback(unittest.TestCase):
 
     def test_GIVEN_theta_with_45_deg_beam_WHEN_next_component_is_along_beam_THEN_value_is_0(self):
 
+        # Given
+        beam_before_and_after_sample = PositionAndAngle(0, 0, 45)
+
         s3 = Component("s3", setup=PositionAndAngle(20, 20, 135))
-        s3.beam_path_rbv.set_incoming_beam(PositionAndAngle(0, 0, 45))
+        s3.beam_path_rbv.set_incoming_beam(beam_before_and_after_sample)
+        s3.beam_path_set_point.set_incoming_beam(beam_before_and_after_sample)
+
         sample = ThetaComponent("sample", setup=PositionAndAngle(10, 10, 135), angle_to=[s3])
-        sample.beam_path_rbv.set_incoming_beam(PositionAndAngle(0, 0, 45))
+        sample.beam_path_rbv.set_incoming_beam(beam_before_and_after_sample)
         theta = AngleParameter("param", sample)
 
+        # When
         result = theta.rbv
 
+        # Then
         assert_that(result, is_(0))
 
     def test_GIVEN_theta_with_0_deg_beam_WHEN_next_component_is_at_45_THEN_value_is_22_5(self):
 
-        s3 = Component("s3", setup=PositionAndAngle(10, 10, 90))
-        sample = ThetaComponent("sample", setup=PositionAndAngle(10, 0, 90), angle_to=[s3])
-        sample.beam_path_rbv.set_incoming_beam(PositionAndAngle(0, 0, 0))
-        theta = AngleParameter("param", sample)
+        height_above_beam = 10
+        expected_theta = 22.5
+        s3 = Component("s3", setup=PositionAndAngle(height_above_beam, 10, 90))
+        s3.beam_path_set_point.set_incoming_beam(PositionAndAngle(0, 0, expected_theta * 2))
+        s3.beam_path_set_point.set_position_relative_to_beam(0)
+
+        theta_comp = ThetaComponent("sample", setup=PositionAndAngle(1, 0, 90), angle_to=[s3])
+        theta_comp.beam_path_rbv.set_incoming_beam(PositionAndAngle(0, 0, 0))
+
+        theta = AngleParameter("param", theta_comp)
 
         result = theta.rbv
 
-        assert_that(result, is_(45/2.0))
+        assert_that(result, is_(expected_theta))
 
 
 class TestBeamlineThetaComponetWhenDisabled(unittest.TestCase):

--- a/ReflectometryServer/test_modules/test_components.py
+++ b/ReflectometryServer/test_modules/test_components.py
@@ -261,7 +261,7 @@ class TestThetaComponent(unittest.TestCase):
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
         result = theta.beam_path_rbv.angle
-        theta_calc_set_of_incoming_beam_next_comp = next_component.beam_path_rbv.theta_calc_set_of_incoming_beam
+        theta_calc_set_of_incoming_beam_next_comp = next_component.beam_path_rbv.substitute_incoming_beam_for_displacement
 
         assert_that(result, is_(0.0))
         assert_that(theta_calc_set_of_incoming_beam_next_comp, is_(position_and_angle(theta.beam_path_set_point.get_outgoing_beam())), "This component has defined theta rbv")
@@ -297,19 +297,19 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp1", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.is_in_beam = False
-        next_component.beam_path_rbv.theta_calc_set_of_incoming_beam = "Not None"
+        next_component.beam_path_rbv.substitute_incoming_beam_for_displacement = "Not None"
 
         next_but_one_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_but_one_component.beam_path_rbv.is_in_beam = True
         next_but_one_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
-        next_component.beam_path_rbv.theta_calc_set_of_incoming_beam = "Not None"
+        next_component.beam_path_rbv.substitute_incoming_beam_for_displacement = "Not None"
 
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component, next_but_one_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
         result = theta.beam_path_rbv.angle
-        theta_calc_set_of_incoming_beam_next_comp = next_component.beam_path_rbv.theta_calc_set_of_incoming_beam
-        theta_calc_set_of_incoming_beam_next_comp_but_one = next_but_one_component.beam_path_rbv.theta_calc_set_of_incoming_beam
+        theta_calc_set_of_incoming_beam_next_comp = next_component.beam_path_rbv.substitute_incoming_beam_for_displacement
+        theta_calc_set_of_incoming_beam_next_comp_but_one = next_but_one_component.beam_path_rbv.substitute_incoming_beam_for_displacement
 
         assert_that(result, is_(45.0/2.0))
         assert_that(theta_calc_set_of_incoming_beam_next_comp, is_(None), "This component does not define theta rbv")
@@ -320,20 +320,20 @@ class TestThetaComponent(unittest.TestCase):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp1", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.is_in_beam = True
-        next_component.beam_path_rbv.theta_calc_set_of_incoming_beam = "Not None"
+        next_component.beam_path_rbv.substitute_incoming_beam_for_displacement = "Not None"
         next_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
 
         next_but_one_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_but_one_component.beam_path_rbv.is_in_beam = True
         next_but_one_component.beam_path_rbv.set_displacement(0, AlarmSeverity.No, AlarmStatus.No)
-        next_but_one_component.beam_path_rbv.theta_calc_set_of_incoming_beam = "Not None"
+        next_but_one_component.beam_path_rbv.substitute_incoming_beam_for_displacement = "Not None"
 
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component, next_but_one_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
         result = theta.beam_path_rbv.angle
-        theta_calc_set_of_incoming_beam_next_comp = next_component.beam_path_rbv.theta_calc_set_of_incoming_beam
-        theta_calc_set_of_incoming_beam_next_comp_but_one = next_but_one_component.beam_path_rbv.theta_calc_set_of_incoming_beam
+        theta_calc_set_of_incoming_beam_next_comp = next_component.beam_path_rbv.substitute_incoming_beam_for_displacement
+        theta_calc_set_of_incoming_beam_next_comp_but_one = next_but_one_component.beam_path_rbv.substitute_incoming_beam_for_displacement
 
         assert_that(result, is_(45.0/2.0))
         assert_that(theta_calc_set_of_incoming_beam_next_comp, is_(position_and_angle(theta.beam_path_set_point.get_outgoing_beam())), "This component does not define theta rbv")

--- a/ReflectometryServer/test_modules/test_components.py
+++ b/ReflectometryServer/test_modules/test_components.py
@@ -1,14 +1,14 @@
 import unittest
 
-from math import tan, radians, sqrt, isnan
+from math import tan, radians, isnan
 from hamcrest import *
 from mock import Mock
 from parameterized import parameterized
 
 from ReflectometryServer.components import Component, ReflectingComponent, TiltingComponent, ThetaComponent
-from ReflectometryServer.geometry import Position, PositionAndAngle, PositionAndAngle
+from ReflectometryServer.geometry import Position, PositionAndAngle
 from server_common.channel_access import AlarmSeverity, AlarmStatus
-from utils import position_and_angle, position,  DEFAULT_TEST_TOLERANCE
+from utils import position_and_angle, position, DEFAULT_TEST_TOLERANCE
 
 
 class TestComponent(unittest.TestCase):
@@ -261,8 +261,10 @@ class TestThetaComponent(unittest.TestCase):
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
         result = theta.beam_path_rbv.angle
+        theta_calc_set_of_incoming_beam_next_comp = next_component.beam_path_rbv.theta_calc_set_of_incoming_beam
 
         assert_that(result, is_(0.0))
+        assert_that(theta_calc_set_of_incoming_beam_next_comp, is_(position_and_angle(theta.beam_path_set_point.get_outgoing_beam())), "This component has defined theta rbv")
 
     def test_GIVEN_next_component_is_enabled_and_at_45_degrees_WHEN_get_read_back_THEN_half_angle_to_component_is_readback(self):
 
@@ -290,21 +292,52 @@ class TestThetaComponent(unittest.TestCase):
 
         assert_that(result, is_(90/2.0))
 
-    def test_GIVEN_next_component_is_disabled_and_next_component_but_one_is_enabled_WHEN_get_read_back_THEN_half_angle_to_component_is_readback(self):
+    def test_GIVEN_next_component_is_disabled_and_next_component_but_one_is_enabled_WHEN_get_read_back_THEN_half_angle_to_component_is_readback_and_theta_calc_set_of_incoming_beam_is_set(self):
 
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         next_component = Component("comp1", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.is_in_beam = False
+        next_component.beam_path_rbv.theta_calc_set_of_incoming_beam = "Not None"
 
         next_but_one_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_but_one_component.beam_path_rbv.is_in_beam = True
         next_but_one_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
+        next_component.beam_path_rbv.theta_calc_set_of_incoming_beam = "Not None"
+
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component, next_but_one_component])
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
         result = theta.beam_path_rbv.angle
+        theta_calc_set_of_incoming_beam_next_comp = next_component.beam_path_rbv.theta_calc_set_of_incoming_beam
+        theta_calc_set_of_incoming_beam_next_comp_but_one = next_but_one_component.beam_path_rbv.theta_calc_set_of_incoming_beam
 
         assert_that(result, is_(45.0/2.0))
+        assert_that(theta_calc_set_of_incoming_beam_next_comp, is_(None), "This component does not define theta rbv")
+        assert_that(theta_calc_set_of_incoming_beam_next_comp_but_one, is_(position_and_angle(theta.beam_path_set_point.get_outgoing_beam())), "This component has defined theta rbv")
+
+    def test_GIVEN_next_component_is_enabled_and_next_component_but_one_is_also_enabled_WHEN_get_read_back_THEN_half_angle_to_first_component_is_readback_and_theta_cal_set_only_on_first_component(self):
+
+        beam_start = PositionAndAngle(y=0, z=0, angle=0)
+        next_component = Component("comp1", setup=PositionAndAngle(0, 10, 90))
+        next_component.beam_path_rbv.is_in_beam = True
+        next_component.beam_path_rbv.theta_calc_set_of_incoming_beam = "Not None"
+        next_component.beam_path_rbv.set_displacement(5, AlarmSeverity.No, AlarmStatus.No)
+
+        next_but_one_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
+        next_but_one_component.beam_path_rbv.is_in_beam = True
+        next_but_one_component.beam_path_rbv.set_displacement(0, AlarmSeverity.No, AlarmStatus.No)
+        next_but_one_component.beam_path_rbv.theta_calc_set_of_incoming_beam = "Not None"
+
+        theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component, next_but_one_component])
+        theta.beam_path_rbv.set_incoming_beam(beam_start)
+
+        result = theta.beam_path_rbv.angle
+        theta_calc_set_of_incoming_beam_next_comp = next_component.beam_path_rbv.theta_calc_set_of_incoming_beam
+        theta_calc_set_of_incoming_beam_next_comp_but_one = next_but_one_component.beam_path_rbv.theta_calc_set_of_incoming_beam
+
+        assert_that(result, is_(45.0/2.0))
+        assert_that(theta_calc_set_of_incoming_beam_next_comp, is_(position_and_angle(theta.beam_path_set_point.get_outgoing_beam())), "This component does not define theta rbv")
+        assert_that(theta_calc_set_of_incoming_beam_next_comp_but_one, is_(None), "This component has defined theta rbv")
 
     def test_GIVEN_next_component_is_enabled_WHEN_set_next_component_displacement_THEN_change_in_beam_path_triggered(self):
 
@@ -349,6 +382,23 @@ class TestThetaComponent(unittest.TestCase):
 
         assert_that(result, is_(close_to(45.0/2.0, DEFAULT_TEST_TOLERANCE)))
 
+    def test_GIVEN_next_component_is_enabled_theta_is_set_to_0_and_component_is_at_45_degrees_WHEN_get_read_back_from_component_THEN_component_readback_is_relative_to_setpoint_beam_not_readback_beam_and_is_not_0_and_outgoing_beam_is_readback_outgoing_beam(self):
+        beam_start = PositionAndAngle(y=0, z=0, angle=0)
+        next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
+        next_component.beam_path_rbv.is_in_beam = True
+        expected_position = 5
+        next_component.beam_path_rbv.set_displacement(expected_position, AlarmSeverity.No, AlarmStatus.No)
+        theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90), angle_to=[next_component])
+        theta.beam_path_set_point.set_incoming_beam(beam_start)
+        theta.beam_path_set_point.set_angle_relative_to_beam(0)
+        theta.beam_path_rbv.set_incoming_beam(beam_start)
+        next_component.beam_path_rbv.set_incoming_beam(theta.beam_path_rbv.get_outgoing_beam())
+
+        result_position = next_component.beam_path_rbv.get_position_relative_to_beam()
+        result_outgoing_beam = next_component.beam_path_rbv.get_outgoing_beam()
+
+        assert_that(result_position, is_(expected_position))
+        assert_that(result_outgoing_beam, is_(position_and_angle(theta.beam_path_rbv.get_outgoing_beam())))
 
 class TestComponentInitialisation(unittest.TestCase):
 


### PR DESCRIPTION
### Description of work

Make theta readback work with setpoint.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4306

### Acceptance criteria

1. With an offset on the detector, theta readback is the same as theta setpoint.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
