### PR TITLE
Cache velocity, edit mock class to reflect change

### DIFF
--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -8,7 +8,7 @@ from ReflectometryServer.components import Component, TiltingComponent, ThetaCom
 from ReflectometryServer.geometry import PositionAndAngle
 from ReflectometryServer.ioc_driver import DisplacementDriver, AngleDriver
 from ReflectometryServer.parameters import BeamlineParameter, TrackingPosition, AngleParameter
-
+from time import time
 
 class EmptyBeamlineParameter(BeamlineParameter):
     """
@@ -173,7 +173,7 @@ class MockChannelAccess(object):
     def pv_exists(self, pv):
         return pv in self._pvs.keys()
 
-    def add_monitor(self):
+    def add_monitor(self,pv, call_back_function):
         pass
 
     def caget(self, pv):

--- a/ReflectometryServer/test_modules/test_pv_wrapper.py
+++ b/ReflectometryServer/test_modules/test_pv_wrapper.py
@@ -50,6 +50,7 @@ class TestMotorPVWrapper(unittest.TestCase):
         expected_velocity = self.velo
 
         wrapper = MotorPVWrapper(self.motor_name, ca=self.mock_ca)
+        wrapper.initialise()
         actual_velocity = wrapper.velocity
 
         self.assertEqual(expected_velocity, actual_velocity)


### PR DESCRIPTION
### Description of work

Cache the latest value for motor velocity in the PVWrapper class. This means the server does not have to make `caget` calls to get the velocity of each individual axis for a synchronized move and improves system performance and stability. 

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4603

### Acceptance criteria

- The reflectometry IOC performs equal to or better than before
- All unit and IOC tests still pass

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
