### PR TITLE
Ticket 4899 - Reflectometry: Fix error when DisplcementDriver is created based on a component which is out of the beam

### DIFF
--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -28,6 +28,7 @@ class IocDriver(object):
             engineering_correction (ReflectometryServer.engineering_corrections.EngineeringCorrection): the engineering
                 correction to apply to the value from the component before it is sent to the pv. None for no correction
         """
+        self._out_of_beam_position = None
         self._component = component
         self._axis = axis
         self.name = axis.name


### PR DESCRIPTION
Updated the `IocDriver` class to have a init value of `None` for the `_out_of_beam_position`. 

Previously if the component was parked out of the beam, and that value was autosaved for the parameter, if the server was started you would see the error described in the ticket. This was because the `DisplacementDriver` class inherited from `IocDriver` and only checks against `is not None` in the `_get_in_beam_status` method.


### To Test

1. Checkout this branch and the associated IOC system tests branch
1. Run the reflectometry initialisation tests (refl_init) (tests should pass)
1. Remove init value in `IocDriver` for `_out_of_beam_position`
1. Run the reflectometry initialisation tests (refl_init) (tests should fail)