### PR TITLE
Allow unit tests to be run with no genie_python

### DIFF
--- a/RemoteIocServer/test_modules/test_config_monitor.py
+++ b/RemoteIocServer/test_modules/test_config_monitor.py
@@ -37,11 +37,12 @@ META_XML = u'<?xml version="1.0" ?>\n<meta>\n\t<description>Configuration for re
 
 class TestConfigMonitor(unittest.TestCase):
 
+    @patch("RemoteIocServer.config_monitor.get_hostname_from_prefix")
     @patch("RemoteIocServer.config_monitor._EpicsMonitor")
-    def test_WHEN_start_monitoring_THEN_monitor_called(self, epicsmonitor):
+    def test_WHEN_start_monitoring_THEN_monitor_called(self, epicsmonitor, get_hostname_from_prefix_mock):
+        get_hostname_from_prefix_mock.return_value = "server"
         mon = ConfigurationMonitor(LOCAL_TEST_PREFIX, lambda *a, **k: None)
         mon.set_remote_pv_prefix(REMOTE_TEST_PREFIX)
-        mon._start_monitoring()
 
         epicsmonitor.assert_called_with("{}CS:BLOCKSERVER:GET_CURR_CONFIG_DETAILS".format(REMOTE_TEST_PREFIX))
         epicsmonitor.return_value.start.assert_called_once()

--- a/RemoteIocServer/utilities.py
+++ b/RemoteIocServer/utilities.py
@@ -6,7 +6,11 @@ import os
 
 from concurrent.futures import ThreadPoolExecutor
 from genie_python.channel_access_exceptions import UnableToConnectToPVException, ReadAccessException
-from genie_python.genie_cachannel_wrapper import CaChannelWrapper
+try:
+    # noinspection PyUnresolvedReferences
+    from genie_python.genie_cachannel_wrapper import CaChannelWrapper, EXIST_TIMEOUT
+except ImportError:
+    print("ERROR: No genie_python on the system can not import CaChannelWrapper! (OK for unit testing)")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
 from server_common.utilities import print_and_log as _common_print_and_log


### PR DESCRIPTION
Fix red hat tests (it has no genie_python)
