### PR TITLE
Ticket 4295 - Reflectometry: Propagate moving state

### DIFF
--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -17,14 +17,17 @@ BEAMLINE_MOVE = BEAMLINE_PREFIX + "MOVE"
 BEAMLINE_STATUS = BEAMLINE_PREFIX + "STAT"
 BEAMLINE_MESSAGE = BEAMLINE_PREFIX + "MSG"
 PARAM_INFO = "PARAM_INFO"
+IN_MODE_SUFFIX = ":IN_MODE"
 SP_SUFFIX = ":SP"
 SP_RBV_SUFFIX = ":SP:RBV"
+RBV_AT_SP = ":RBV:AT_SP"
 MOVE_SUFFIX = ":MOVE"
 CHANGING = ":CHANGING"
-RBV_AT_POSITION = ":RBV:AT_POS"
 CHANGED_SUFFIX = ":CHANGED"
+
+
 SET_AND_NO_MOVE_SUFFIX = ":SP_NO_MOVE"
-IN_MODE_SUFFIX = ":IN_MODE"
+
 VAL_FIELD = ".VAL"
 
 FOOTPRINT_PREFIX = "FP"
@@ -104,7 +107,7 @@ class PvSort(Enum):
     CHANGED = 6
     IN_MODE = 7
     CHANGING = 8
-    RBV_AT_POSITION = 9
+    RBV_AT_SP = 9
 
     @staticmethod
     def what(pv_sort):
@@ -130,8 +133,8 @@ class PvSort(Enum):
             return "(Is in mode)"
         elif pv_sort == PvSort.CHANGING:
             return "(Is changing)"
-        elif pv_sort == PvSort.RBV_AT_POSITION:
-            return "(Tolerance between RBV and SP:RBV)"
+        elif pv_sort == PvSort.RBV_AT_SP:
+            return "(Tolerance between RBV and target set point)"
         else:
             print_and_log("Unknown pv sort!! {}".format(pv_sort), severity=SEVERITY.MAJOR, src="REFL")
             return "(unknown)"
@@ -158,8 +161,8 @@ class PvSort(Enum):
             return parameter.move
         elif self == PvSort.CHANGING:
             return parameter.is_changing
-        elif self == PvSort.RBV_AT_POSITION:
-            return parameter.rbv_at_position
+        elif self == PvSort.RBV_AT_SP:
+            return parameter.rbv_at_sp
         return float("NaN")
 
 
@@ -331,8 +334,8 @@ class PVManager:
                                   PvSort.IN_MODE)
 
             # RBV to SP:RBV tolerance once move completed
-            self._add_pv_with_val(prepended_alias + RBV_AT_POSITION, param_name, fields, description,
-                                  PvSort.RBV_AT_POSITION)
+            self._add_pv_with_val(prepended_alias + RBV_AT_SP, param_name, fields, description,
+                                  PvSort.RBV_AT_SP)
 
         except Exception as err:
             print("Error adding parameter PV: " + err.message)

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -334,7 +334,7 @@ class PVManager:
                                   PvSort.IN_MODE)
 
             # RBV to SP:RBV tolerance once move completed
-            self._add_pv_with_val(prepended_alias + RBV_AT_SP, param_name, fields, description,
+            self._add_pv_with_val(prepended_alias + RBV_AT_SP, param_name, PARAM_FIELDS_BINARY, description,
                                   PvSort.RBV_AT_SP)
 
         except Exception as err:

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -21,6 +21,7 @@ SP_SUFFIX = ":SP"
 SP_RBV_SUFFIX = ":SP:RBV"
 MOVE_SUFFIX = ":MOVE"
 CHANGING = ":CHANGING"
+RBV_AT_POSITION = ":RBV:AT_POS"
 CHANGED_SUFFIX = ":CHANGED"
 SET_AND_NO_MOVE_SUFFIX = ":SP_NO_MOVE"
 IN_MODE_SUFFIX = ":IN_MODE"
@@ -103,6 +104,7 @@ class PvSort(Enum):
     CHANGED = 6
     IN_MODE = 7
     CHANGING = 8
+    RBV_AT_POSITION = 9
 
     @staticmethod
     def what(pv_sort):
@@ -128,6 +130,8 @@ class PvSort(Enum):
             return "(Is in mode)"
         elif pv_sort == PvSort.CHANGING:
             return "(Is changing)"
+        elif pv_sort == PvSort.RBV_AT_POSITION:
+            return "(Tolerance between RBV and SP:RBV)"
         else:
             print_and_log("Unknown pv sort!! {}".format(pv_sort), severity=SEVERITY.MAJOR, src="REFL")
             return "(unknown)"
@@ -154,6 +158,8 @@ class PvSort(Enum):
             return parameter.move
         elif self == PvSort.CHANGING:
             return parameter.is_changing
+        elif self == PvSort.RBV_AT_POSITION:
+            return parameter.rbv_at_position
         return float("NaN")
 
 
@@ -323,6 +329,10 @@ class PVManager:
             # In mode PV
             self._add_pv_with_val(prepended_alias + IN_MODE_SUFFIX, param_name, PARAM_IN_MODE, description,
                                   PvSort.IN_MODE)
+
+            # RBV to SP:RBV tolerance once move completed
+            self._add_pv_with_val(prepended_alias + RBV_AT_POSITION, param_name, fields, description,
+                                  PvSort.RBV_AT_POSITION)
 
         except Exception as err:
             print("Error adding parameter PV: " + err.message)

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -20,6 +20,7 @@ PARAM_INFO = "PARAM_INFO"
 SP_SUFFIX = ":SP"
 SP_RBV_SUFFIX = ":SP:RBV"
 MOVE_SUFFIX = ":MOVE"
+CHANGING = ":CHANGING"
 CHANGED_SUFFIX = ":CHANGED"
 SET_AND_NO_MOVE_SUFFIX = ":SP_NO_MOVE"
 IN_MODE_SUFFIX = ":IN_MODE"
@@ -39,7 +40,7 @@ FP_RBV_PREFIX = "RBV"
 
 FOOTPRINT_PREFIXES = [FP_SP_PREFIX, FP_SP_RBV_PREFIX, FP_RBV_PREFIX]
 
-PARAM_FIELDS_CHANGED = {'type': 'enum', 'enums': ["NO", "YES"]}
+PARAM_FIELDS_BINARY = {'type': 'enum', 'enums': ["NO", "YES"]}
 
 PARAM_IN_MODE = {'type': 'enum', 'enums': ["NO", "YES"]}
 
@@ -101,6 +102,7 @@ class PvSort(Enum):
     SET_AND_NO_MOVE = 4
     CHANGED = 6
     IN_MODE = 7
+    CHANGING = 8
 
     @staticmethod
     def what(pv_sort):
@@ -121,9 +123,11 @@ class PvSort(Enum):
         elif pv_sort == PvSort.SET_AND_NO_MOVE:
             return "(Set point with no move afterwards)"
         elif pv_sort == PvSort.CHANGED:
-            return "(is changed)"
+            return "(Is changed)"
         elif pv_sort == PvSort.IN_MODE:
-            return "(is in mode)"
+            return "(Is in mode)"
+        elif pv_sort == PvSort.CHANGING:
+            return "(Is changing)"
         else:
             print_and_log("Unknown pv sort!! {}".format(pv_sort), severity=SEVERITY.MAJOR, src="REFL")
             return "(unknown)"
@@ -148,6 +152,8 @@ class PvSort(Enum):
             return parameter.sp_changed
         elif self == PvSort.MOVE:
             return parameter.move
+        elif self == PvSort.CHANGING:
+            return parameter.is_changing
         return float("NaN")
 
 
@@ -303,12 +309,16 @@ class PVManager:
                                   PvSort.SET_AND_NO_MOVE)
 
             # Changed PV
-            self._add_pv_with_val(prepended_alias + CHANGED_SUFFIX, param_name, PARAM_FIELDS_CHANGED, description,
+            self._add_pv_with_val(prepended_alias + CHANGED_SUFFIX, param_name, PARAM_FIELDS_BINARY, description,
                                   PvSort.CHANGED)
 
             # Move PV
             self._add_pv_with_val(prepended_alias + MOVE_SUFFIX, param_name, PARAM_FIELDS_MOVE, description,
                                   PvSort.MOVE)
+
+            # Moving state PV
+            self._add_pv_with_val(prepended_alias + CHANGING, param_name, PARAM_FIELDS_BINARY, description,
+                                  PvSort.CHANGING)
 
             # In mode PV
             self._add_pv_with_val(prepended_alias + IN_MODE_SUFFIX, param_name, PARAM_IN_MODE, description,

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -461,7 +461,6 @@ class PVManager:
 
     def _is_pv_name_this_field(self, field_name, pv_name):
         """
-
         Args:
             field_name: field name to match
             pv_name: pv name to match

--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -189,16 +189,20 @@ class ReflectometryDriver(Driver):
         """
         Add listeners to beamline parameter changes, which update pvs in the server
         """
+        print("---- refl_serv: Adding after rbv_at_pos listeners ----------")
         for pv_name, (param_name, param_sort) in self._pv_manager.param_names_pvnames_and_sort():
             parameter = self._beamline.parameter(param_name)
             parameter.add_init_listener(partial(self._update_param_listener, pv_name))
-            print("adding listeners fors")
             if param_sort == PvSort.RBV:
                 parameter.add_rbv_change_listener(partial(self._update_param_listener, pv_name))
             if param_sort == PvSort.SP_RBV:
                 parameter.add_sp_rbv_change_listener(partial(self._update_param_listener, pv_name))
             if param_sort == PvSort.CHANGING:
                 parameter.add_after_moving_state_update_listener(partial(self._update_binary_listener, pv_name))
+            if param_sort == PvSort.RBV_AT_POSITION:
+                print("REFL_DRV:add_param_listeners:PvSort.RBV_AT_POSITION:{}".format(pv_name))
+                parameter.add_after_rbv_at_position_listener(partial(self._update_binary_listener, pv_name))
+        print("----------")
 
     def _update_binary_listener(self, pv_name, value):
         self.setParam(pv_name, value)

--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -45,7 +45,7 @@ class ReflectometryDriver(Driver):
         self.add_param_listeners()
         self.add_trigger_active_mode_change_listener()
         self.add_trigger_status_change_listener()
-        self.add_trigger_is_moving_change_listener()
+        self.add_trigger_is_changing_change_listener()
         self.add_footprint_param_listeners()
 
     def read(self, reason):
@@ -198,8 +198,8 @@ class ReflectometryDriver(Driver):
                 parameter.add_sp_rbv_change_listener(partial(self._update_param_listener, pv_name))
             if param_sort == PvSort.CHANGING:
                 parameter.add_after_moving_state_update_listener(partial(self._update_binary_listener, pv_name))
-            if param_sort == PvSort.RBV_AT_POSITION:
-                parameter.add_after_rbv_at_position_listener(partial(self._update_binary_listener, pv_name))
+            if param_sort == PvSort.RBV_AT_SP:
+                parameter.add_after_rbv_at_sp_listener(partial(self._update_binary_listener, pv_name))
 
     def _update_binary_listener(self, pv_name, value):
         self.setParam(pv_name, value)
@@ -244,7 +244,7 @@ class ReflectometryDriver(Driver):
             self.updatePVs()
         self._beamline.add_status_change_listener(_bl_status_change)
 
-    def add_trigger_is_moving_change_listener(self):
+    def add_trigger_is_changing_change_listener(self):
         """
         Adds the monitor on the moving status, if this changes a monitor update is posted
         """

--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -189,7 +189,6 @@ class ReflectometryDriver(Driver):
         """
         Add listeners to beamline parameter changes, which update pvs in the server
         """
-        print("---- refl_serv: Adding after rbv_at_pos listeners ----------")
         for pv_name, (param_name, param_sort) in self._pv_manager.param_names_pvnames_and_sort():
             parameter = self._beamline.parameter(param_name)
             parameter.add_init_listener(partial(self._update_param_listener, pv_name))
@@ -200,9 +199,7 @@ class ReflectometryDriver(Driver):
             if param_sort == PvSort.CHANGING:
                 parameter.add_after_moving_state_update_listener(partial(self._update_binary_listener, pv_name))
             if param_sort == PvSort.RBV_AT_POSITION:
-                print("REFL_DRV:add_param_listeners:PvSort.RBV_AT_POSITION:{}".format(pv_name))
                 parameter.add_after_rbv_at_position_listener(partial(self._update_binary_listener, pv_name))
-        print("----------")
 
     def _update_binary_listener(self, pv_name, value):
         self.setParam(pv_name, value)

--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -197,7 +197,7 @@ class ReflectometryDriver(Driver):
             if param_sort == PvSort.SP_RBV:
                 parameter.add_sp_rbv_change_listener(partial(self._update_param_listener, pv_name))
             if param_sort == PvSort.CHANGING:
-                parameter.add_after_moving_state_update_listener(partial(self._update_binary_listener, pv_name))
+                parameter.add_after_is_changing_change_listener(partial(self._update_binary_listener, pv_name))
             if param_sort == PvSort.RBV_AT_SP:
                 parameter.add_after_rbv_at_sp_listener(partial(self._update_binary_listener, pv_name))
 

--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -45,7 +45,6 @@ class ReflectometryDriver(Driver):
         self.add_param_listeners()
         self.add_trigger_active_mode_change_listener()
         self.add_trigger_status_change_listener()
-        self.add_trigger_is_changing_change_listener()
         self.add_footprint_param_listeners()
 
     def read(self, reason):
@@ -243,12 +242,6 @@ class ReflectometryDriver(Driver):
             self._update_param_both_pv_and_pv_val(BEAMLINE_MESSAGE, message)
             self.updatePVs()
         self._beamline.add_status_change_listener(_bl_status_change)
-
-    def add_trigger_is_changing_change_listener(self):
-        """
-        Adds the monitor on the moving status, if this changes a monitor update is posted
-        """
-        self.updatePVs()
 
     def add_footprint_param_listeners(self):
         """

--- a/ReflectometryServer/beam_path_calc.py
+++ b/ReflectometryServer/beam_path_calc.py
@@ -26,7 +26,7 @@ class TrackingBeamPathCalc(object):
         self._after_beam_path_update_listeners = set()
         self._after_beam_path_update_on_init_listeners = set()
         self._after_physical_move_listeners = set()
-        self._after_changing_state_update_listeners = set()
+        self._after_is_changing_change_listeners = set()
         self._init_listeners = set()
         self._is_in_beam = True
         self._is_displacing = False
@@ -68,17 +68,20 @@ class TrackingBeamPathCalc(object):
         for listener in self._init_listeners:
             listener()
 
-    def add_after_changing_state_update_listener(self, listener):
+    def add_after_is_changing_change_listener(self, listener):
         """
-        TODO
-        """
-        self._after_changing_state_update_listeners.add(listener)
+        Add a listener which is triggered if the changing (rotating, displacing etc) state is changed.
 
-    def _trigger_after_changing_state_update(self):
+        Args:
+            listener: listener with a single argument which is the calling calculation.
         """
-        TODO
+        self._after_is_changing_change_listeners.add(listener)
+
+    def _trigger_after_is_changing_change(self):
         """
-        for listener in self._after_changing_state_update_listeners:
+        Runs all the current listeners on the changing state because something has changed.
+        """
+        for listener in self._after_is_changing_change_listeners:
             listener()
 
     def add_after_beam_path_update_listener(self, listener):
@@ -263,32 +266,38 @@ class TrackingBeamPathCalc(object):
     @property
     def is_displacing(self):
         """
-        TODO
+        Returns: Is the displacement component currently displacing
         """
         return self._is_displacing
 
     @is_displacing.setter
     def is_displacing(self, value):
         """
-         TODO
+         Update the displacement component displacing state and triggers the changing state listeners
+
+         Args:
+             value: the new displacing state
         """
         self._is_displacing = value
-        self._trigger_after_changing_state_update()
+        self._trigger_after_is_changing_change()
 
     @property
     def is_rotating(self):
         """
-        TODO
+        Returns: Is the angular component currently rotating
         """
         return self._is_rotating
 
     @is_rotating.setter
     def is_rotating(self, value):
         """
-         TODO
+         Update the angular components rotating state and triggers the changing state listeners
+
+         Args:
+             value: the new rotating state
         """
         self._is_rotating = value
-        self._trigger_after_changing_state_update()
+        self._trigger_after_is_changing_change()
 
     def add_after_physical_move_listener(self, listener):
         """
@@ -451,13 +460,13 @@ class BeamPathCalcThetaRBV(_BeamPathCalcReflecting):
         for readback_beam_path_calc, setpoint_beam_path_calc in self._angle_to:
             readback_beam_path_calc.add_after_physical_move_listener(self._update_angle)
             setpoint_beam_path_calc.add_after_physical_move_listener(self._update_angle)
-            readback_beam_path_calc.add_after_changing_state_update_listener(self._on_moving_state_update)
+            readback_beam_path_calc.add_after_is_changing_change_listener(self._on_moving_state_update)
 
     def _on_moving_state_update(self):
         for readback_beam_path_calc, setpoint_beam_path_calc in self._angle_to:
             if readback_beam_path_calc.is_in_beam:
                 self.is_rotating = readback_beam_path_calc.is_displacing
-                self._trigger_after_changing_state_update()
+                self._trigger_after_is_changing_change()
                 break
 
     def _update_angle(self, source):

--- a/ReflectometryServer/beam_path_calc.py
+++ b/ReflectometryServer/beam_path_calc.py
@@ -26,7 +26,7 @@ class TrackingBeamPathCalc(object):
         self._after_beam_path_update_listeners = set()
         self._after_beam_path_update_on_init_listeners = set()
         self._after_physical_move_listeners = set()
-        self._after_moving_state_update_listeners = set()
+        self._after_changing_state_update_listeners = set()
         self._init_listeners = set()
         self._is_in_beam = True
         self._is_displacing = False
@@ -68,17 +68,17 @@ class TrackingBeamPathCalc(object):
         for listener in self._init_listeners:
             listener()
 
-    def add_after_moving_state_update_listener(self, listener):
+    def add_after_changing_state_update_listener(self, listener):
         """
         TODO
         """
-        self._after_moving_state_update_listeners.add(listener)
+        self._after_changing_state_update_listeners.add(listener)
 
-    def _trigger_after_moving_state_update(self):
+    def _trigger_after_changing_state_update(self):
         """
         TODO
         """
-        for listener in self._after_moving_state_update_listeners:
+        for listener in self._after_changing_state_update_listeners:
             listener()
 
     def add_after_beam_path_update_listener(self, listener):
@@ -273,7 +273,7 @@ class TrackingBeamPathCalc(object):
          TODO
         """
         self._is_displacing = value
-        self._trigger_after_moving_state_update()
+        self._trigger_after_changing_state_update()
 
     @property
     def is_rotating(self):
@@ -288,7 +288,7 @@ class TrackingBeamPathCalc(object):
          TODO
         """
         self._is_rotating = value
-        self._trigger_after_moving_state_update()
+        self._trigger_after_changing_state_update()
 
     def add_after_physical_move_listener(self, listener):
         """
@@ -451,13 +451,13 @@ class BeamPathCalcThetaRBV(_BeamPathCalcReflecting):
         for readback_beam_path_calc, setpoint_beam_path_calc in self._angle_to:
             readback_beam_path_calc.add_after_physical_move_listener(self._update_angle)
             setpoint_beam_path_calc.add_after_physical_move_listener(self._update_angle)
-            readback_beam_path_calc.add_after_moving_state_update_listener(self._on_moving_state_update)
+            readback_beam_path_calc.add_after_changing_state_update_listener(self._on_moving_state_update)
 
     def _on_moving_state_update(self):
         for readback_beam_path_calc, setpoint_beam_path_calc in self._angle_to:
             if readback_beam_path_calc.is_in_beam:
                 self.is_rotating = readback_beam_path_calc.is_displacing
-                self._trigger_after_moving_state_update()
+                self._trigger_after_changing_state_update()
                 break
 
     def _update_angle(self, source):

--- a/ReflectometryServer/beam_path_calc.py
+++ b/ReflectometryServer/beam_path_calc.py
@@ -451,6 +451,14 @@ class BeamPathCalcThetaRBV(_BeamPathCalcReflecting):
         for readback_beam_path_calc, setpoint_beam_path_calc in self._angle_to:
             readback_beam_path_calc.add_after_physical_move_listener(self._update_angle)
             setpoint_beam_path_calc.add_after_physical_move_listener(self._update_angle)
+            readback_beam_path_calc.add_after_moving_state_update_listener(self._on_moving_state_update)
+
+    def _on_moving_state_update(self):
+        for readback_beam_path_calc, setpoint_beam_path_calc in self._angle_to:
+            if readback_beam_path_calc.is_in_beam:
+                self.is_rotating = readback_beam_path_calc.is_displacing
+                self._trigger_after_moving_state_update()
+                break
 
     def _update_angle(self, source):
         """

--- a/ReflectometryServer/beam_path_calc.py
+++ b/ReflectometryServer/beam_path_calc.py
@@ -265,7 +265,6 @@ class TrackingBeamPathCalc(object):
         """
         TODO
         """
-        print("SET: component(beam_path_calc)[displacing]: {}".format(self._is_displacing))
         return self._is_displacing
 
     @is_displacing.setter
@@ -274,7 +273,6 @@ class TrackingBeamPathCalc(object):
          TODO
         """
         self._is_displacing = value
-        print("SET: component(beam_path_calc)[displacing]: {}".format(value))
         self._trigger_after_moving_state_update()
 
     @property
@@ -282,7 +280,6 @@ class TrackingBeamPathCalc(object):
         """
         TODO
         """
-        print("GET: component(beam_path_calc)[rotating]: {}".format(self._is_rotating))
         return self._is_rotating
 
     @is_rotating.setter
@@ -291,7 +288,6 @@ class TrackingBeamPathCalc(object):
          TODO
         """
         self._is_rotating = value
-        print("SET: component(beam_path_calc)[rotating]: {}".format(value))
         self._trigger_after_moving_state_update()
 
     def add_after_physical_move_listener(self, listener):

--- a/ReflectometryServer/beam_path_calc.py
+++ b/ReflectometryServer/beam_path_calc.py
@@ -460,9 +460,9 @@ class BeamPathCalcThetaRBV(_BeamPathCalcReflecting):
         for readback_beam_path_calc, setpoint_beam_path_calc in self._angle_to:
             readback_beam_path_calc.add_after_physical_move_listener(self._update_angle)
             setpoint_beam_path_calc.add_after_physical_move_listener(self._update_angle)
-            readback_beam_path_calc.add_after_is_changing_change_listener(self._on_moving_state_update)
+            readback_beam_path_calc.add_after_is_changing_change_listener(self._on_is_changing_change)
 
-    def _on_moving_state_update(self):
+    def _on_is_changing_change(self):
         for readback_beam_path_calc, setpoint_beam_path_calc in self._angle_to:
             if readback_beam_path_calc.is_in_beam:
                 self.is_rotating = readback_beam_path_calc.is_displacing

--- a/ReflectometryServer/beam_path_calc.py
+++ b/ReflectometryServer/beam_path_calc.py
@@ -26,8 +26,11 @@ class TrackingBeamPathCalc(object):
         self._after_beam_path_update_listeners = set()
         self._after_beam_path_update_on_init_listeners = set()
         self._after_physical_move_listeners = set()
+        self._after_moving_state_update_listeners = set()
         self._init_listeners = set()
         self._is_in_beam = True
+        self._is_displacing = False
+        self._is_rotating = False
         self._movement_strategy = movement_strategy
 
         self.autosaved_offset = None
@@ -63,6 +66,19 @@ class TrackingBeamPathCalc(object):
         Runs initialisation listeners because an initial value has been read.
         """
         for listener in self._init_listeners:
+            listener()
+
+    def add_after_moving_state_update_listener(self, listener):
+        """
+        TODO
+        """
+        self._after_moving_state_update_listeners.add(listener)
+
+    def _trigger_after_moving_state_update(self):
+        """
+        TODO
+        """
+        for listener in self._after_moving_state_update_listeners:
             listener()
 
     def add_after_beam_path_update_listener(self, listener):
@@ -243,6 +259,40 @@ class TrackingBeamPathCalc(object):
         self._is_in_beam = is_in_beam
         self._trigger_after_beam_path_update()
         self._trigger_after_physical_move_listener()
+
+    @property
+    def is_displacing(self):
+        """
+        TODO
+        """
+        print("SET: component(beam_path_calc)[displacing]: {}".format(self._is_displacing))
+        return self._is_displacing
+
+    @is_displacing.setter
+    def is_displacing(self, value):
+        """
+         TODO
+        """
+        self._is_displacing = value
+        print("SET: component(beam_path_calc)[displacing]: {}".format(value))
+        self._trigger_after_moving_state_update()
+
+    @property
+    def is_rotating(self):
+        """
+        TODO
+        """
+        print("GET: component(beam_path_calc)[rotating]: {}".format(self._is_rotating))
+        return self._is_rotating
+
+    @is_rotating.setter
+    def is_rotating(self, value):
+        """
+         TODO
+        """
+        self._is_rotating = value
+        print("SET: component(beam_path_calc)[rotating]: {}".format(value))
+        self._trigger_after_moving_state_update()
 
     def add_after_physical_move_listener(self, listener):
         """

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -28,6 +28,7 @@ class IocDriver(object):
 
         self._axis.add_after_rbv_change_listener(self._on_update_rbv)
         self._axis.add_after_sp_change_listener(self._on_update_sp)
+        self._axis.add_after_is_changing_change_listener(self._on_update_is_changing)
 
     def __repr__(self):
         return "{} for axis pv {} and component {}".format(
@@ -133,6 +134,14 @@ class IocDriver(object):
         """
         self._sp_cache = value
 
+    def _on_update_is_changing(self, value, alarm_severity, alarm_status):
+        """
+        Updates the cached is_moving field for the motor record with a new value if the underlying motor rbv is changing
+        Args:
+            value: The new is_moving value
+        """
+        raise NotImplemented()
+
     def at_target_setpoint(self):
         """
         Returns: True if the setpoint on the component and the one on the motor PV are the same (within tolerance),
@@ -212,6 +221,14 @@ class DisplacementDriver(IocDriver):
         """
         return self._out_of_beam_position is not None
 
+    def _on_update_is_changing(self, value, alarm_severity, alarm_status):
+        """
+        Updates the cached is_moving field for the motor record with a new value if the underlying motor rbv is changing
+        Args:
+            value: The new is_moving value
+        """
+        self._component.beam_path_rbv.is_displacing = value
+
 
 class AngleDriver(IocDriver):
     """
@@ -245,3 +262,11 @@ class AngleDriver(IocDriver):
 
     def _get_set_point_position(self):
         return self._component.beam_path_set_point.angle
+
+    def _on_update_is_changing(self, value, alarm_severity, alarm_status):
+        """
+        Updates the cached is_moving field for the motor record with a new value if the underlying motor rbv is changing
+        Args:
+            value: The new is_moving value
+        """
+        self._component.beam_path_rbv.is_rotating = value

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -65,7 +65,7 @@ class BeamlineParameter(object):
         self._after_is_changing_change_listeners = set()
         self._after_rbv_at_sp_listeners = set()
         self._init_listeners = set()
-        self.rbv_to_sp_tolerance = rbv_to_sp_tolerance
+        self._rbv_to_sp_tolerance = rbv_to_sp_tolerance
 
     def __repr__(self):
         return "{} '{}': sp={}, sp_rbv={}, rbv={}, changed={}".format(__name__, self.name, self._set_point,
@@ -113,7 +113,7 @@ class BeamlineParameter(object):
         """
         Returns: Does the read back value match the set point target within a defined tolerance
         """
-        if self.rbv is None or self._set_point_rbv is None or abs(self.rbv - self._set_point_rbv) > self.rbv_to_sp_tolerance:
+        if self.rbv is None or self._set_point_rbv is None or abs(self.rbv - self._set_point_rbv) > self._rbv_to_sp_tolerance:
             return 0
         else:
             return 1

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -41,7 +41,7 @@ class BeamlineParameter(object):
     General beamline parameter that can be set. Subclass must implement _move_component to decide what to do with the
     value that is set.
     """
-    def __init__(self, name, sim=False, init=None, description=None, autosave=False, rbv_tolerance=0.04):
+    def __init__(self, name, sim=False, init=None, description=None, autosave=False, rbv_tolerance=0.01):
         if sim:
             self._set_point = init
             self._set_point_rbv = init
@@ -104,12 +104,12 @@ class BeamlineParameter(object):
 
     @property
     def rbv_at_position(self):
-        if abs(self.rbv - self._set_point_rbv) > self.rbv_tolerance:
+        if self.rbv is None or self._set_point_rbv is None or abs(self.rbv - self._set_point_rbv) > self.rbv_tolerance:
             print("PARAM:@Property:rbv_at_position:{}:FALSE ({:0.3f})".format(self.name, abs(self.rbv - self._set_point_rbv)))
-            return False
+            return 0
         else:
             #print("PARAM:@Property:rbv_at_position:{}:true ({:0.3f})".format(self.name, abs(self.rbv - self._set_point_rbv)))
-            return True
+            return 1
 
     @property
     def sp_rbv(self):
@@ -212,6 +212,7 @@ class BeamlineParameter(object):
         rbv = self._rbv()
         for listener in self._rbv_change_listeners:
             listener(rbv)
+        self._trigger_after_rbv_at_position_update()
 
     @property
     def is_changing(self):
@@ -262,6 +263,7 @@ class BeamlineParameter(object):
         """
         for listener in self._sp_rbv_change_listeners:
             listener(self._set_point_rbv)
+        self._trigger_after_rbv_at_position_update()
 
     def add_init_listener(self, listener):
         self._init_listeners.add(listener)

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -114,9 +114,9 @@ class BeamlineParameter(object):
         Returns: Does the read back value match the set point target within a defined tolerance
         """
         if self.rbv is None or self._set_point_rbv is None or abs(self.rbv - self._set_point_rbv) > self._rbv_to_sp_tolerance:
-            return 0
+            return False
         else:
-            return 1
+            return True
 
     @property
     def sp_rbv(self):
@@ -486,6 +486,16 @@ class TrackingPosition(BeamlineParameter):
         return self._component.beam_path_rbv.get_position_relative_to_beam()
 
     @property
+    def rbv_at_sp(self):
+        """
+        Returns: Does the read back value match the set point target within a defined tolerance
+        """
+        if self.rbv is None or self._set_point_rbv is None or abs(self.rbv - self._set_point_rbv) > self._rbv_to_sp_tolerance and self._component.beam_path_set_point.is_in_beam:
+            return False
+        else:
+            return True
+
+    @property
     def is_changing(self):
         """
         Returns: Is the parameter changing (displacing)
@@ -585,6 +595,16 @@ class InBeamParameter(BeamlineParameter):
 
     def _rbv(self):
         return self._component.beam_path_rbv.is_in_beam
+
+    @property
+    def rbv_at_sp(self):
+        """
+        Returns: Does the read back value match the set point target within a defined tolerance
+        """
+        if self.rbv is None or self._set_point_rbv is None or abs(self.rbv - self._set_point_rbv) > self._rbv_to_sp_tolerance and self._component.beam_path_rbv.is_in_beam:
+            return False
+        else:
+            return True
 
     @property
     def is_changing(self):

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -105,10 +105,8 @@ class BeamlineParameter(object):
     @property
     def rbv_at_position(self):
         if self.rbv is None or self._set_point_rbv is None or abs(self.rbv - self._set_point_rbv) > self.rbv_tolerance:
-            print("PARAM:@Property:rbv_at_position:{}:FALSE ({:0.3f})".format(self.name, abs(self.rbv - self._set_point_rbv)))
             return 0
         else:
-            #print("PARAM:@Property:rbv_at_position:{}:true ({:0.3f})".format(self.name, abs(self.rbv - self._set_point_rbv)))
             return 1
 
     @property
@@ -226,25 +224,19 @@ class BeamlineParameter(object):
     def _trigger_after_moving_state_update(self):
         """
         """
-        print("PARAM:_trigger_after_moving_state_update:{}".format(self.is_changing))
         for listener in self._after_moving_state_update_listeners:
             listener(self.is_changing)
 
     def add_after_rbv_at_position_listener(self, listener):
         """
         """
-        print("PARAM:add_after_rbv_at_position:{}".format(listener))
         self._after_at_position_listeners.add(listener)
 
     def _trigger_after_rbv_at_position_update(self):
         """
         """
-        print("---- PARA: triggering after_at_position listeners")
-        print("PARAM:_trigger_after_rbv_at_position_update:{}".format(self.rbv_at_position))
         for listener in self._after_at_position_listeners:
-            print("PARAM:_trigger_after_rbv_at_position_update:{}".format(listener))
             listener(self.rbv_at_position)
-        print("----------")
 
     def add_sp_rbv_change_listener(self, listener):
         """

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -488,12 +488,14 @@ class TrackingPosition(BeamlineParameter):
     @property
     def rbv_at_sp(self):
         """
-        Returns: Does the read back value match the set point target within a defined tolerance
+        Returns: Does the read back value match the set point target within a defined tolerance and the component is in
+            the beam
         """
-        if self.rbv is None or self._set_point_rbv is None or abs(self.rbv - self._set_point_rbv) > self._rbv_to_sp_tolerance and self._component.beam_path_set_point.is_in_beam:
+        if self.rbv is None or self._set_point_rbv is None:
             return False
-        else:
-            return True
+
+        return not self._component.beam_path_set_point.is_in_beam or \
+            abs(self.rbv - self._set_point_rbv) <= self._rbv_to_sp_tolerance
 
     @property
     def is_changing(self):
@@ -601,10 +603,10 @@ class InBeamParameter(BeamlineParameter):
         """
         Returns: Does the read back value match the set point target within a defined tolerance
         """
-        if self.rbv is None or self._set_point_rbv is None or abs(self.rbv - self._set_point_rbv) > self._rbv_to_sp_tolerance and self._component.beam_path_rbv.is_in_beam:
+        if self.rbv is None or self._set_point_rbv is None:
             return False
-        else:
-            return True
+
+        return abs(self.rbv - self._set_point_rbv) < self._rbv_to_sp_tolerance
 
     @property
     def is_changing(self):

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -32,6 +32,7 @@ class PVWrapper(object):
         self._prefixed_pv = "{}{}".format(MYPVPREFIX, base_pv)
         self._after_rbv_change_listeners = set()
         self._after_sp_change_listeners = set()
+        self._after_dmov_change_listeners = set()
 
         self._move_initiated = False
         self._moving_state = None
@@ -82,6 +83,8 @@ class PVWrapper(object):
                          partial(self._trigger_listeners, "readback value", self._after_rbv_change_listeners))
         self._monitor_pv(self._sp_pv,
                          partial(self._trigger_listeners, "setpoint value", self._after_sp_change_listeners))
+        self._monitor_pv(self._dmov_pv,
+                         partial(self._trigger_listeners, "moving state value", self._after_dmov_change_listeners))
 
         self._monitor_pv(self._dmov_pv, self._on_update_moving_state)
         self._monitor_pv(self._velo_pv, self._on_update_velocity)
@@ -302,13 +305,10 @@ class _JawsAxisPVWrapper(PVWrapper):
         """
         self.is_vertical = is_vertical
         self._individual_moving_states = {}
-        self._state_init_events = {}
+        self._state_init_event = Event()
 
         self._directions = []
         self._set_directions()
-
-        for key in self._directions:
-            self._state_init_events[key] = Event()
 
         super(_JawsAxisPVWrapper, self).__init__(base_pv, ca)
 
@@ -346,9 +346,8 @@ class _JawsAxisPVWrapper(PVWrapper):
                          partial(self._trigger_listeners, "readback value", self._after_rbv_change_listeners))
         self._monitor_pv(self._sp_pv,
                          partial(self._trigger_listeners, "setpoint value", self._after_sp_change_listeners))
-
-        for dmov_pv in self._pv_names_for_directions("MTR.DMOV"):
-            self._monitor_pv(dmov_pv, partial(self._on_update_moving_state, source=self._strip_source_pv(dmov_pv)))
+        self._monitor_pv(self._dmov_pv,
+                         partial(self._on_update_moving_state, "moving state value"))
 
     @property
     def velocity(self):
@@ -397,12 +396,10 @@ class _JawsAxisPVWrapper(PVWrapper):
             alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
             alarm_status (server_common.channel_access.AlarmCondition): the alarm status
         """
-        self._individual_moving_states[source] = new_value
-        overall_state = self._get_overall_moving_state()
-        if overall_state == MTR_STOPPED and self._v_restore is not None:
+        if new_value == MTR_STOPPED and self._v_restore is not None:
             self.velocity = self._v_restore
-        self._moving_state = overall_state
-        self._state_init_events[source].set()
+        self._moving_state = new_value
+        self._state_init_event.set()
 
     def _init_velocity_to_restore(self, value):
         """
@@ -411,25 +408,12 @@ class _JawsAxisPVWrapper(PVWrapper):
         """
         v_init = value
         v_autosaved = read_autosave_value(self.name, AutosaveType.VELOCITY)
-        for key, event in self._state_init_events.items():
-            event.wait()
+        self._state_init_event.wait()
         if self._moving_state == MTR_MOVING:
             if v_autosaved is not None:
                 v_init = v_autosaved
         self._v_restore = v_init
         write_autosave_value(self.name, v_init, AutosaveType.VELOCITY)
-
-    def _get_overall_moving_state(self):
-        """
-        Returns the overall moving state of the jaws. If every individual axis is stopped the overall state is stopped,
-        otherwise the state is moving.
-
-        Returns: The overall moving state.
-        """
-        overall_state = MTR_MOVING
-        if all(state == MTR_STOPPED for state in self._individual_moving_states.values()):
-            overall_state = MTR_STOPPED
-        return overall_state
 
     def _strip_source_pv(self, pv):
         """
@@ -443,6 +427,7 @@ class _JawsAxisPVWrapper(PVWrapper):
         for key in self._directions:
             if key in pv:
                 return key
+        logger.error("Unexpected event source: {}".format(pv))
         logger.error("Unexpected event source: {}".format(pv))
 
 
@@ -464,6 +449,7 @@ class JawsGapPVWrapper(_JawsAxisPVWrapper):
         """
         self._sp_pv = "{}:{}GAP:SP".format(self._prefixed_pv, self._direction_symbol)
         self._rbv_pv = "{}:{}GAP".format(self._prefixed_pv, self._direction_symbol)
+        self._dmov_pv = "{}:{}GAP:DMOV".format(self._prefixed_pv, self._direction_symbol)
 
 
 class JawsCentrePVWrapper(_JawsAxisPVWrapper):
@@ -487,3 +473,4 @@ class JawsCentrePVWrapper(_JawsAxisPVWrapper):
         """
         self._sp_pv = "{}:{}CENT:SP".format(self._prefixed_pv, self._direction_symbol)
         self._rbv_pv = "{}:{}CENT".format(self._prefixed_pv, self._direction_symbol)
+        self._dmov_pv = "{}:{}CENT:DMOV".format(self._prefixed_pv, self._direction_symbol)

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -242,6 +242,9 @@ class PVWrapper(object):
         self._trigger_listeners(self._after_is_changing_change_listeners, self._dmov_to_bool(new_value), alarm_severity, alarm_status)
 
     def _dmov_to_bool(self, value):
+        """
+        Converts the inverted dmov (0=True, 1=False) to the standard format
+        """
         return not value
 
     def _on_update_velocity(self, value, alarm_severity, alarm_status):

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -128,6 +128,7 @@ class MockMotorPVWrapper(object):
         self.after_rbv_change_listener = set()
         self.after_sp_change_listener = set()
         self.after_status_change_listener = set()
+        self.after_is_changing_change_listener = set()
         self.after_velocity_change_listener = set()
         self.is_vertical = is_vertical
 
@@ -142,6 +143,9 @@ class MockMotorPVWrapper(object):
 
     def add_after_status_change_listener(self, listener):
         self.after_status_change_listener.add(listener)
+
+    def add_after_is_changing_change_listener(self, listener):
+        self.after_is_changing_change_listener.add(listener)
 
     def add_after_velocity_change_listener(self, listener):
         self.after_velocity_change_listener.add(listener)


### PR DESCRIPTION
### Description of work

![refl_colour_change](https://user-images.githubusercontent.com/43140680/61786421-8c188f00-ae05-11e9-94eb-6d606549e9fc.gif)


#### Additions
Two new PV types:

- `CHANGING`: Is the parameter (and underlying component/s) value changing.
- `RBV:AT_SP`: Has the read back value arrived at target set point.

The `CHANGING` PV can be used to establish if the parameter (and its underlying components) value is changing. And while currently this extends to rotating (for angular components), displacing (for displacement and binary components), it's general enough to extend to other future components that can ramp for example.

The `RBV:AT_SP` PV is used as a confirmation that given some requested change via a target set point, that the read back value matches this within some tolerance. This tolerance is an new available argument when creating the parameter in the configuration file. As a side note the binary `InBeamParameter` parameter has a hard coded tolerance by design.

#### Implementation

At the lowest level in the `PVWrapper` we wrap a given axis and now have a representation of its moving state via the `dmov` field of the motor record via monitors. 

This value is passed up the layers using either the standard listener/trigger method for all components except jaws. This uses the standard naming convention of `is_moving` at the `PVWrapper` layer as currently is ties directly to an axis. At all other levels the standard of `is_changing` is used. The `BeamPathCalcThetaRBV` class also has a unique `_on_is_changing_change` method as theta is dependant on calculations from the PDOffset.

NB: `SlitGapsParameter` uses the standard direct route of `Axis->parameter` mapping bypassing the layers.

#### GUI

A few additions were made to the GUI OPI:

- A new linking container for the column headers of data outputs/inputs was created and placed into the OPI appropriately.
- If a parameter is changing then the objects background will turn green to indicate this (controlled via a rule).
- If a parameter has arrived at its intended set point target and is outside of the set tolerance, then the background will turn red (controlled via a rule).
- Minor tweaks: Matched size of updating text and spacing for `param.opi` and `param_move.opi`.


#### Tests

Additional tests have been created to validate these changes and can be found in the IoC Test Framework.

### To test

[#4295](https://github.com/ISISComputingGroup/IBEX/issues/4295)

### Acceptance criteria

- [x] The changing state of a parameter can be observed
- [x] The confirmation that a read back value has arrived at a set point target within some given tolerance can be observed

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [x] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
