### PR TITLE
Increased pv char waveform size from 64k to 128k

### DIFF
--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -119,13 +119,13 @@ class DatabaseServer(Driver):
         Returns:
             Dictionary : Dictionary containing the information to construct PVs
         """
-        pv_size_64k = 64000
+        pv_size_128k = 128000
         pv_size_10k = 10000
         pv_info = {}
 
         for pv in [DbPVNames.IOCS, DbPVNames.HIGH_INTEREST, DbPVNames.MEDIUM_INTEREST, DbPVNames.FACILITY,
                    DbPVNames.ACTIVE_PVS, DbPVNames.ALL_PVS, DbPVNames.IOCS_NOT_TO_STOP]:
-            pv_info[pv] = char_waveform(pv_size_64k)
+            pv_info[pv] = char_waveform(pv_size_128k)
 
         for pv in [DbPVNames.SAMPLE_PARS, DbPVNames.BEAMLINE_PARS, DbPVNames.USER_PARS]:
             pv_info[pv] = char_waveform(pv_size_10k)


### PR DESCRIPTION
### Description of work

Increased pv char waveform size from 64k to 128k. Reqiured for the DETMON blocks database encoding

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4182

### Acceptance criteria

Flash review only

---
 
#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
