### PR TITLE
Fix bug saving floats

### DIFF
--- a/server_common/autosave.py
+++ b/server_common/autosave.py
@@ -45,7 +45,7 @@ class AutosaveFile(object):
             # Disallow embedding the separator inside the value as this will cause a read to fail later.
             raise ValueError("Parameter name '{}' contains autosave separator which is not allowed".format(parameter))
 
-        if "\n" in value or "\n" in parameter:
+        if "\n" in str(value) or "\n" in parameter:
             # Autosave parameters are saved one-per-line, newlines would interfere with this.
             raise ValueError("Value or parameter contains line separator which is now allowed")
 


### PR DESCRIPTION
### Description of work

Floats can not be iterated through so can not have \n checked in them.

### To test

error on refl startup

### Acceptance criteria

1. Parameter can be autosaved

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
