### PR TITLE
Ticket2328/4624 Database server reads default macro values if they are available

### DIFF
--- a/DatabaseServer/options_loader.py
+++ b/DatabaseServer/options_loader.py
@@ -25,6 +25,7 @@ TAG_IOC_CONFIG = 'ioc_config'
 CONFIG_PART = 'config_part'
 TAG_PATTERN = 'pattern'
 TAG_DESCRIPTION = 'description'
+TAG_DEFAULT = 'defaultValue'
 
 
 def create_xpath_search(group, individual):
@@ -65,7 +66,8 @@ class OptionsLoader(object):
                 # Get any macros
                 for macro in ioc.findall(MACROS):
                     iocs[name.upper()].macros[macro.attrib[TAG_NAME]] = {TAG_DESCRIPTION: macro.attrib[TAG_DESCRIPTION],
-                                                                            TAG_PATTERN: macro.attrib.get(TAG_PATTERN)}
+                                                                         TAG_PATTERN: macro.attrib.get(TAG_PATTERN),
+                                                                         TAG_DEFAULT: macro.attrib.get(TAG_DEFAULT)}
 
                 # Get any pvsets
                 for pvset in ioc.findall(PVSETS):

--- a/DatabaseServer/options_loader.py
+++ b/DatabaseServer/options_loader.py
@@ -26,6 +26,7 @@ CONFIG_PART = 'config_part'
 TAG_PATTERN = 'pattern'
 TAG_DESCRIPTION = 'description'
 TAG_DEFAULT = 'defaultValue'
+TAG_HAS_DEFAULT = 'hasDefault'
 
 
 def create_xpath_search(group, individual):
@@ -67,7 +68,8 @@ class OptionsLoader(object):
                 for macro in ioc.findall(MACROS):
                     iocs[name.upper()].macros[macro.attrib[TAG_NAME]] = {TAG_DESCRIPTION: macro.attrib[TAG_DESCRIPTION],
                                                                          TAG_PATTERN: macro.attrib.get(TAG_PATTERN),
-                                                                         TAG_DEFAULT: macro.attrib.get(TAG_DEFAULT)}
+                                                                         TAG_DEFAULT: macro.attrib.get(TAG_DEFAULT),
+                                                                         TAG_HAS_DEFAULT: macro.attrib[TAG_HAS_DEFAULT]}
 
                 # Get any pvsets
                 for pvset in ioc.findall(PVSETS):

--- a/DatabaseServer/options_loader.py
+++ b/DatabaseServer/options_loader.py
@@ -69,7 +69,7 @@ class OptionsLoader(object):
                     iocs[name.upper()].macros[macro.attrib[TAG_NAME]] = {TAG_DESCRIPTION: macro.attrib[TAG_DESCRIPTION],
                                                                          TAG_PATTERN: macro.attrib.get(TAG_PATTERN),
                                                                          TAG_DEFAULT: macro.attrib.get(TAG_DEFAULT),
-                                                                         TAG_HAS_DEFAULT: macro.attrib[TAG_HAS_DEFAULT]}
+                                                                         TAG_HAS_DEFAULT: macro.attrib.get(TAG_HAS_DEFAULT)}
 
                 # Get any pvsets
                 for pvset in ioc.findall(PVSETS):

--- a/DatabaseServer/test_files/config.xml
+++ b/DatabaseServer/test_files/config.xml
@@ -3,9 +3,9 @@
 	<ioc_config name="SIMPLE1">
 		<config_part>
 			<macros>		
-				<macro description="COM port to use for communication" name="COMPORT" pattern="COM[0-9]+:"/>
-				<macro description="TEST" name="ANOTHERMACRO" pattern="COM[0-9]+:"/>
-				<macro description="TEST" name="FINALMACRO" pattern="COM[0-9]+:"/>
+				<macro description="COM port to use for communication" name="COMPORT" pattern="COM[0-9]+:" hasDefault="UNKNOWN"/>
+				<macro description="TEST" name="ANOTHERMACRO" pattern="COM[0-9]+:" hasDefault="UNKNOWN"/>
+				<macro description="TEST" name="FINALMACRO" pattern="COM[0-9]+:" hasDefault="UNKNOWN"/>
 			</macros>
 			<pvsets>
 				<pvset description="Motor high and low limits" name="Motor Limits"/>
@@ -21,8 +21,8 @@
 	<ioc_config name="SIMPLE2">
 		<config_part>
 			<macros>
-				<macro description="COM port to use for communication" name="COMPORT" pattern="COM[0-9]+:"/>
-				<macro description="TEST" name="ANOTHERMACRO" pattern="COM[0-9]+:"/>
+				<macro description="COM port to use for communication" name="COMPORT" pattern="COM[0-9]+:" hasDefault="UNKNOWN"/>
+				<macro description="TEST" name="ANOTHERMACRO" pattern="COM[0-9]+:" hasDefault="UNKNOWN"/>
 			</macros>
 			<pvsets>
 				<pvset description="Motor high and low limits" name="Motor Limits"/>

--- a/schema/iocs.xsd
+++ b/schema/iocs.xsd
@@ -72,6 +72,9 @@
 	  <xs:attribute name="description" use="optional" type="xs:string">
         <xs:annotation><xs:documentation>macro description</xs:documentation></xs:annotation>      
       </xs:attribute>
+      <xs:attribute name="defaultValue" use="optional" type="xs:string">
+        <xs:annotation><xs:documentation>macro default value</xs:documentation></xs:annotation>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/schema/iocs.xsd
+++ b/schema/iocs.xsd
@@ -75,6 +75,9 @@
       <xs:attribute name="defaultValue" use="optional" type="xs:string">
         <xs:annotation><xs:documentation>macro default value</xs:documentation></xs:annotation>
       </xs:attribute>
+      <xs:attribute name="hasDefault" use="optional" type="xs:string">
+        <xs:annotation><xs:documentation>whether the macro has a default</xs:documentation></xs:annotation>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
 </xs:schema>


### PR DESCRIPTION
### Description of work

As title.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2328
https://github.com/ISISComputingGroup/IBEX/issues/4624

### Acceptance criteria

- [ ] Default macro values in IOC config.xml are read by the database server and can be picked up by the GUI.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
