### PR TITLE
Added log message warning if set_curr_config is used incorrectly

### DIFF
--- a/block_server.py
+++ b/block_server.py
@@ -301,15 +301,26 @@ class BlockServer(Driver):
         self._initialise_config()
 
     def _set_curr_config(self, details):
-        """Sets the current configuration details to that defined in the XML, saves to disk, then initialises it.
+        """Sets the current configuration details to that defined in the JSON, saves to disk,
+        then re-initialises the current configuration.
 
         Args:
-            details (string): the configuration XML
+            details (string): the configuration JSON
         """
-        # Need to save the config to file before we initialize or the changes won't be propagated to IOCS
 
+        current_name = self._active_configserver.get_config_name()
+        details_name = convert_from_json(details)["name"]
+
+        # This method saves the given details and then reloads the current config.
+        # Sending the details of a new config to this method, as was being done incorrectly (see #4606)
+        # will save the details as a new config, but not load it. A warning is sent in case this happens again.
+        if current_name != details_name:
+            print_and_log("Config details to be set ({}) did not match current config ({})"
+                          .format(details_name, current_name), "MINOR")
+
+        # Need to save the config to file before we initialize or the changes won't be propagated to IOCS
         self.save_inactive_config(details)
-        self.load_config(self._active_configserver.get_config_name(), full_init=False)
+        self.load_config(current_name, full_init=False)
 
     def _initialise_config(self, full_init=False):
         """Responsible for initialising the configuration.


### PR DESCRIPTION
### Description of work

Updated the docstring to reflect the new behaviour changed in https://github.com/ISISComputingGroup/EPICS-inst_servers/commit/fad6941f4e289b10dd722b5bafaa5e0b2f03150e. Added a warning which gets logged if `set_curr_config` is used incorrectly.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4605

### Acceptance criteria

- [x] A warning is logged by the BlockServer if the method is used incorrectly (see ticket and the GUI PR for an incorrect use)

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
