### PR TITLE
Move all genie python access to channel access wrapper

### DIFF
--- a/RemoteIocServer/config_monitor.py
+++ b/RemoteIocServer/config_monitor.py
@@ -14,8 +14,6 @@ from BlockServer.core.file_path_manager import FILEPATH_MANAGER
 from BlockServer.fileIO.file_manager import ConfigurationFileManager
 from RemoteIocServer.utilities import print_and_log, get_hostname_from_prefix, THREADPOOL
 from server_common.channel_access import ChannelAccess
-from genie_python.genie_cachannel_wrapper import CaChannelWrapper
-from genie_python.channel_access_exceptions import UnableToConnectToPVException
 from server_common.utilities import dehex_and_decompress_waveform
 from BlockServer.config.ioc import IOC
 
@@ -64,10 +62,7 @@ class _EpicsMonitor(object):
         """
         Ends an EPICS monitor
         """
-        try:
-            CaChannelWrapper.get_chan(self._pv).clear_channel()
-        except UnableToConnectToPVException:
-            pass
+        ChannelAccess.clear_monitor(self._pv)
 
 
 class ConfigurationMonitor(object):

--- a/server_common/channel_access.py
+++ b/server_common/channel_access.py
@@ -87,19 +87,24 @@ class ChannelAccess(object):
     installing genie_python.
     """
     @staticmethod
-    def caget(name, as_string=False):
+    def caget(name, as_string=False, timeout=None):
         """Uses CaChannelWrapper from genie_python to get a pv value. We import CaChannelWrapper when used as this means
         the tests can run without having genie_python installed
 
         Args:
             name (string): The name of the PV to be read
             as_string (bool, optional): Set to read a char array as a string, defaults to false
+            timeout (float, None): timeout value to use; None for use default timeout
 
         Returns:
             obj : The value of the requested PV, None if no value was read
         """
         try:
-            return CaChannelWrapper.get_pv_value(name, as_string)
+            if timeout is None:
+                return CaChannelWrapper.get_pv_value(name, as_string)
+            else:
+                return CaChannelWrapper.get_pv_value(name, as_string, timeout=timeout)
+
         except Exception as err:
             # Probably has timed out
             print_and_log(str(err))
@@ -185,6 +190,16 @@ class ChannelAccess(object):
         NB Connected pv is one which is in the cache
         """
         CaChannelWrapper.poll()
+
+    @staticmethod
+    def clear_monitor(name):
+        """
+        Clears the monitor on a pv if it exists
+        """
+        try:
+            CaChannelWrapper.get_chan(name).clear_channel()
+        except UnableToConnectToPVException:
+            pass
 
 
 class ManagerModeRequiredException(Exception):


### PR DESCRIPTION
Move all genie python access to channel access wrapper. Then make sure it is not used during tests.