### PR TITLE
Changes to blockserver to write new sub element to meta.xml

### DIFF
--- a/BlockServer/config/metadata.py
+++ b/BlockServer/config/metadata.py
@@ -39,6 +39,7 @@ class MetaData(object):
         self.description = description
         self.synoptic = synoptic
         self.history = []
+        self.isProtected = False
 
     def to_dict(self):
         """ Puts the metadata into a dictionary.
@@ -47,4 +48,4 @@ class MetaData(object):
             dict : The metadata
         """
         return {'name': self.name, 'pv': self.pv, 'description': self.description, 'synoptic': self.synoptic,
-                'history': self.history}
+                'history': self.history, 'isProtected': self.isProtected}

--- a/BlockServer/config/xml_converter.py
+++ b/BlockServer/config/xml_converter.py
@@ -425,7 +425,7 @@ class ConfigurationXmlConverter(object):
 
         isProtected = root_xml.find("./" + TAG_PROTECTED)
         if isProtected is not None:
-            data.isProtected = isProtected.text if isProtected.text is not None else ""
+            data.isProtected = isProtected.text if isProtected.text is not None else "false"
 
         edits = root_xml.findall("./" + TAG_EDITS + "/" + TAG_EDIT)
         data.history = [e.text for e in edits]

--- a/BlockServer/config/xml_converter.py
+++ b/BlockServer/config/xml_converter.py
@@ -37,6 +37,7 @@ BANNER_SCHEMA = "banner/1.0"
 TAG_META = "meta"
 TAG_DESC = "description"
 TAG_SYNOPTIC = "synoptic"
+TAG_PROTECTED = "isProtected"
 
 NS_TAG_BLOCK = 'blk'
 NS_TAG_IOC = 'ioc'
@@ -166,6 +167,9 @@ class ConfigurationXmlConverter(object):
         for e in data.history:
             edit = ElementTree.SubElement(edits_xml, TAG_EDIT)
             edit.text = e
+
+        protect_xml = ElementTree.SubElement(root, TAG_PROTECTED)
+        protect_xml.text = repr(data.isProtected).lower()
 
         return minidom.parseString(ElementTree.tostring(root)).toprettyxml()
 
@@ -418,6 +422,10 @@ class ConfigurationXmlConverter(object):
         synoptic = root_xml.find("./" + TAG_SYNOPTIC)
         if synoptic is not None:
             data.synoptic = synoptic.text if synoptic.text is not None else ""
+
+        isProtected = root_xml.find("./" + TAG_PROTECTED)
+        if isProtected is not None:
+            data.isProtected = isProtected.text if isProtected.text is not None else ""
 
         edits = root_xml.findall("./" + TAG_EDITS + "/" + TAG_EDIT)
         data.history = [e.text for e in edits]

--- a/BlockServer/config/xml_converter.py
+++ b/BlockServer/config/xml_converter.py
@@ -169,7 +169,7 @@ class ConfigurationXmlConverter(object):
             edit.text = e
 
         protect_xml = ElementTree.SubElement(root, TAG_PROTECTED)
-        protect_xml.text = repr(data.isProtected).lower()
+        protect_xml.text = str(data.isProtected).lower()
 
         return minidom.parseString(ElementTree.tostring(root)).toprettyxml()
 

--- a/BlockServer/core/config_holder.py
+++ b/BlockServer/core/config_holder.py
@@ -303,6 +303,7 @@ class ConfigHolder(object):
             'description': self._config.meta.description,
             'synoptic': self._config.meta.synoptic,
             'history': self._config.meta.history,
+            'isProtected': self._config.meta.isProtected
         }
 
     def _comps_to_list(self):

--- a/BlockServer/core/inactive_config_holder.py
+++ b/BlockServer/core/inactive_config_holder.py
@@ -98,6 +98,8 @@ class InactiveConfigHolder(ConfigHolder):
                 for args in details["components"]:
                     comp = self.load_configuration(args['name'], True)
                     self.add_component(comp.get_name(), comp)
+            if "isProtected" in details:
+                self._config.meta.isProtected = details["isProtected"]
         except Exception:
             self._retrieve_cache()
             raise

--- a/schema/meta.xsd
+++ b/schema/meta.xsd
@@ -7,6 +7,7 @@
         <xs:element name="description" minOccurs="0" maxOccurs="1" type="xs:string"/>
 		<xs:element name="synoptic" minOccurs="0" maxOccurs="1" type="xs:string"/>
 		<xs:element name="edits" minOccurs="1" maxOccurs="1" type="edits_type"/>
+		<xs:element name="isProtected" minOccurs="1" maxOccurs="1" type="xs:boolean" default="false"/>
 	  </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/schema/meta.xsd
+++ b/schema/meta.xsd
@@ -7,7 +7,7 @@
         <xs:element name="description" minOccurs="0" maxOccurs="1" type="xs:string"/>
 		<xs:element name="synoptic" minOccurs="0" maxOccurs="1" type="xs:string"/>
 		<xs:element name="edits" minOccurs="1" maxOccurs="1" type="edits_type"/>
-		<xs:element name="isProtected" minOccurs="1" maxOccurs="1" type="xs:boolean" default="false"/>
+		<xs:element name="isProtected" minOccurs="0" maxOccurs="1" type="xs:boolean" default="false"/>
 	  </xs:sequence>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
### Description of work

Block server to make changes to the XML file after the configuration is edited or new configuration is changed with a new sub-element.

Ticket: https://github.com/ISISComputingGroup/IBEX/issues/4794
### To test



### Acceptance criteria

Check if the GUI retains the ticked box after the config is protected even after closing the window

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
