### PR TITLE
Ticket4462 init beam path

### DIFF
--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -332,7 +332,7 @@ class AngleParameter(BeamlineParameter):
         """
         Get the setpoint value for this parameter based on the motor setpoint position.
         """
-        init_sp = self._reflection_component.beam_path_set_point.angle
+        init_sp = self._reflection_component.beam_path_set_point.get_angle_relative_to_beam()
         self._set_initial_sp(init_sp)
 
     def _move_component(self):

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -1,7 +1,7 @@
 """
 Parameters that the user would interact with
 """
-from file_io import AutosaveType, read_autosave_value, write_autosave_value
+from ReflectometryServer.file_io import AutosaveType, read_autosave_value, write_autosave_value
 import logging
 
 from enum import Enum
@@ -322,8 +322,9 @@ class AngleParameter(BeamlineParameter):
         sp_init = read_autosave_value(self._name, AutosaveType.PARAM)
         if sp_init is not None:
             try:
-                angle = float(sp_init)
-                self._set_initial_sp(angle)
+                sp_init = float(sp_init)
+                self._set_initial_sp(sp_init)
+                self._reflection_component.beam_path_set_point.autosaved_angle = sp_init
                 self._move_component()
             except ValueError as e:
                 self._log_autosave_type_error()

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -1,14 +1,16 @@
 """
 Test data and classes.
 """
+from math import tan, radians
+
 from utils import DEFAULT_TEST_TOLERANCE
 
 from ReflectometryServer.beamline import BeamlineMode, Beamline
-from ReflectometryServer.components import Component, TiltingComponent, ThetaComponent
+from ReflectometryServer.components import Component, TiltingComponent, ThetaComponent, ReflectingComponent
 from ReflectometryServer.geometry import PositionAndAngle
 from ReflectometryServer.ioc_driver import DisplacementDriver, AngleDriver
 from ReflectometryServer.parameters import BeamlineParameter, TrackingPosition, AngleParameter
-from time import time
+
 
 class EmptyBeamlineParameter(BeamlineParameter):
     """
@@ -66,12 +68,13 @@ class DataMother(object):
         Returns: beamline, axes
 
         """
-        # components
+        # COMPONENTS
         s1 = Component("s1_comp", PositionAndAngle(0.0, 1 * spacing, 90))
         s3 = Component("s3_comp", PositionAndAngle(0.0, 3 * spacing, 90))
         detector = TiltingComponent("Detector_comp", PositionAndAngle(0.0, 4 * spacing, 90))
         theta = ThetaComponent("ThetaComp_comp", PositionAndAngle(0.0, 2 * spacing, 90), [detector])
         comps = [s1, theta, s3, detector]
+
         # BEAMLINE PARAMETERS
         slit1_pos = TrackingPosition("s1", s1, True)
         slit3_pos = TrackingPosition("s3", s3, True)
@@ -79,7 +82,8 @@ class DataMother(object):
         detector_position = TrackingPosition("det", detector, True)
         detector_angle = AngleParameter("det_angle", detector, True)
         params = [slit1_pos, theta_ang, slit3_pos, detector_position, detector_angle]
-        # DRIVES
+
+        # DRIVERS
         s1_axis = create_mock_axis("MOT:MTR0101", 0, 1)
         s3_axis = create_mock_axis("MOT:MTR0102", 0, 1)
         det_axis = create_mock_axis("MOT:MTR0104", 0, 1)
@@ -98,6 +102,57 @@ class DataMother(object):
         disabled_mode = BeamlineMode("DISABLED", [param.name for param in params], nr_inits, is_disabled=True)
         modes = [nr_mode, disabled_mode]
         beam_start = PositionAndAngle(0.0, 0.0, 0.0)
+        bl = Beamline(comps, params, drives, modes, beam_start)
+        bl.active_mode = nr_mode.name
+        return bl, axes
+
+    @staticmethod
+    def beamline_sm_theta_detector(sm_angle, theta, det_offset=0, autosave_theta_not_offset=True):
+        """
+        Create beamline with Slits 1 and 3 a theta and a detector
+        Args:
+            spacing: spacing between components
+
+        Returns: beamline, axes
+
+        """
+        # COMPONENTS
+        z_sm_to_sample = 1
+        z_sample_to_det = 2
+        sm_comp = ReflectingComponent("sm_comp", PositionAndAngle(0.0, 0, 90))
+        detector_comp = TiltingComponent("detector_comp", PositionAndAngle(0.0, z_sm_to_sample + z_sample_to_det, 90))
+        theta_comp = ThetaComponent("theta_comp", PositionAndAngle(0.0, z_sm_to_sample, 90), [detector_comp])
+
+        comps = [sm_comp, theta_comp, detector_comp]
+
+        # BEAMLINE PARAMETERS
+        sm_angle_param = AngleParameter("sm_angle", sm_comp)
+        theta_param = AngleParameter("theta", theta_comp, autosave=autosave_theta_not_offset)
+        detector_position_param = TrackingPosition("det_pos", detector_comp, autosave=not autosave_theta_not_offset)
+        detector_angle_param = AngleParameter("det_angle", detector_comp)
+
+        params = [sm_angle_param, theta_param, detector_position_param, detector_angle_param]
+
+        # DRIVERS
+        beam_angle_after_sample = theta * 2 + sm_angle * 2
+        offset_from_sm_angle = z_sm_to_sample * tan(radians(sm_angle * 2))
+        offset_from_theta = z_sample_to_det * tan(radians(beam_angle_after_sample))
+        sm_axis = create_mock_axis("MOT:MTR0101", sm_angle, 1)
+        det_axis = create_mock_axis("MOT:MTR0104", offset_from_sm_angle + offset_from_theta + det_offset, 1)
+        det_angle_axis = create_mock_axis("MOT:MTR0105", beam_angle_after_sample, 1)
+        axes = {"sm_axis": sm_axis,
+                "det_axis": det_axis,
+                "det_angle_axis": det_angle_axis}
+
+        drives = [AngleDriver(sm_comp, sm_axis),
+                  DisplacementDriver(detector_comp, det_axis),
+                  AngleDriver(detector_comp, det_angle_axis)]
+
+        # MODES
+        nr_inits = {}
+        nr_mode = BeamlineMode("NR", [param.name for param in params], nr_inits)
+        modes = [nr_mode]
+        beam_start = PositionAndAngle(0.0, 0.0, -1)
         bl = Beamline(comps, params, drives, modes, beam_start)
         bl.active_mode = nr_mode.name
         return bl, axes

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -3,7 +3,7 @@ import unittest
 
 from math import tan, radians
 from hamcrest import *
-from mock import Mock, patch
+from mock import Mock, patch, MagicMock
 
 from ReflectometryServer import *
 
@@ -286,5 +286,84 @@ class TestBeamlineModeInitialization(unittest.TestCase):
         mock_mode_inits.assert_not_called()
 
 
+class TestRealisticWithAutosaveInit(unittest.TestCase):
+
+    @patch("ReflectometryServer.parameters.read_autosave_value")
+    def test_GIVEN_beam_line_where_autosave_theta_at_0_WHEN_init_THEN_beamline_is_at_given_place(self, file_io):
+        expected_sm_angle = 22.5
+        expected_theta = 0
+        file_io.return_value = expected_theta
+
+        bl, drives = DataMother.beamline_sm_theta_detector(expected_sm_angle, expected_theta)
+
+        assert_that(bl.parameter("sm_angle").sp, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP")
+        assert_that(bl.parameter("theta").sp, is_(close_to(expected_theta, 1e-6)), "theta SP")
+        assert_that(bl.parameter("det_pos").sp, is_(close_to(0, 1e-6)), "det position SP")
+        assert_that(bl.parameter("det_angle").sp, is_(close_to(0, 1e-6)), "det angle SP")
+
+        assert_that(bl.parameter("sm_angle").sp_rbv, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP RBV")
+        assert_that(bl.parameter("theta").sp_rbv, is_(close_to(expected_theta, 1e-6)), "theta SP RBV")
+        assert_that(bl.parameter("det_pos").sp_rbv, is_(close_to(0, 1e-6)), "det position SP RBV")
+        assert_that(bl.parameter("det_angle").sp_rbv, is_(close_to(0, 1e-6)), "det angle SP RBV")
+
+    @patch("ReflectometryServer.parameters.read_autosave_value")
+    def test_GIVEN_beam_line_where_autosave_theta_at_non_zero_WHEN_init_THEN_beamline_is_at_given_place(self, file_io):
+        expected_sm_angle = 22.5
+        expected_theta = 2
+        file_io.return_value = expected_theta
+
+        bl, drives = DataMother.beamline_sm_theta_detector(expected_sm_angle, expected_theta)
+
+        assert_that(bl.parameter("sm_angle").sp, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP")
+        assert_that(bl.parameter("theta").sp, is_(close_to(expected_theta, 1e-6)), "theta SP")
+        assert_that(bl.parameter("det_pos").sp, is_(close_to(0, 1e-6)), "det position SP")
+        assert_that(bl.parameter("det_angle").sp, is_(close_to(0, 1e-6)), "det angle SP")
+
+        assert_that(bl.parameter("sm_angle").sp_rbv, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP RBV")
+        assert_that(bl.parameter("theta").sp_rbv, is_(close_to(expected_theta, 1e-6)), "theta SP RBV")
+        assert_that(bl.parameter("det_pos").sp_rbv, is_(close_to(0, 1e-6)), "det position SP RBV")
+        assert_that(bl.parameter("det_angle").sp_rbv, is_(close_to(0, 1e-6)), "det angle SP RBV")
+
+    @patch("ReflectometryServer.parameters.read_autosave_value")
+    def test_GIVEN_beam_line_where_autosave_det_offset_at_zero_WHEN_init_THEN_beamline_is_at_given_place(self, file_io):
+        expected_sm_angle = 22.5
+        expected_theta = 0
+        expected_det_offset = 0
+        file_io.return_value = expected_det_offset
+
+        bl, drives = DataMother.beamline_sm_theta_detector(expected_sm_angle, expected_theta, autosave_theta_not_offset=False)
+
+        assert_that(bl.parameter("sm_angle").sp, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP")
+        assert_that(bl.parameter("theta").sp, is_(close_to(expected_theta, 1e-6)), "theta SP")
+        assert_that(bl.parameter("det_pos").sp, is_(close_to(0, 1e-6)), "det position SP")
+        assert_that(bl.parameter("det_angle").sp, is_(close_to(0, 1e-6)), "det angle SP")
+
+        assert_that(bl.parameter("sm_angle").sp_rbv, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP RBV")
+        assert_that(bl.parameter("theta").sp_rbv, is_(close_to(expected_theta, 1e-6)), "theta SP RBV")
+        assert_that(bl.parameter("det_pos").sp_rbv, is_(close_to(0, 1e-6)), "det position SP RBV")
+        assert_that(bl.parameter("det_angle").sp_rbv, is_(close_to(0, 1e-6)), "det angle SP RBV")
+
+    @patch("ReflectometryServer.parameters.read_autosave_value")
+    def test_GIVEN_beam_line_where_autosave_det_offset_at_non_zero_WHEN_init_THEN_beamline_is_at_given_place(self, file_io):
+        expected_sm_angle = 22.5
+        expected_theta = 0
+        expected_det_offset = 1
+        file_io.return_value = expected_det_offset
+
+        bl, drives = DataMother.beamline_sm_theta_detector(expected_sm_angle, expected_theta, expected_det_offset, autosave_theta_not_offset=False)
+
+        assert_that(bl.parameter("sm_angle").sp, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP")
+        assert_that(bl.parameter("theta").sp, is_(close_to(expected_theta, 1e-6)), "theta SP")
+        assert_that(bl.parameter("det_pos").sp, is_(close_to(expected_det_offset, 1e-6)), "det position SP")
+        assert_that(bl.parameter("det_angle").sp, is_(close_to(0, 1e-6)), "det angle SP")
+
+        assert_that(bl.parameter("sm_angle").sp_rbv, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP RBV")
+        assert_that(bl.parameter("theta").sp_rbv, is_(close_to(expected_theta, 1e-6)), "theta SP RBV")
+        assert_that(bl.parameter("det_pos").sp_rbv, is_(close_to(expected_det_offset, 1e-6)), "det position SP RBV")
+        assert_that(bl.parameter("det_angle").sp_rbv, is_(close_to(0, 1e-6)), "det angle SP RBV")
+
+
 if __name__ == '__main__':
     unittest.main()
+
+


### PR DESCRIPTION
### Description of work

Fixes a bug where setpoint and readback values after  theta would be initialised incorrectly if the incoming beam at theta was not the straight through beam as the outgoing beam from theta SP was wrong.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4462

### Acceptance criteria

Given a supermirror in beam with non-zero angle on IOC startup, a detector with offset and a Theta angled to this detector:
- [x] If theta and/or detector offset parameters are autosaved, their SPs are initialised to the autosaved values
- [x] If they are not autosaved, their setpoint is initialised to the same as the readback value
- [x] All values are exactly where they were before after a reflectometry IOC restart

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
