### PR TITLE
Fix prefix used for detmon

### DIFF
--- a/scripts/set_instrument_list.py
+++ b/scripts/set_instrument_list.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
         inst_dictionary("SOFTMAT", is_scheduled=False),
         inst_dictionary("SURF"),
         inst_dictionary("NIMROD"),
-        inst_dictionary("DETMON", hostname_prefix="NDA", is_scheduled=False),
+        inst_dictionary("DETMON", hostname_prefix="NDA", is_scheduled=False, pv_prefix="TE:NDADETF1:"),
     ]
 
     new_value = json.dumps(instruments_list)


### PR DESCRIPTION
To test, verify you can connect to DETMON using the drop-down list in the GUI.

Note: changing DETMON's prefix to `IN:DETMON:` is probably a better solution but the algorithm to turn machine name into instrument prefix is in lots of places (gui/genie_python/blockserver/config_env) and can't handle the `NDA` prefix. This solution will get something working and then we can look at setting in to something more friendly down the line