### PR TITLE
Fix blockserver starting iocs

### DIFF
--- a/block_server.py
+++ b/block_server.py
@@ -377,23 +377,9 @@ class BlockServer(Driver):
                 # IOCs are restarted if and only if auto start is True. Note that auto restart instructs proc serv to
                 # restart an IOC if it terminates unexpectedly and does not apply here.
                 if ioc.autostart:
-                    # Throws if IOC does not exist
-                    if self._ioc_control.get_ioc_status(name) == "RUNNING":
-                        self._ioc_control.restart_ioc(name)
-                    else:
-                        self._ioc_control.start_ioc(name)
+                    self.start_iocs([name])
             except Exception as err:
                 print_and_log("Could not (re)start IOC {}: {}".format(name, err), "MAJOR")
-
-        # Give it time to start as IOC has to be running to be able to set restart property
-        print_and_log("Beginning arbitrary wait for IOCs to start.")
-        sleep(2)
-        print_and_log("Finished arbitrary wait for IOCs to start.")
-        for name, ioc in self._active_configserver.get_all_ioc_details().iteritems():
-            if ioc.autostart:
-                # Set the restart property
-                print_and_log("Setting IOC %s's auto-restart to %s" % (name, ioc.restart))
-                self._ioc_control.set_autorestart(name, ioc.restart)
 
     def load_config(self, config, full_init=True):
         """Load a configuration.

--- a/block_server.py
+++ b/block_server.py
@@ -377,7 +377,10 @@ class BlockServer(Driver):
                 # IOCs are restarted if and only if auto start is True. Note that auto restart instructs proc serv to
                 # restart an IOC if it terminates unexpectedly and does not apply here.
                 if ioc.autostart:
-                    self.start_iocs([name])
+                    if self._ioc_control.get_ioc_status(name) == "RUNNING":
+                        self._ioc_control.restart_iocs([name], reapply_auto=True)
+                    else:
+                        self.start_iocs([name])
             except Exception as err:
                 print_and_log("Could not (re)start IOC {}: {}".format(name, err), "MAJOR")
 


### PR DESCRIPTION
### Description of work

This fixes an issue seen during deployment, where on initial ibex server start the correct set of IOCs were not being started.

I believe this was a logic issue in some code that was specifically only initialising a config - I think there was a race which sometimes meant the ioc was being started and then immediately stopped again.

I have replaced it with a call to a common start_ioc function.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4660

This is difficult to system/unit test - I can't reproduce it on non-instrument machines. I have added a manual system test for it to the usual spreadsheet.

### Acceptance criteria

Issue is fixed (can check on MUONFE for example)

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
