### PR TITLE
Ticket4541 Take backlash into account for move duration

### DIFF
--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -400,8 +400,14 @@ class Beamline(object):
         Issue move for all drivers at the speed of the slowest axis and set appropriate status for failure/success.
         """
         try:
-            self._perform_move_for_all_drivers(self._get_max_move_duration())
-            self.set_status(STATUS.OKAY, "")
+
+            try:
+                self._perform_move_for_all_drivers(self._get_max_move_duration())
+                self.set_status(STATUS.OKAY, "")
+            except ZeroDivisionError as e:
+                print(str(e))
+                self.set_status(STATUS.CONFIG_ERROR, str(e))
+
         except (ValueError, UnableToConnectToPVException) as e:
             self.set_status(STATUS.GENERAL_ERROR, e.message)
 

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -405,7 +405,7 @@ class Beamline(object):
                 self._perform_move_for_all_drivers(self._get_max_move_duration())
                 self.set_status(STATUS.OKAY, "")
             except ZeroDivisionError as e:
-                print(str(e))
+                logger.error("Failed to perform move: {}".format(e))
                 self.set_status(STATUS.CONFIG_ERROR, str(e))
 
         except (ValueError, UnableToConnectToPVException) as e:

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -69,9 +69,8 @@ class IocDriver(object):
         Returns: gets the parameters used for calculating duration
         direction, rbv, sp, bdst, mvel, bvel
         """
-        return self._axis.direction, self.rbv_cache(),\
-               self._get_set_point_position(), self._axis.backlash_distance,\
-               self._axis.max_velocity, self._axis.backlash_velocity
+        return self._axis.direction, self.rbv_cache(), self._get_set_point_position(),\
+               self._axis.backlash_distance, self._axis.max_velocity, self._axis.backlash_velocity
 
     def _backlash_duration(self, (direction, rbv, sp, bdst, vmax, bvel)):
         """
@@ -84,8 +83,12 @@ class IocDriver(object):
             bvel: the backlash velocity
         Returns: the duration of the backlash move
         """
-        if direction == "Pos":
-            bdst = bdst * -1
+        # If the speeds are zero on a motor which is going to move, error as it makes no sense
+        # to move a non-zero distance with a zero velocity
+        if vmax == 0 or vmax is None and not (bvel == 0 or bvel is None):
+            raise ZeroDivisionError("Motor max velocity is zero or none")
+        if bvel == 0 or bvel is None and not (vmax == 0 or vmax is None):
+            raise ZeroDivisionError("Backlash speed is zero or none")
 
         if bvel == 0 or bvel is None:
             # Return 0 instead of error as when this is called by perform_move it can be on motors which are
@@ -97,29 +100,33 @@ class IocDriver(object):
         else:
             return math.fabs(bdst) / bvel
 
+    def _base_move_duration(self, (direction, rbv, sp, bdst, vmax, bvel)):
+        """
+        Args:
+            direction: the current dir setting of the motor
+            rbv: the position read back value
+            sp: the set point
+            bdst: the backlash distance
+            vmax: the maximum velocity (not used)
+            bvel: the backlash velocity
+        Returns: the duration move without the backlash
+        """
+        if not (min([0, bdst]) <= rbv - sp <= max([0, bdst])):
+            # If the motor is not already within the backlash distance
+            return math.fabs(rbv - (sp + bdst)) / vmax
+        else:
+            return 0
+
     def get_max_move_duration(self):
         """
         Returns: The maximum duration of the requested move for all associated axes. If axes are not synchronised this
         will return 0 but movement will still be required.
         """
         if self._axis_will_move() and self._synchronised:
-            direction, rbv, sp, bdst, vmax, bvel = self._get_duration_parameters()
+            base_move_duration = self._base_move_duration(self._get_duration_parameters())
+            backlash_duration = self._backlash_duration(self._get_duration_parameters())
 
-            # If the speeds are zero on a motor which is going to move, error as it makes no sense
-            # to move a non-zero distance with a zero velocity
-            if vmax == 0 or vmax is None:
-                raise ZeroDivisionError("Motor max is zero or none")
-            if bvel == 0 or bvel is None:
-                raise ZeroDivisionError("Backlash speed is zero or none")
-
-            duration = self._backlash_duration(self._get_duration_parameters())
-
-            if direction == "Pos":
-                bdst = bdst * -1
-
-            if not (min([0, bdst]) <= rbv - sp <= max([0, bdst])):
-                # If the motor is not already within the backlash distance
-                duration += math.fabs(rbv - (sp + bdst)) / vmax
+            duration = base_move_duration + backlash_duration
 
             return duration
         else:
@@ -133,9 +140,9 @@ class IocDriver(object):
             move_duration (float): The duration in which to perform this move
             force (bool): move even if component does not report changed
         """
-        move_duration -= self._backlash_duration(self._get_duration_parameters())
-
+        
         if self._axis_will_move() or force:
+            move_duration -= self._backlash_duration(self._get_duration_parameters())
             logger.debug("Moving axis {} {}".format(self._axis.name, self._get_distance()))
             if move_duration > 1e-6 and self._synchronised:
                 self._axis.initiate_move_with_change_of_velocity()
@@ -172,8 +179,6 @@ class IocDriver(object):
         :return: The distance between the target component position and the actual motor position in y.
         """
         bdst = self._axis.backlash_distance
-        if self._axis.direction == "Pos":
-            bdst = bdst * -1
         return math.fabs(self.rbv_cache() - (self._get_set_point_position() + bdst))
 
     def _get_set_point_position(self):

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -85,9 +85,9 @@ class IocDriver(object):
         """
         # If the speeds are zero on a motor which is going to move, error as it makes no sense
         # to move a non-zero distance with a zero velocity
-        if vmax == 0 or vmax is None and not (bvel == 0 or bvel is None):
+        if vmax == 0 or vmax is None:
             raise ZeroDivisionError("Motor max velocity is zero or none")
-        if bvel == 0 or bvel is None and not (vmax == 0 or vmax is None):
+        if (bvel == 0 or bvel is None) and not (bdst == 0 or bdst is None):
             raise ZeroDivisionError("Backlash speed is zero or none")
 
         if bvel == 0 or bvel is None:
@@ -123,8 +123,8 @@ class IocDriver(object):
         will return 0 but movement will still be required.
         """
         if self._axis_will_move() and self._synchronised:
-            base_move_duration = self._base_move_duration(self._get_duration_parameters())
             backlash_duration = self._backlash_duration(self._get_duration_parameters())
+            base_move_duration = self._base_move_duration(self._get_duration_parameters())
 
             duration = base_move_duration + backlash_duration
 
@@ -140,7 +140,7 @@ class IocDriver(object):
             move_duration (float): The duration in which to perform this move
             force (bool): move even if component does not report changed
         """
-        
+
         if self._axis_will_move() or force:
             move_duration -= self._backlash_duration(self._get_duration_parameters())
             logger.debug("Moving axis {} {}".format(self._axis.name, self._get_distance()))

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -8,6 +8,7 @@ from threading import Event
 from ReflectometryServer.ChannelAccess.constants import MYPVPREFIX, MTR_MOVING, MTR_STOPPED
 from ReflectometryServer.file_io import AutosaveType, read_autosave_value, write_autosave_value
 import logging
+import math
 
 from server_common.channel_access import ChannelAccess, UnableToConnectToPVException
 
@@ -37,6 +38,9 @@ class PVWrapper(object):
         self._moving_state = None
         self._v_restore = None
         self._v_curr = None
+        self._d_back = None
+        self._v_back = None
+        self._dir = None
         self.max_velocity = None
         self._state_init_event = Event()
         self._velocity_event = Event()
@@ -54,6 +58,9 @@ class PVWrapper(object):
         self._velo_pv = ""
         self._vmax_pv = ""
         self._dmov_pv = ""
+        self._bdst_pv = ""
+        self._bvel_pv = ""
+        self._dir_pv = ""
         raise NotImplementedError()
 
     def _set_resolution(self):
@@ -75,6 +82,9 @@ class PVWrapper(object):
         """
         self._add_monitors()
         self._v_curr = self._read_pv(self._velo_pv)
+        self._d_back = self._read_pv(self._bdst_pv)
+        self._v_back = self._read_pv(self._bvel_pv)
+        self._dir = self._read_pv(self._dir_pv)
 
     def _add_monitors(self):
         """
@@ -87,6 +97,9 @@ class PVWrapper(object):
 
         self._monitor_pv(self._dmov_pv, self._on_update_moving_state)
         self._monitor_pv(self._velo_pv, self._on_update_velocity)
+        self._monitor_pv(self._bdst_pv, self._on_update_backlash_distance)
+        self._monitor_pv(self._bvel_pv, self._on_update_backlash_velocity)
+        self._monitor_pv(self._dir_pv, self._on_update_direction)
 
     def _monitor_pv(self, pv, call_back_function):
         """
@@ -192,6 +205,27 @@ class PVWrapper(object):
         """
         return self._v_curr
 
+    @property
+    def backlash_distance(self):
+        """
+        Returns: the value of the underlying backlash distance PV
+        """
+        return self._d_back
+
+    @property
+    def backlash_velocity(self):
+        """
+        Returns: the value of the underlying backlash velocity PV
+        """
+        return self._v_back
+
+    @property
+    def direction(self):
+        """
+        Returns: the value of the underlying direction PV
+        """
+        return self._dir
+
     @velocity.setter
     def velocity(self, value):
         """
@@ -263,6 +297,48 @@ class PVWrapper(object):
         self._v_restore = v_init
         write_autosave_value(self.name, v_init, AutosaveType.VELOCITY)
 
+    def _on_update_backlash_distance(self, value, alarm_severity, alarm_status):
+        """
+        React to an update in the backlash distance of the underlying motor axis.
+
+        Params:
+            value (Boolean): The new backlash distance
+            alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
+            alarm_status (server_common.channel_access.AlarmCondition): the alarm status
+        """
+        self._d_back = value
+
+    def _on_update_backlash_velocity(self, value, alarm_severity, alarm_status):
+        """
+        React to an update in the backlash velocity of the underlying motor axis.
+
+        Params:
+            value (Boolean): The new backlash distance
+            alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
+            alarm_status (server_common.channel_access.AlarmCondition): the alarm status
+        """
+        self._v_back = value
+
+    def _on_update_direction(self, value, alarm_severity, alarm_status):
+        """
+        React to an update in the direction of the underlying motor axis.
+
+        Params:
+            value (Boolean): The new backlash distance
+            alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
+            alarm_status (server_common.channel_access.AlarmCondition): the alarm status
+        """
+        self._dir = value
+
+    def get_distance(self, rbv, set_point_position):
+        """
+        Args:
+            rbv: the read back value
+            set_point_position: the set point position
+        Returns: The distance between the target component position and the actual motor position in y.
+        """
+        raise NotImplemented("This should be implemented in the subclass")
+
 
 class MotorPVWrapper(PVWrapper):
     """
@@ -286,6 +362,9 @@ class MotorPVWrapper(PVWrapper):
         self._velo_pv = "{}.VELO".format(self._prefixed_pv)
         self._vmax_pv = "{}.VMAX".format(self._prefixed_pv)
         self._dmov_pv = "{}.DMOV".format(self._prefixed_pv)
+        self._bdst_pv = "{}.BDST".format(self._prefixed_pv)
+        self._bvel_pv = "{}.BVEL".format(self._prefixed_pv)
+        self._dir_pv = "{}.DIR".format(self._prefixed_pv)
 
     def _set_resolution(self):
         """

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -210,7 +210,10 @@ class PVWrapper(object):
         """
         Returns: the value of the underlying backlash distance PV
         """
-        return self._d_back
+        if self._dir == "Pos":
+            return self._d_back * -1
+        else:
+            return self._d_back
 
     @property
     def backlash_velocity(self):

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -128,6 +128,8 @@ class MockMotorPVWrapper(object):
         self.velocity = None
         self.direction = direction
         self.backlash_distance = backlash_distance
+        if self.direction == "Pos":
+            self.backlash_distance = backlash_distance * -1
         self.backlash_velocity = backlash_velocity
         self.resolution = DEFAULT_TEST_TOLERANCE
         self.after_rbv_change_listener = set()

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -103,27 +103,32 @@ class DataMother(object):
         return bl, axes
 
 
-def create_mock_axis(name, init_position, max_velocity):
+def create_mock_axis(name, init_position, max_velocity, backlash_distance=0, backlash_velocity=1, direction="Pos"):
     """
     Create a mock axis
     Args:
         name: pv name of axis
         init_position: initial position
         max_velocity: maximum velocity of the axis
-
+        backlash_distance: distance that the axis will backlash
+        backlash_velocity: velocity that the backlash is performed
+        direction: calibration direction of the axis, Pos or Neg
     Returns:
             mocked axis
     """
 
-    return MockMotorPVWrapper(name, init_position, max_velocity)
+    return MockMotorPVWrapper(name, init_position, max_velocity, True, backlash_distance, backlash_velocity, direction)
 
 
 class MockMotorPVWrapper(object):
-    def __init__(self, pv_name, init_position, max_velocity, is_vertical=True):
+    def __init__(self, pv_name, init_position, max_velocity, is_vertical=True, backlash_distance=0, backlash_velocity=1, direction="Neg"):
         self.name = pv_name
         self._value = init_position
         self.max_velocity = max_velocity
         self.velocity = None
+        self.direction = direction
+        self.backlash_distance = backlash_distance
+        self.backlash_velocity = backlash_velocity
         self.resolution = DEFAULT_TEST_TOLERANCE
         self.after_rbv_change_listener = set()
         self.after_sp_change_listener = set()

--- a/ReflectometryServer/test_modules/test_ioc_driving_layer.py
+++ b/ReflectometryServer/test_modules/test_ioc_driving_layer.py
@@ -1,6 +1,7 @@
 import unittest
 from math import fabs
 
+from parameterized import parameterized
 
 from mock import MagicMock, patch
 from hamcrest import *
@@ -453,3 +454,105 @@ class BeamlineMoveDurationTest(unittest.TestCase):
 
         self.beamline.move = 1
         assert_that(self.beamline.status, is_(STATUS.GENERAL_ERROR))
+
+
+class BeamlineBacklashMoveDurationTest(unittest.TestCase):
+
+    @parameterized.expand([
+        (  # Error when speeds are 0
+            {"max_vel": 0, "start": 0, "set": 0.5, "back_dist": 0, "back_speed": 0, "dir": "Pos"},
+            {"max_vel": 0, "start": 0, "set": 10, "back_dist": 0, "back_speed": 0, "dir": "Pos"},
+            "ERROR"
+        ),
+        (  # No backlash distance
+            {"max_vel": 20, "start": 0, "set": 0.5, "back_dist": 0, "back_speed": 1, "dir": "Pos"},
+            {"max_vel": 0.2, "start": 0, "set": 10, "back_dist": 0, "back_speed": 0.1, "dir": "Pos"},
+            50  # 10/0.2
+        ),
+        (  # Test where backlash is in same direction as motion
+            {"max_vel": 20, "start": 0, "set": 0.5, "back_dist": 0, "back_speed": 1, "dir": "Pos"},
+            {"max_vel": 0.2, "start": 0, "set": 10, "back_dist": 2, "back_speed": 0.1, "dir": "Pos"},
+            60  # (10-2)/0.2 + 2/0.1
+        ),
+        (  # Test where backlash is in the opposite direction to set point
+            {"max_vel": 20, "start": 0.5, "set": 0, "back_dist": 0, "back_speed": 1, "dir": "Pos"},
+            {"max_vel": 0.2, "start": 10, "set": 0, "back_dist": 2, "back_speed": 0.1, "dir": "Pos"},
+            80  # (10+2)/0.2 + 2/0.1
+        ),
+        (  # Test where move starts already within backlash distance
+            {"max_vel": 20, "start": 0, "set": 0.5, "back_dist": 0, "back_speed": 1, "dir": "Pos"},
+            {"max_vel": 0.2, "start": 0, "set": 1, "back_dist": 2, "back_speed": 0.1, "dir": "Pos"},
+            10  # 1/0.1
+        ),
+        (  # Test where move starts within backlash distance but not from backlash direction
+            {"max_vel": 20, "start": 0.5, "set": 0, "back_dist": 0, "back_speed": 1, "dir": "Pos"},
+            {"max_vel": 0.2, "start": 1, "set": 0, "back_dist": 2, "back_speed": 0.1, "dir": "Pos"},
+            35  # (1+2)/0.2 + 2/0.1
+        ),
+        (  # Test where both axes have backlash
+            {"max_vel": 20, "start": 0, "set": 0.5, "back_dist": 0.1, "back_speed": 0.1, "dir": "Pos"},
+            {"max_vel": 0.2, "start": 0, "set": 0.1, "back_dist": 2, "back_speed": 0.1, "dir": "Pos"},
+            1.02  # (0.5-0.1)/20 + 0.1/0.1
+        ),
+        (  # Test where backlash is in same direction as motion and axes are Neg
+            {"max_vel": 20, "start": 0, "set": 0.5, "back_dist": 0, "back_speed": 1, "dir": "Neg"},
+            {"max_vel": 0.2, "start": 0, "set": 10, "back_dist": 2, "back_speed": 0.1, "dir": "Neg"},
+            80  # (10+2)/0.2 + 2/0.1
+        ),
+        (  # Test where backlash is in the opposite direction to set point and axes are Neg
+            {"max_vel": 20, "start": 0.5, "set": 0, "back_dist": 0, "back_speed": 1, "dir": "Neg"},
+            {"max_vel": 0.2, "start": 10, "set": 0, "back_dist": 2, "back_speed": 0.1, "dir": "Neg"},
+            60  # (10-2)/0.2 + 2/0.1
+        ),
+        (  # Test where move starts already within backlash distance and axes are Neg
+            {"max_vel": 20, "start": 0, "set": 0.5, "back_dist": 0, "back_speed": 1, "dir": "Neg"},
+            {"max_vel": 0.2, "start": 0, "set": 1, "back_dist": 2, "back_speed": 0.1, "dir": "Neg"},
+            35  # (1+2)/0.2 + 2/0.1
+        ),
+        (  # Test where move starts within backlash distance but not from backlash direction and axes are Neg
+            {"max_vel": 20, "start": 0.5, "set": 0, "back_dist": 0, "back_speed": 1, "dir": "Neg"},
+            {"max_vel": 0.2, "start": 1, "set": 0, "back_dist": 2, "back_speed": 0.1, "dir": "Neg"},
+            10  # 1/0.1
+        ),
+        (  # Test where both axes have backlash and axes are Neg
+            {"max_vel": 20, "start": 0, "set": 0.5, "back_dist": 0.1, "back_speed": 0.1, "dir": "Neg"},
+            {"max_vel": 0.2, "start": 0, "set": 0.1, "back_dist": 2, "back_speed": 0.1, "dir": "Neg"},
+            30.5  # (0.1+2)/0.2 + 2/0.1
+        ),
+        (  # Test where both axes have backlash and one axis is Neg
+            {"max_vel": 20, "start": 0, "set": 0.5, "back_dist": 0.1, "back_speed": 0.1, "dir": "Neg"},
+            {"max_vel": 0.2, "start": 0, "set": 0.1, "back_dist": 2, "back_speed": 0.1, "dir": "Pos"},
+            1.03  # (0.5+0.1)/20 + 0.1/0.1
+        ),
+    ])
+    def test_GIVEN_two_axes_with_backlash_WHEN_triggering_move_THEN_components_move_at_speed_of_slowest_axis(
+            self, pos, ang, expected_max_duration):
+
+        detector = TiltingComponent("point_detector", setup=PositionAndAngle(y=0.0, z=6.0, angle=90.0))
+        detector_height_axis = create_mock_axis("HEIGHT", pos["start"], pos["max_vel"], pos["back_dist"], pos["back_speed"], pos["dir"])
+        detector_tilt_axis = create_mock_axis("TILT", ang["start"], ang["max_vel"], ang["back_dist"], ang["back_speed"], ang["dir"])
+        detector_driver_disp = DisplacementDriver(detector, detector_height_axis)
+        detector_driver_ang = AngleDriver(detector, detector_tilt_axis)
+        det_pos = TrackingPosition("det_pos", detector)
+        det_ang = AngleParameter("det_ang", detector)
+
+        components = [detector]
+        beamline_parameters = [det_pos, det_ang]
+        drivers = [detector_driver_disp, detector_driver_ang]
+        mode = BeamlineMode("mode name",
+                            [det_pos.name, det_ang.name])
+        beam_start = PositionAndAngle(0.0, 0.0, 0.0)
+        beamline = Beamline(components, beamline_parameters, drivers, [mode], beam_start)
+
+        beamline.active_mode = mode.name
+
+        det_pos.sp_no_move = pos["set"]
+        det_ang.sp_no_move = ang["set"]
+
+        with patch.object(beamline, '_perform_move_for_all_drivers') as mock:
+            beamline.move = 1
+
+            if expected_max_duration == "ERROR":
+                mock.assert_not_called()
+            else:
+                mock.assert_called_with(expected_max_duration)

--- a/ReflectometryServer/test_modules/test_ioc_driving_layer.py
+++ b/ReflectometryServer/test_modules/test_ioc_driving_layer.py
@@ -459,10 +459,15 @@ class BeamlineMoveDurationTest(unittest.TestCase):
 class BeamlineBacklashMoveDurationTest(unittest.TestCase):
 
     @parameterized.expand([
-        (  # Error when speeds are 0
+        (  # Error when max_vel is 0
             {"max_vel": 0, "start": 0, "set": 0.5, "back_dist": 0, "back_speed": 0, "dir": "Pos"},
             {"max_vel": 0, "start": 0, "set": 10, "back_dist": 0, "back_speed": 0, "dir": "Pos"},
             "ERROR"
+        ),
+        (  # No error when back_speed is 0 if back_dist is also 0
+            {"max_vel": 1, "start": 0, "set": 0.5, "back_dist": 0, "back_speed": 0, "dir": "Pos"},
+            {"max_vel": 1, "start": 0, "set": 10, "back_dist": 0, "back_speed": 0, "dir": "Pos"},
+            10  # 10/1
         ),
         (  # No backlash distance
             {"max_vel": 20, "start": 0, "set": 0.5, "back_dist": 0, "back_speed": 1, "dir": "Pos"},

--- a/ReflectometryServer/test_modules/test_pv_wrapper.py
+++ b/ReflectometryServer/test_modules/test_pv_wrapper.py
@@ -88,7 +88,18 @@ class TestMotorPVWrapper(unittest.TestCase):
 
         self.assertEqual(expected_rbv, actual_rbv)
 
-    def test_GIVEN_base_pv_WHEN_creating_motor_pv_wrapper_THEN_backlash_distance_is_initialised_correctly(self):
+    def test_GIVEN_base_pv_and_positive_dir_WHEN_creating_motor_pv_wrapper_THEN_backlash_distance_is_initialised_correctly(self):
+        self.mock_ca.caput(self.dir_pv, "Pos")
+        expected_bdst = self.bdst * -1
+
+        wrapper = MotorPVWrapper(self.motor_name, ca=self.mock_ca)
+        wrapper.initialise()
+        actual_bdst = wrapper.backlash_distance
+
+        self.assertEqual(expected_bdst, actual_bdst)
+
+    def test_GIVEN_base_pv_and_negative_dir_WHEN_creating_motor_pv_wrapper_THEN_backlash_distance_is_initialised_correctly(self):
+        self.mock_ca.caput(self.dir_pv, "Neg")
         expected_bdst = self.bdst
 
         wrapper = MotorPVWrapper(self.motor_name, ca=self.mock_ca)

--- a/ReflectometryServer/test_modules/test_pv_wrapper.py
+++ b/ReflectometryServer/test_modules/test_pv_wrapper.py
@@ -25,16 +25,25 @@ class TestMotorPVWrapper(unittest.TestCase):
         self.mres_pv = _create_pv(self.motor_name, ".MRES")
         self.vmax_pv = _create_pv(self.motor_name, ".VMAX")
         self.velo_pv = _create_pv(self.motor_name, ".VELO")
+        self.bdst_pv = _create_pv(self.motor_name, ".BDST")
+        self.bvel_pv = _create_pv(self.motor_name, ".BVEL")
+        self.dir_pv = _create_pv(self.motor_name, ".DIR")
         self.sp = 1.0
         self.rbv = 1.1
         self.mres = 0.1
         self.vmax = 1
         self.velo = 0.5
+        self.bdst = 0.05
+        self.bvel = 0.1
+        self.dir = "Pos"
         self.mock_motor_pvs = {self.sp_pv: self.sp,
                                self.rbv_pv: self.rbv,
                                self.mres_pv: self.mres,
                                self.vmax_pv: self.vmax,
-                               self.velo_pv: self.velo
+                               self.velo_pv: self.velo,
+                               self.bdst_pv: self.bdst,
+                               self.bvel_pv: self.bvel,
+                               self.dir_pv: self.dir
                                }
         self.mock_ca = MockChannelAccess(self.mock_motor_pvs)
 
@@ -78,6 +87,33 @@ class TestMotorPVWrapper(unittest.TestCase):
         actual_rbv = wrapper.rbv
 
         self.assertEqual(expected_rbv, actual_rbv)
+
+    def test_GIVEN_base_pv_WHEN_creating_motor_pv_wrapper_THEN_backlash_distance_is_initialised_correctly(self):
+        expected_bdst = self.bdst
+
+        wrapper = MotorPVWrapper(self.motor_name, ca=self.mock_ca)
+        wrapper.initialise()
+        actual_bdst = wrapper.backlash_distance
+
+        self.assertEqual(expected_bdst, actual_bdst)
+
+    def test_GIVEN_base_pv_WHEN_creating_motor_pv_wrapper_THEN_backlash_velocity_is_initialised_correctly(self):
+        expected_bvel = self.bvel
+
+        wrapper = MotorPVWrapper(self.motor_name, ca=self.mock_ca)
+        wrapper.initialise()
+        actual_bvel = wrapper.backlash_velocity
+
+        self.assertEqual(expected_bvel, actual_bvel)
+
+    def test_GIVEN_base_pv_WHEN_creating_motor_pv_wrapper_THEN_direction_is_initialised_correctly(self):
+        expected_dir = self.dir
+
+        wrapper = MotorPVWrapper(self.motor_name, ca=self.mock_ca)
+        wrapper.initialise()
+        actual_dir = wrapper.direction
+
+        self.assertEqual(expected_dir, actual_dir)
 
 
 class TestJawsAxisPVWrapper(unittest.TestCase):


### PR DESCRIPTION
### Description of work

The server now gets the direction and backlash move and speed for each axis and uses them to take backlash into account for move duration calculation. To ensure that motors still move at the intended speed, also modified `perform_move` to subtract the duration of the backlash from the previously calculated duration.
Added errors when motor or backlash speed is 0, as this would cause it to divide by zero.

Updated wiki [Reflectometry Composite Driving Layer](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reflectometry-Composite-Driving-Layer)

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4541

### Unit tests

Added new tests for the PV wrapper and added new tests for the IOC driver which checks the calculations in a variety of situations.

### Acceptance criteria

- [ ] When moving the beamline, all axes finish at roughly the same time even if the backlash distance makes up a considerable part of the total move duration for some axes.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
