### PR TITLE
Ticket3906 comp angle relative to beam

### DIFF
--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -146,7 +146,8 @@ class Beamline(object):
                 the beamline
             modes(list[BeamlineMode])
             incoming_beam (ReflectometryServer.geometry.PositionAndAngle): the incoming beam point
-                (defaults to position 0,0 and angle 0)
+                Defaults to position 0,0 and angle 0 in mantid coordinates, i.e the natural beam as it enters the
+                blockhouse.
             footprint_setup (ReflectometryServer.BaseFootprintSetup.BaseFootprintSetup): the foot print setup
         """
 
@@ -184,11 +185,11 @@ class Beamline(object):
 
         self._incoming_beam = incoming_beam if incoming_beam is not None else PositionAndAngle(0, 0, 0)
 
-        for driver in self._drivers:
-            driver.initialise()
-
         self.update_next_beam_component(None, self._beam_path_calcs_rbv)
         self.update_next_beam_component(None, self._beam_path_calcs_set_point)
+
+        for driver in self._drivers:
+            driver.initialise()
 
         self._active_mode = None
         self._initialise_mode(modes)

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -1,7 +1,7 @@
 """
 Test data and classes.
 """
-from math import tan, radians
+from math import tan, radians, sin, cos
 
 from utils import DEFAULT_TEST_TOLERANCE
 
@@ -107,21 +107,29 @@ class DataMother(object):
         return bl, axes
 
     @staticmethod
-    def beamline_sm_theta_detector(sm_angle, theta, det_offset=0, autosave_theta_not_offset=True):
+    def beamline_sm_theta_detector(sm_angle, theta, det_offset=0, autosave_theta_not_offset=True, beam_angle=0.0):
         """
-        Create beamline with Slits 1 and 3 a theta and a detector
+        Create beamline with supermirror, theta and a tilting detector.
+
         Args:
-            spacing: spacing between components
+            sm_angle (float): The initialisation value for supermirror angle
+            theta (float): The initialisation value for theta
+            det_offset (float): The initialisation value for detector offset
+            autosave_theta_not_offset (bool):
+            beam_start (PositionAndAngle):
 
         Returns: beamline, axes
 
         """
+        beam_start = PositionAndAngle(0.0, 0.0, 0.0)
+        perp_to_floor_angle_in_mantid = 90 + beam_angle
+
         # COMPONENTS
         z_sm_to_sample = 1
         z_sample_to_det = 2
-        sm_comp = ReflectingComponent("sm_comp", PositionAndAngle(0.0, 0, 90))
-        detector_comp = TiltingComponent("detector_comp", PositionAndAngle(0.0, z_sm_to_sample + z_sample_to_det, 90))
-        theta_comp = ThetaComponent("theta_comp", PositionAndAngle(0.0, z_sm_to_sample, 90), [detector_comp])
+        sm_comp = ReflectingComponent("sm_comp", PositionAndAngle(0.0, 0, perp_to_floor_angle_in_mantid))
+        detector_comp = TiltingComponent("detector_comp", PositionAndAngle(0.0, z_sm_to_sample + z_sample_to_det, perp_to_floor_angle_in_mantid))
+        theta_comp = ThetaComponent("theta_comp", PositionAndAngle(0.0, z_sm_to_sample, perp_to_floor_angle_in_mantid), [detector_comp])
 
         comps = [sm_comp, theta_comp, detector_comp]
 
@@ -135,11 +143,12 @@ class DataMother(object):
 
         # DRIVERS
         beam_angle_after_sample = theta * 2 + sm_angle * 2
-        offset_from_sm_angle = z_sm_to_sample * tan(radians(sm_angle * 2))
-        offset_from_theta = z_sample_to_det * tan(radians(beam_angle_after_sample))
+        supermirror_segment = (z_sm_to_sample, sm_angle)
+        theta_segment = (z_sample_to_det, theta)
+        reflection_offset = DataMother._calc_reflection_offset(beam_angle, [supermirror_segment, theta_segment])
         sm_axis = create_mock_axis("MOT:MTR0101", sm_angle, 1)
-        det_axis = create_mock_axis("MOT:MTR0104", offset_from_sm_angle + offset_from_theta + det_offset, 1)
-        det_angle_axis = create_mock_axis("MOT:MTR0105", beam_angle_after_sample, 1)
+        det_axis = create_mock_axis("MOT:MTR0104", reflection_offset + det_offset, 1)
+        det_angle_axis = create_mock_axis("MOT:MTR0105",  beam_start.angle + beam_angle_after_sample, 1)
         axes = {"sm_axis": sm_axis,
                 "det_axis": det_axis,
                 "det_angle_axis": det_angle_axis}
@@ -152,10 +161,37 @@ class DataMother(object):
         nr_inits = {}
         nr_mode = BeamlineMode("NR", [param.name for param in params], nr_inits)
         modes = [nr_mode]
-        beam_start = PositionAndAngle(0.0, 0.0, -1)
         bl = Beamline(comps, params, drives, modes, beam_start)
         bl.active_mode = nr_mode.name
         return bl, axes
+
+    @staticmethod
+    def _calc_reflection_offset(beam_angle, segments):
+        """
+        Calculates a position offset to the beam intercept for a linear axis given an ordered list of beam segments,
+        each of which adds an angle to the beam.
+
+        Params:
+            beam_angle (float): The angle of the straight through beam to the linear motion axes
+            segments (tuple[float, float]): A list of beam segments made of tuples with (segment_length, added angle)
+
+        Returns: The total offset for the linear axis
+        """
+        total_offset = 0.0
+
+        reflection_angles = []
+        for distance, added_angle in segments:
+            reflection_angles.append(added_angle)
+
+            cumulative_reflection_angle = 0
+            for reflection_angle in reflection_angles:
+                cumulative_reflection_angle += 2*reflection_angle
+
+            offset_1 = distance * sin(radians(beam_angle))
+            offset_2 = distance * cos(radians(beam_angle)) * tan(radians(cumulative_reflection_angle - beam_angle))
+            total_offset += offset_1 + offset_2
+
+        return total_offset
 
 
 def create_mock_axis(name, init_position, max_velocity, backlash_distance=0, backlash_velocity=1, direction="Pos"):

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -362,6 +362,103 @@ class TestRealisticWithAutosaveInit(unittest.TestCase):
         assert_that(bl.parameter("det_pos").sp_rbv, is_(close_to(expected_det_offset, 1e-6)), "det position SP RBV")
         assert_that(bl.parameter("det_angle").sp_rbv, is_(close_to(0, 1e-6)), "det angle SP RBV")
 
+    @patch("ReflectometryServer.parameters.read_autosave_value")
+    def test_GIVEN_beam_line_with_nonzero_beam_start_with_all_values_at_0_WHEN_init_THEN_beamline_is_at_given_place(self, file_io):
+        beam_start_angle = -2.3
+        expected_sm_angle = 0
+        expected_theta = 0
+        file_io.return_value = expected_theta
+
+        bl, drives = DataMother.beamline_sm_theta_detector(expected_sm_angle, expected_theta, beam_angle=beam_start_angle)
+
+        assert_that(bl.parameter("sm_angle").sp, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP")
+        assert_that(bl.parameter("theta").sp, is_(close_to(expected_theta, 1e-6)), "theta SP")
+        assert_that(bl.parameter("det_pos").sp, is_(close_to(0, 1e-6)), "det position SP")
+        assert_that(bl.parameter("det_angle").sp, is_(close_to(0, 1e-6)), "det angle SP")
+
+        assert_that(bl.parameter("sm_angle").sp_rbv, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP RBV")
+        assert_that(bl.parameter("theta").sp_rbv, is_(close_to(expected_theta, 1e-6)), "theta SP RBV")
+        assert_that(bl.parameter("det_pos").sp_rbv, is_(close_to(0, 1e-6)), "det position SP RBV")
+        assert_that(bl.parameter("det_angle").sp_rbv, is_(close_to(0, 1e-6)), "det angle SP RBV")
+
+    @patch("ReflectometryServer.parameters.read_autosave_value")
+    def test_GIVEN_beam_line_with_nonzero_beam_start_where_autosave_theta_at_0_WHEN_init_THEN_beamline_is_at_given_place(self, file_io):
+        beam_start_angle = -2.3
+        expected_sm_angle = 22.5
+        expected_theta = 0
+        file_io.return_value = expected_theta
+
+        bl, drives = DataMother.beamline_sm_theta_detector(expected_sm_angle, expected_theta, beam_angle=beam_start_angle)
+
+        assert_that(bl.parameter("sm_angle").sp, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP")
+        assert_that(bl.parameter("theta").sp, is_(close_to(expected_theta, 1e-6)), "theta SP")
+        assert_that(bl.parameter("det_pos").sp, is_(close_to(0, 1e-6)), "det position SP")
+        assert_that(bl.parameter("det_angle").sp, is_(close_to(0, 1e-6)), "det angle SP")
+
+        assert_that(bl.parameter("sm_angle").sp_rbv, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP RBV")
+        assert_that(bl.parameter("theta").sp_rbv, is_(close_to(expected_theta, 1e-6)), "theta SP RBV")
+        assert_that(bl.parameter("det_pos").sp_rbv, is_(close_to(0, 1e-6)), "det position SP RBV")
+        assert_that(bl.parameter("det_angle").sp_rbv, is_(close_to(0, 1e-6)), "det angle SP RBV")
+
+    @patch("ReflectometryServer.parameters.read_autosave_value")
+    def test_GIVEN_beam_line_with_nonzero_beam_start_where_autosave_theta_at_non_zero_WHEN_init_THEN_beamline_is_at_given_place(self, file_io):
+        beam_start_angle = -2.3
+        expected_sm_angle = 22.5
+        expected_theta = 2
+        file_io.return_value = expected_theta
+
+        bl, drives = DataMother.beamline_sm_theta_detector(expected_sm_angle, expected_theta, beam_angle=beam_start_angle)
+
+        assert_that(bl.parameter("sm_angle").sp, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP")
+        assert_that(bl.parameter("theta").sp, is_(close_to(expected_theta, 1e-6)), "theta SP")
+        assert_that(bl.parameter("det_pos").sp, is_(close_to(0, 1e-6)), "det position SP")
+        assert_that(bl.parameter("det_angle").sp, is_(close_to(0, 1e-6)), "det angle SP")
+
+        assert_that(bl.parameter("sm_angle").sp_rbv, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP RBV")
+        assert_that(bl.parameter("theta").sp_rbv, is_(close_to(expected_theta, 1e-6)), "theta SP RBV")
+        assert_that(bl.parameter("det_pos").sp_rbv, is_(close_to(0, 1e-6)), "det position SP RBV")
+        assert_that(bl.parameter("det_angle").sp_rbv, is_(close_to(0, 1e-6)), "det angle SP RBV")
+
+    @patch("ReflectometryServer.parameters.read_autosave_value")
+    def test_GIVEN_beam_line_with_nonzero_beam_start_where_autosave_det_offset_at_zero_WHEN_init_THEN_beamline_is_at_given_place(self, file_io):
+        beam_start_angle = -2.3
+        expected_sm_angle = 22.5
+        expected_theta = 0
+        expected_det_offset = 0
+        file_io.return_value = expected_det_offset
+
+        bl, drives = DataMother.beamline_sm_theta_detector(expected_sm_angle, expected_theta, autosave_theta_not_offset=False, beam_angle=beam_start_angle)
+
+        assert_that(bl.parameter("sm_angle").sp, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP")
+        assert_that(bl.parameter("theta").sp, is_(close_to(expected_theta, 1e-6)), "theta SP")
+        assert_that(bl.parameter("det_pos").sp, is_(close_to(0, 1e-6)), "det position SP")
+        assert_that(bl.parameter("det_angle").sp, is_(close_to(0, 1e-6)), "det angle SP")
+
+        assert_that(bl.parameter("sm_angle").sp_rbv, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP RBV")
+        assert_that(bl.parameter("theta").sp_rbv, is_(close_to(expected_theta, 1e-6)), "theta SP RBV")
+        assert_that(bl.parameter("det_pos").sp_rbv, is_(close_to(0, 1e-6)), "det position SP RBV")
+        assert_that(bl.parameter("det_angle").sp_rbv, is_(close_to(0, 1e-6)), "det angle SP RBV")
+
+    @patch("ReflectometryServer.parameters.read_autosave_value")
+    def test_GIVEN_beam_line_with_nonzero_beam_start_where_autosave_det_offset_at_non_zero_WHEN_init_THEN_beamline_is_at_given_place(self, file_io):
+        beam_start_angle = -2.3
+        expected_sm_angle = 22.5
+        expected_theta = 0
+        expected_det_offset = 1
+        file_io.return_value = expected_det_offset
+
+        bl, drives = DataMother.beamline_sm_theta_detector(expected_sm_angle, expected_theta, expected_det_offset, autosave_theta_not_offset=False, beam_angle=beam_start_angle)
+
+        assert_that(bl.parameter("sm_angle").sp, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP")
+        assert_that(bl.parameter("theta").sp, is_(close_to(expected_theta, 1e-6)), "theta SP")
+        assert_that(bl.parameter("det_pos").sp, is_(close_to(expected_det_offset, 1e-6)), "det position SP")
+        assert_that(bl.parameter("det_angle").sp, is_(close_to(0, 1e-6)), "det angle SP")
+
+        assert_that(bl.parameter("sm_angle").sp_rbv, is_(close_to(expected_sm_angle, 1e-6)), "sm angle SP RBV")
+        assert_that(bl.parameter("theta").sp_rbv, is_(close_to(expected_theta, 1e-6)), "theta SP RBV")
+        assert_that(bl.parameter("det_pos").sp_rbv, is_(close_to(expected_det_offset, 1e-6)), "det position SP RBV")
+        assert_that(bl.parameter("det_angle").sp_rbv, is_(close_to(0, 1e-6)), "det angle SP RBV")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description of work

Added tests to ensure beamline initialises correctly when motion axes are not perpendicular to the beam. Renamed `_absolute_angle` to the more descriptive `_angle_to_natural_beam`.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3906

### Acceptance criteria

- Tests are sensible and pass
- Variable names are sensible

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
