### PR TITLE
Ticket 4251 -  Individual move of theta causes other parameters to move

### DIFF
--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -684,7 +684,7 @@ class SlitGapParameter(BeamlineParameter):
         pass
 
     def _move_component(self):
-        self._pv_wrapper.sp = self._set_point
+        self._pv_wrapper.sp = self._set_point_rbv
 
     def _rbv(self):
         return self._rbv_value

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -645,11 +645,12 @@ class SlitGapParameter(BeamlineParameter):
         else:
             self.group_names.append(BeamlineParameterGroup.GAP_HORIZONTAL)
 
-
         if self._autosave:
             self._initialise_sp_from_file()
         if self._set_point_rbv is None:
             self._initialise_sp_from_motor()
+        if sim:
+            self._rbv_value = init
 
     def _initialise_sp_from_file(self):
         """

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -125,7 +125,7 @@ class DataMother(object):
         return bl, axes
 
     @staticmethod
-    def beamline_s1_gaps_theta_detector(spacing):
+    def beamline_s1_gap_theta_s3_gap_detector(spacing):
         """
         Create beamline with Slits 1 and 3 a theta and a detector
         Args:
@@ -136,6 +136,7 @@ class DataMother(object):
         """
         # DRIVERS
         s1_gap_axis = create_mock_axis("MOT:MTR0101", 0, 1)
+        s3_gap_axis = create_mock_axis("MOT:MTR0103", 0, 1)
         axes = {"s1_gap_axis": s1_gap_axis}
         drives = []
 
@@ -147,9 +148,10 @@ class DataMother(object):
         # BEAMLINE PARAMETERS
         s1_gap = SlitGapParameter("s1_gap", s1_gap_axis, sim=True)
         theta_ang = AngleParameter("theta", theta, sim=True)
+        s3_gap = SlitGapParameter("s3_gap", s3_gap_axis, sim=True)
         detector_position = TrackingPosition("det", detector, sim=True)
         detector_angle = AngleParameter("det_angle", detector, sim=True)
-        params = [s1_gap, theta_ang, detector_position, detector_angle]
+        params = [s1_gap, theta_ang, s3_gap, detector_position, detector_angle]
 
         # MODES
         nr_inits = {}

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -479,6 +479,21 @@ class TestBeamlineOnMove(unittest.TestCase):
 
         assert_that(param_init_position, is_(close_to(param_final_position, delta=1e-6)))
 
+    @parameterized.expand([("s1_gap", 2.452, "theta", 4.012), ("s1_gap", 4.223, "theta", 1.632)])
+    def test_GIVEN_slit_gap_parameter_WHEN_theta_moved_independently_THEN_slit_gap_parameter_unchanged(self, param, param_sp, theta, theta_sp):
+        spacing = 2.0
+        bl, drives = DataMother.beamline_s1_gaps_theta_detector(spacing)
+
+        param_init_position = bl.parameter(param).rbv
+
+        bl.parameter(param).sp_no_move = param_sp
+        bl.parameter(theta).sp_no_move = theta_sp
+        bl.parameter(theta).move = 1  # Move only theta
+
+        param_final_position = bl.parameter(param).rbv
+
+        assert_that(param_init_position, is_(close_to(param_final_position, delta=1e-6)))
+
 
 class TestBeamlineParameterReadback(unittest.TestCase):
 

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -479,7 +479,7 @@ class TestBeamlineOnMove(unittest.TestCase):
 
         assert_that(param_init_position, is_(close_to(param_final_position, delta=1e-6)))
 
-    @parameterized.expand([("s1_gap", 2.452, "theta", 4.012), ("s1_gap", 4.223, "theta", 1.632)])
+    @parameterized.expand([("s3_gap", 2.452, "theta", 4.012), ("s3_gap", 4.223, "theta", 1.632)])
     def test_GIVEN_slit_gap_parameter_WHEN_theta_moved_independently_THEN_slit_gap_parameter_unchanged(self, param, param_sp, theta, theta_sp):
         spacing = 2.0
         bl, drives = DataMother.beamline_s1_gaps_theta_detector(spacing)
@@ -492,7 +492,7 @@ class TestBeamlineOnMove(unittest.TestCase):
 
         param_final_position = bl.parameter(param).rbv
 
-        assert_that(param_init_position, is_(close_to(param_final_position, delta=1e-6)))
+        assert_that(param_final_position, is_(close_to(param_init_position, delta=1e-6)))
 
 
 class TestBeamlineParameterReadback(unittest.TestCase):

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -4,6 +4,7 @@ from math import isnan
 
 from hamcrest import *
 from mock import Mock
+from parameterized import parameterized
 
 from ReflectometryServer import *
 from ReflectometryServer import file_io
@@ -462,6 +463,21 @@ class TestBeamlineOnMove(unittest.TestCase):
         moves = [beamline_parameter.move_component_count for beamline_parameter in beamline_parameters]
 
         assert_that(moves, contains(1, 1, 1), "beamline parameter move counts")
+
+    @parameterized.expand([("s1", 12.132, "theta", 4.012), ("s3", 1.123, "theta", 2.342)])
+    def test_GIVEN_parameter_with_new_sp_WHEN_theta_moved_independently_THEN_parameter_unchanged(self, param, param_sp, theta, theta_sp):
+        spacing = 2.0
+        bl, drives = DataMother.beamline_s1_s3_theta_detector(spacing)
+
+        param_init_position = bl.parameter(param).rbv
+
+        bl.parameter(param).sp_no_move = param_sp
+        bl.parameter(theta).sp_no_move = theta_sp
+        bl.parameter(theta).move = 1  # Move only theta
+
+        param_final_position = bl.parameter(param).rbv
+
+        assert_that(param_init_position, is_(close_to(param_final_position, delta=1e-6)))
 
 
 class TestBeamlineParameterReadback(unittest.TestCase):


### PR DESCRIPTION
### Description of work

- Changed the method for move component to use the set point read back (rather than set point).
- Created tests for the server to detect if this spurious behavior occurs again.

### To test

[#4251](https://github.com/ISISComputingGroup/IBEX/issues/4251)

### Acceptance criteria

- [ ] Performing an individual move on theta etc will not move other components on the beamline with `SP_NO_MOVE` changes.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
