### PR TITLE
Ticket4797 db server low interest p vs

### DIFF
--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -101,6 +101,7 @@ class DatabaseServer(Driver):
         add_get_method(DbPVNames.IOCS, self._get_iocs_info)
         add_get_method(DbPVNames.HIGH_INTEREST, partial(self._get_interesting_pvs, "HIGH"))
         add_get_method(DbPVNames.MEDIUM_INTEREST, partial(self._get_interesting_pvs, "MEDIUM"))
+        add_get_method(DbPVNames.LOW_INTEREST, partial(self._get_interesting_pvs, "LOW"))
         add_get_method(DbPVNames.FACILITY, partial(self._get_interesting_pvs, "FACILITY"))
         add_get_method(DbPVNames.ACTIVE_PVS, self._get_active_pvs)
         add_get_method(DbPVNames.ALL_PVS, partial(self._get_interesting_pvs, ""))
@@ -123,8 +124,8 @@ class DatabaseServer(Driver):
         pv_size_10k = 10000
         pv_info = {}
 
-        for pv in [DbPVNames.IOCS, DbPVNames.HIGH_INTEREST, DbPVNames.MEDIUM_INTEREST, DbPVNames.FACILITY,
-                   DbPVNames.ACTIVE_PVS, DbPVNames.ALL_PVS, DbPVNames.IOCS_NOT_TO_STOP]:
+        for pv in [DbPVNames.IOCS, DbPVNames.HIGH_INTEREST, DbPVNames.MEDIUM_INTEREST, DbPVNames.LOW_INTEREST,
+                   DbPVNames.FACILITY, DbPVNames.ACTIVE_PVS, DbPVNames.ALL_PVS, DbPVNames.IOCS_NOT_TO_STOP]:
             pv_info[pv] = char_waveform(pv_size_64k)
 
         for pv in [DbPVNames.SAMPLE_PARS, DbPVNames.BEAMLINE_PARS, DbPVNames.USER_PARS]:

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -190,7 +190,7 @@ class DatabaseServer(Driver):
             if self._iocs is not None:
                 self._iocs.update_iocs_status()
                 for pv in [DbPVNames.IOCS, DbPVNames.HIGH_INTEREST, DbPVNames.MEDIUM_INTEREST, DbPVNames.FACILITY,
-                            DbPVNames.ACTIVE_PVS, DbPVNames.ALL_PVS]:
+                           DbPVNames.ACTIVE_PVS, DbPVNames.ALL_PVS]:
                     encoded_data = self.get_data_for_pv(pv)
                     self.setParam(pv, encoded_data)
                 # Update them

--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -222,6 +222,14 @@ class DatabaseServer(Driver):
         return iocs
 
     def _get_pvs(self, get_method, replace_pv_prefix, *get_args):
+        """
+        Method to get pv data using the given method called with the given arguments and optionally remove instrument
+        prefixes from pv names.
+        :param get_method: The method used to get pv data.
+        :param replace_pv_prefix: True to remove pv prefixes, False if not.
+        :param get_args: The arguments to be applied to get_method.
+        :return: a list of names of pvs.
+        """
         if self._iocs is not None:
             pv_data = get_method(*get_args)
             if replace_pv_prefix:
@@ -231,9 +239,19 @@ class DatabaseServer(Driver):
             return list()
 
     def _get_interesting_pvs(self, level):
+        """
+        Gets interesting pvs of the current instrument.
+        :param level: The level of high interesting pvs, can be high, low, medium or facility. If level is an empty
+        string, it returns all interesting pvs of all levels.
+        :return: a list of names of pvs.
+        """
         return self._get_pvs(self._iocs.get_interesting_pvs, False, level)
 
     def _get_active_pvs(self):
+        """
+        Gets all pvs belonging to IOCs that are currently running on the current instrument.
+        :return: a list of names of pvs.
+        """
         return self._get_pvs(self._iocs.get_active_pvs, False)
 
     def _get_sample_par_names(self):

--- a/DatabaseServer/test_modules/test_database_server.py
+++ b/DatabaseServer/test_modules/test_database_server.py
@@ -25,7 +25,7 @@ import unittest
 from DatabaseServer.database_server import DatabaseServer
 from server_common.mocks.mock_ca_server import MockCAServer
 from server_common.mocks.mock_ioc_data_source import MockIocDataSource, IOCS
-from server_common.test_modules.test_ioc_data import HIGH_PV_NAMES, MEDIUM_PV_NAMES, FACILITY_PV_NAMES
+from server_common.test_modules.test_ioc_data import HIGH_PV_NAMES, MEDIUM_PV_NAMES, LOW_PV_NAMES, FACILITY_PV_NAMES
 from server_common.utilities import dehex_and_decompress
 from DatabaseServer.mocks.mock_procserv_utils import MockProcServWrapper
 from server_common.ioc_data import IOCData
@@ -62,6 +62,16 @@ class TestDatabaseServer(unittest.TestCase):
             if len(item) > 0:
                 pv_names.append(item[0])
         for name in MEDIUM_PV_NAMES:
+            self.assertTrue(name in pv_names, msg="{name} in {pv_names}".format(name=name, pv_names=pv_names))
+
+    @unittest.skipIf(IS_LINUX, "DB server not configured to run properly on Linux build")
+    def test_WHEN_asked_for_low_THEN_get_low_pvs(self):
+        pv_data = json.loads(dehex_and_decompress(self.db_server.read(DatabasePVNames.LOW_INTEREST)))
+        pv_names = []
+        for item in pv_data:
+            if len(item) > 0:
+                pv_names.append(item[0])
+        for name in LOW_PV_NAMES:
             self.assertTrue(name in pv_names, msg="{name} in {pv_names}".format(name=name, pv_names=pv_names))
 
     @unittest.skipIf(IS_LINUX, "DB server not configured to run properly on Linux build")

--- a/DatabaseServer/test_modules/test_database_server.py
+++ b/DatabaseServer/test_modules/test_database_server.py
@@ -47,40 +47,32 @@ class TestDatabaseServer(unittest.TestCase):
     @unittest.skipIf(IS_LINUX, "DB server not configured to run properly on Linux build")
     def test_interest_high_pvs_correct(self):
         pv_data = json.loads(dehex_and_decompress(self.db_server.read(DatabasePVNames.HIGH_INTEREST)))
-        pv_names = []
-        for item in pv_data:
-            if len(item) > 0:
-                pv_names.append(item[0])
+        pv_names = [item[0] for item in pv_data if len(item) > 0]
+
         for name in HIGH_PV_NAMES:
             self.assertTrue(name in pv_names, msg="{name} in {pv_names}".format(name=name, pv_names=pv_names))
 
     @unittest.skipIf(IS_LINUX, "DB server not configured to run properly on Linux build")
     def test_interest_medium_pvs_correct(self):
         pv_data = json.loads(dehex_and_decompress(self.db_server.read(DatabasePVNames.MEDIUM_INTEREST)))
-        pv_names = []
-        for item in pv_data:
-            if len(item) > 0:
-                pv_names.append(item[0])
+        pv_names = [item[0] for item in pv_data if len(item) > 0]
+
         for name in MEDIUM_PV_NAMES:
             self.assertTrue(name in pv_names, msg="{name} in {pv_names}".format(name=name, pv_names=pv_names))
 
     @unittest.skipIf(IS_LINUX, "DB server not configured to run properly on Linux build")
     def test_WHEN_asked_for_low_THEN_get_low_pvs(self):
         pv_data = json.loads(dehex_and_decompress(self.db_server.read(DatabasePVNames.LOW_INTEREST)))
-        pv_names = []
-        for item in pv_data:
-            if len(item) > 0:
-                pv_names.append(item[0])
+        pv_names = [item[0] for item in pv_data if len(item) > 0]
+
         for name in LOW_PV_NAMES:
             self.assertTrue(name in pv_names, msg="{name} in {pv_names}".format(name=name, pv_names=pv_names))
 
     @unittest.skipIf(IS_LINUX, "DB server not configured to run properly on Linux build")
     def test_interest_facility_pvs_correct(self):
         pv_data = json.loads(dehex_and_decompress(self.db_server.read(DatabasePVNames.FACILITY)))
-        pv_names = []
-        for item in pv_data:
-            if len(item) > 0:
-                pv_names.append(item[0])
+        pv_names = [item[0] for item in pv_data if len(item) > 0]
+
         for name in FACILITY_PV_NAMES:
             self.assertTrue(name in pv_names, msg="{name} in {pv_names}".format(name=name, pv_names=pv_names))
 

--- a/server_common/ioc_data_source.py
+++ b/server_common/ioc_data_source.py
@@ -164,6 +164,8 @@ class IocDataSource(object):
                 interest = 'HIGH'
             elif level.lower().startswith('m'):
                 interest = 'MEDIUM'
+            elif level.lower().startswith('l'):
+                interest = 'LOW'
             elif level.lower().startswith('f'):
                 interest = 'FACILITY'
             else:

--- a/server_common/ioc_data_source.py
+++ b/server_common/ioc_data_source.py
@@ -92,6 +92,12 @@ class IocDataSource(object):
         self.mysql_abstraction_layer = mysql_abstraction_layer
 
     def _query_and_normalise(self, sqlquery, bind_vars=None):
+        """
+        Executes the given query to the database and converts the data in each row from bytearray to a normal string.
+        :param sqlquery: The query to execute.
+        :param bind_vars: Any variables to bind to query. Defaults to None.
+        :return: A list of lists of strings, representing the data from the table.
+        """
         # Get as a plain list of lists
         values = [list(element) for element in self.mysql_abstraction_layer.query(sqlquery, bind_vars)]
 
@@ -151,8 +157,8 @@ class IocDataSource(object):
         Queries the database for PVs based on their interest level and their IOC.
 
         Args:
-            level (string, optional): The interest level to search for, either High, Medium or Facility. Default to
-                                    all interest levels
+            level (string, optional): The interest level to search for, either High, Medium, Low or Facility. Default to
+                                    all interest levels.
             ioc (string, optional): The IOC to search. Default is all IOCs.
 
         Returns:
@@ -175,16 +181,16 @@ class IocDataSource(object):
             if ioc is not None and ioc != "":
                 bind_vars = (ioc, )
                 if interest is not None:
-                    sqlquery = GET_PVS_WITH_TEMPLATED_INTEREST_FOR_AN_IOC.format(interest=interest)
+                    sql_query = GET_PVS_WITH_TEMPLATED_INTEREST_FOR_AN_IOC.format(interest=interest)
                 else:
-                    sqlquery = GET_PVS_WITH_DETAILS_FOR_AN_IOC
+                    sql_query = GET_PVS_WITH_DETAILS_FOR_AN_IOC
             else:
                 bind_vars = None
                 if interest is not None:
-                    sqlquery = GET_PVS_WITH_TEMPLATED_INTEREST.format(interest=interest)
+                    sql_query = GET_PVS_WITH_TEMPLATED_INTEREST.format(interest=interest)
                 else:
-                    sqlquery = GET_PVS_WITH_DETAILS
-            return self._query_and_normalise(sqlquery, bind_vars)
+                    sql_query = GET_PVS_WITH_DETAILS
+            return self._query_and_normalise(sql_query, bind_vars)
         except Exception as err:
             print_and_log("issue with getting interesting PVs: %s" % err, "MAJOR", "DBSVR")
             return []
@@ -259,7 +265,7 @@ class IocDataSource(object):
             info_field_value: value of the info field
             pv_fullname: full pv name with prefix
 
-        Returns:
+        Returns: nothing.
 
         """
         try:

--- a/server_common/mocks/mock_ioc_data_source.py
+++ b/server_common/mocks/mock_ioc_data_source.py
@@ -48,9 +48,8 @@ class MockIocDataSource(object):
         Gets IOC names together with IOC's run status.
         :return: a list of tuples.
         """
-        iocs_and_run_status = []
-        for ioc_name, ioc_info in self.iocs.iteritems():
-            iocs_and_run_status.append((ioc_name, ioc_info["running"]))
+        iocs_and_run_status = [(ioc_name, ioc_info["running"]) for ioc_name, ioc_info in self.iocs.iteritems()]
+
         return iocs_and_run_status
 
     def update_ioc_is_running(self, iocname, running):

--- a/server_common/mocks/mock_ioc_data_source.py
+++ b/server_common/mocks/mock_ioc_data_source.py
@@ -73,7 +73,7 @@ class MockIocDataSource(object):
         pvs = []
 
         if level == "":
-            pvs = [pv_name for pv_list in [HIGH_PVS, MEDIUM_PVS, LOW_PVS, FACILITY_PVS] for pv_name in pv_list]
+            pvs = HIGH_PVS + MEDIUM_PVS + LOW_PVS + FACILITY_PVS
         elif level.lower().startswith('h'):
             pvs.extend(HIGH_PVS)
         elif level.lower().startswith('m'):

--- a/server_common/mocks/mock_ioc_data_source.py
+++ b/server_common/mocks/mock_ioc_data_source.py
@@ -12,6 +12,13 @@ MEDIUM_PVS = [
     [MEDIUM_PV_NAMES[2], "ai", "MED PV 3", "SomeIOC"]
 ]
 
+LOW_PV_NAMES = ["LOW_PV1", "LOW_PV2", "LOW_PV3"]
+LOW_PVS = [
+    [LOW_PV_NAMES[0], "ai", "LOW PV 1", "SomeIOC"],
+    [LOW_PV_NAMES[1], "ai", "LOW PV 2", "SomeIOC"],
+    [LOW_PV_NAMES[2], "ai", "LOW PV 3", "SomeIOC"]
+]
+
 FACILITY_PV_NAMES = ["FAC_PV1", "FAC_PV2", "FAC_PV3"]
 FACILITY_PVS = [
     [FACILITY_PV_NAMES[0], "ai", "FACILITY PV 1", "SomeIOC"],

--- a/server_common/mocks/mock_ioc_data_source.py
+++ b/server_common/mocks/mock_ioc_data_source.py
@@ -54,12 +54,21 @@ class MockIocDataSource(object):
 
     def get_interesting_pvs(self, level="", ioc=None):
         pvs = []
-        if level == "" or level.lower().startswith('h'):
+
+        if level == "":
+            pvs = [pv_name for pv_list in [HIGH_PVS, MEDIUM_PVS, LOW_PVS, FACILITY_PVS] for pv_name in pv_list]
+        elif level.lower().startswith('h'):
             pvs.extend(HIGH_PVS)
-        if level == "" or level.lower().startswith('m'):
+        elif level.lower().startswith('m'):
             pvs.extend(MEDIUM_PVS)
-        if level == "" or level.lower().startswith('f'):
+        elif level.lower().startswith('l'):
+            pvs.extend(LOW_PVS)
+        elif level.lower().startswith('f'):
             pvs.extend(FACILITY_PVS)
+        else:
+            raise ValueError("Value of level argument can only start with h for high, m for medium, l for low or f for"
+                             " facility")
+
         return pvs
 
     def get_active_pvs(self):

--- a/server_common/mocks/mock_ioc_data_source.py
+++ b/server_common/mocks/mock_ioc_data_source.py
@@ -44,15 +44,32 @@ class MockIocDataSource(object):
         return self.iocs
 
     def get_iocs_and_running_status(self):
-        d = []
-        for k, v in self.iocs.iteritems():
-            d.append((k, v["running"]))
-        return d
+        """
+        Gets IOC names together with IOC's run status.
+        :return: a list of tuples.
+        """
+        iocs_and_run_status = []
+        for ioc_name, ioc_info in self.iocs.iteritems():
+            iocs_and_run_status.append((ioc_name, ioc_info["running"]))
+        return iocs_and_run_status
 
     def update_ioc_is_running(self, iocname, running):
         self.iocs[iocname]["running"] = running
 
     def get_interesting_pvs(self, level="", ioc=None):
+        """
+        Gets a list of interesting pvs based on their level. The interesting pvs are fake pvs with data defined at the
+        beginning of this module.
+        Args:
+            level (string, optional): The interest level to search for, either High, Medium, Low or Facility. Default to
+                                    all interest levels.
+            ioc (string, optional): The IOC to search. Default is all IOCs. This argument is not actually used in this
+            mock method, but it is used in the method of the real IOCDataSource class, so we need this argument to
+            completely imitate the real method.
+        Returns:
+            list : A list of the PVs that match the search given by level and ioc
+
+        """
         pvs = []
 
         if level == "":
@@ -72,6 +89,11 @@ class MockIocDataSource(object):
         return pvs
 
     def get_active_pvs(self):
+        """
+        Returns names of fake high pvs, because the active pv test compares the result of this method to those fake pvs.
+        Returns:
+            list : A list of the PVs in running IOCs
+        """
         return HIGH_PV_NAMES
 
     def get_pars(self, category):

--- a/server_common/pv_names.py
+++ b/server_common/pv_names.py
@@ -28,6 +28,7 @@ class DatabasePVNames:
     IOCS = prepend_blockserver('IOCS')
     HIGH_INTEREST = prepend_blockserver('PVS:INTEREST:HIGH')
     MEDIUM_INTEREST = prepend_blockserver('PVS:INTEREST:MEDIUM')
+    LOW_INTEREST = prepend_blockserver('PVS:INTEREST:LOW')
     FACILITY = prepend_blockserver('PVS:INTEREST:FACILITY')
     ACTIVE_PVS = prepend_blockserver('PVS:ACTIVE')
     ALL_PVS = prepend_blockserver('PVS:ALL')

--- a/server_common/test_modules/test_ioc_data.py
+++ b/server_common/test_modules/test_ioc_data.py
@@ -17,7 +17,7 @@
 import unittest
 from DatabaseServer.mocks.mock_procserv_utils import MockProcServWrapper
 from server_common.ioc_data import IOCData
-from server_common.mocks.mock_ioc_data_source import (MockIocDataSource, HIGH_PV_NAMES, MEDIUM_PV_NAMES,
+from server_common.mocks.mock_ioc_data_source import (MockIocDataSource, HIGH_PV_NAMES, MEDIUM_PV_NAMES, LOW_PV_NAMES,
                                                       FACILITY_PV_NAMES, SAMPLE_PVS, BL_PVS, USER_PVS)
 
 
@@ -58,6 +58,7 @@ class TestIocDataSequence(unittest.TestCase):
 
         all_names = HIGH_PV_NAMES
         all_names.extend(MEDIUM_PV_NAMES)
+        all_names.extend(LOW_PV_NAMES)
         all_names.extend(FACILITY_PV_NAMES)
 
         # Check all pvs are in all names
@@ -65,26 +66,34 @@ class TestIocDataSequence(unittest.TestCase):
             self.assertTrue(pv[0] in all_names)
 
     def test_get_interesting_pvs_high(self):
-        # Get all PVs
         pvs = self.ioc_data.get_interesting_pvs("HIGH")
 
         for pv in pvs:
             self.assertTrue(pv[0] in HIGH_PV_NAMES)
 
     def test_get_interesting_pvs_medium(self):
-        # Get all PVs
         pvs = self.ioc_data.get_interesting_pvs("MEDIUM")
+
         for pv in pvs:
             self.assertTrue(pv[0] in MEDIUM_PV_NAMES)
+
+    def test_WHEN_asked_for_low_THEN_get_low_interesting_pvs(self):
+        pvs = self.ioc_data.get_interesting_pvs("LOW")
+
+        for pv in pvs:
+            self.assertTrue(pv[0] in LOW_PV_NAMES)
 
     def test_get_interesting_pvs_facility(self):
         # Get all PVs
         pvs = self.ioc_data.get_interesting_pvs("FACILITY")
+
         for pv in pvs:
             self.assertTrue(pv[0] in FACILITY_PV_NAMES)
 
     def test_get_active_pvs(self):
-        # Get all Active PVs
+        # Get all Active PVs. Note that MockIOCDataSource get_active_pvs() returns the contents of HIGH_PV_NAMES, so
+        # this is why this test compares pv names with the contents of that list. It is not because in general active
+        # pvs are the high interesting pvs.
         pvs = self.ioc_data.get_active_pvs()
         for pv in pvs:
             self.assertTrue(pv in HIGH_PV_NAMES)


### PR DESCRIPTION
### Description of work

This pull request has minor changes made to the DB Server so that for an instrument it sets up a PV which contains data about all the Low Interesting PVs of that instrument, read from the MySQL database.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4797

### Acceptance criteria

If you go into an epics terminal and type in caget -t -S IN:YOUR_INSTRUMENT:CS:BLOCKSERVER:PVS:INTEREST:LOW | uzhex should return an empty list (or a non empty list with low interesting pvs if your developer machine has low interesting pvs).

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
