### PR TITLE
Allow axes to not be synchornised

### DIFF
--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -190,6 +190,7 @@ class Beamline(object):
         self.update_next_beam_component(None, self._beam_path_calcs_rbv)
         self.update_next_beam_component(None, self._beam_path_calcs_set_point)
 
+        self._active_mode = None
         self._initialise_mode(modes)
 
     def _validate(self, beamline_parameters, modes):
@@ -415,6 +416,11 @@ class Beamline(object):
             driver.perform_move(move_duration)
 
     def _get_max_move_duration(self):
+        """
+        Returns: maximum time taken for all required moves, if axes are not synchronised this will return 0 but
+        movement will still be required
+
+        """
         max_move_duration = 0.0
         for driver in self._get_drivers_not_at_setpoint():
             max_move_duration = max(max_move_duration, driver.get_max_move_duration())

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -72,10 +72,11 @@ class IocDriver(object):
             move_duration: The duration in which to perform this move
         """
         logger.debug("Moving axis {} {}".format(self._axis.name, self._get_distance()))
-        self._axis.initiate_move()
         # TODO: Is it sensible if the time is short to not change the velocity
         if move_duration > 1e-6 and self._synchronised:
+            self._axis.initiate_move_with_change_of_velocity()
             self._axis.velocity = self._get_distance() / move_duration
+
         self._axis.sp = self._get_set_point_position()
         self._sp_cache = self._get_set_point_position()
 

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -5,8 +5,6 @@ The driving layer communicates between the component layer and underlying pvs.
 import math
 import logging
 
-from threading import Event
-
 logger = logging.getLogger(__name__)
 
 
@@ -14,17 +12,20 @@ class IocDriver(object):
     """
     Drives an actual motor axis based on a component in the beamline model.
     """
-    def __init__(self, component, axis):
+    def __init__(self, component, axis, synchronised=True):
         """
         Drive the IOC based on a component
         Args:
             component (ReflectometryServer.components.Component):
             axis (ReflectometryServer.pv_wrapper.MotorPVWrapper): The PV that this driver controls.
+            synchronised (bool): If True then axes will set their velocities so they arrive at the end point at the same
+                time; if false they will move at their current speed.
         """
         self._component = component
         self._axis = axis
         self._rbv_cache = self._axis.rbv
         self._sp_cache = None
+        self._synchronised = synchronised
 
         self._axis.add_after_rbv_change_listener(self._on_update_rbv)
         self._axis.add_after_sp_change_listener(self._on_update_sp)
@@ -58,9 +59,10 @@ class IocDriver(object):
 
     def get_max_move_duration(self):
         """
-        Returns: The maximum duration of the requested move for all associated axes
+        Returns: The maximum duration of the requested move for all associated axes. If axes are not synchornised this
+        will return 0 but movement will still be required.
         """
-        return self._get_distance() / self._axis.max_velocity
+        return self._get_distance() / self._axis.max_velocity if self._synchronised else 0.0
 
     def perform_move(self, move_duration):
         """
@@ -71,7 +73,8 @@ class IocDriver(object):
         """
         logger.debug("Moving axis {} {}".format(self._axis.name, self._get_distance()))
         self._axis.initiate_move()
-        if move_duration > 1e-6:  # TODO Is this the correct thing to do and if so test it
+        # TODO: Is it sensible if the time is short to not change the velocity
+        if move_duration > 1e-6 and self._synchronised:
             self._axis.velocity = self._get_distance() / move_duration
         self._axis.sp = self._get_set_point_position()
         self._sp_cache = self._get_set_point_position()
@@ -149,7 +152,8 @@ class DisplacementDriver(IocDriver):
     """
     Drives a component with linear displacement movement
     """
-    def __init__(self, component, motor_axis, out_of_beam_position=None, tolerance_on_out_of_beam_position=1):
+    def __init__(self, component, motor_axis, out_of_beam_position=None, tolerance_on_out_of_beam_position=1,
+                 synchronised=True):
         """
         Constructor.
         Args:
@@ -159,8 +163,10 @@ class DisplacementDriver(IocDriver):
                 can not set the component to be out of the beam
             tolerance_on_out_of_beam_position (float): this the tolerance on the out of beam position, if the motor
                 is within this tolerance of the out_of_beam_position it will read out of beam otherwise the position
+            synchronised (bool): If True then axes will set their velocities so they arrive at the end point at the same
+                time; if false they will move at their current speed.
         """
-        super(DisplacementDriver, self).__init__(component, motor_axis)
+        super(DisplacementDriver, self).__init__(component, motor_axis, synchronised)
         self._out_of_beam_position = out_of_beam_position
         self._tolerance_on_out_of_beam_position = tolerance_on_out_of_beam_position
 
@@ -217,14 +223,16 @@ class AngleDriver(IocDriver):
     """
     Drives a component that has variable angle.
     """
-    def __init__(self, component, angle_axis):
+    def __init__(self, component, angle_axis, synchronised=True):
         """
         Constructor.
         Args:
             component (ReflectometryServer.components.Component): Component providing the values for the axes
             angle_axis(ReflectometryServer.pv_wrapper.MotorPVWrapper): PV for the angle motor axis
+            synchronised (bool): If True then axes will set their velocities so they arrive at the end point at the same
+                time; if false they will move at their current speed.
         """
-        super(AngleDriver, self).__init__(component, angle_axis)
+        super(AngleDriver, self).__init__(component, angle_axis, synchronised)
 
     def initialise_setpoint(self):
         """

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -200,7 +200,7 @@ class PVWrapper(object):
         """
         self._write_pv(self._velo_pv, value)
 
-    def initiate_move(self):
+    def initiate_move_with_change_of_velocity(self):
         """
         Sets internal state of the pv wrapper to reflect that a move has just been initialised.
         """


### PR DESCRIPTION
### Description of work

Allow axes to not be synchronised, this means the velocity on that axis will not be set on it.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4310

### Acceptance criteria

1. A non-synchronised axis does not have its velocity change in a move with other axes
1. Synchronised axis does have its velocity change in a move with other axes if the other zxes will take longer to move

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
