### PR TITLE
Ticket 4638 - Set backlash to zero on init for _JawsAxisPVWrapper

### DIFF
--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -445,6 +445,7 @@ class _JawsAxisPVWrapper(PVWrapper):
         self._init_velocity_to_restore(self.velocity)
         for velo_pv in self._pv_names_for_directions("MTR.VELO"):
             self._velocities[self._strip_source_pv(velo_pv)] = self._read_pv(velo_pv)
+        self._d_back = 0  # No backlash used as source of clash conditions on jaws sets
 
     def _add_monitors(self):
         """

--- a/ReflectometryServer/test_modules/test_pv_wrapper.py
+++ b/ReflectometryServer/test_modules/test_pv_wrapper.py
@@ -1,7 +1,10 @@
+from hamcrest import *
+
 import ReflectometryServer
 import unittest
 
 from ReflectometryServer import *
+from ReflectometryServer.ChannelAccess.constants import MTR_STOPPED
 from ReflectometryServer.test_modules.data_mother import MockChannelAccess
 
 from server_common.channel_access import UnableToConnectToPVException
@@ -212,3 +215,12 @@ class TestJawsAxisPVWrapper(unittest.TestCase):
 
         self.assertEqual(expected_sp, actual_sp)
         self.assertEqual(expected_rbv, actual_rbv)
+
+    def test_GIVEN_initialised_jaw_gap_WHEN_get_backlash_distance_THEN_distance_is_0_because_jaws_do_not_backlash(self):
+        wrapper = JawsGapPVWrapper(self.jaws_name, is_vertical=False, ca=self.mock_ca)
+        wrapper._on_update_moving_state(MTR_STOPPED, None, None)  # fake call from monitor initialisation TODO: remove after 4588
+        wrapper.initialise()
+
+        result = wrapper.backlash_distance
+
+        assert_that(result, is_(0), "Jaws should not have backlash distance")


### PR DESCRIPTION
### Description of work

Changed the `_JawsAxisPVWrapper` to init backlash to `0` (zero) on initialization.

### To test

[#4638](https://github.com/ISISComputingGroup/IBEX/issues/4683)

### Acceptance criteria

- [ ] The backlash distance is set to 0 (no backlash) if the axis relates to a Jaws set.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
