### PR TITLE
Allow options for disconnected blocks in run control

### DIFF
--- a/BlockServer/config/block.py
+++ b/BlockServer/config/block.py
@@ -37,7 +37,7 @@ class Block(object):
             arch_deadband (float): Deadband for the block to be archived
     """
     def __init__(self, name, pv, local=True, visible=True, component=None, runcontrol=False, lowlimit=None,
-                 highlimit=None, log_periodic=False, log_rate=5, log_deadband=0):
+                 highlimit=None, suspend_on_invalid=False, log_periodic=False, log_rate=5, log_deadband=0):
         """ Constructor.
 
         Args:
@@ -50,6 +50,7 @@ class Block(object):
             runcontrol (bool): Whether run-control is enabled
             lowlimt (float): The low limit for run-control
             highlimit (float): The high limit for run-control
+            suspend_on_invalid (bool): Whether to suspend run-control on invalid values
 
             arch_periodic (bool): Whether the block is sampled periodically in the archiver
             arch_rate (float): Time between archive samples (in seconds)
@@ -63,6 +64,7 @@ class Block(object):
         self.rc_lowlimit = lowlimit
         self.rc_highlimit = highlimit
         self.rc_enabled = runcontrol
+        self.rc_suspend_on_invalid = suspend_on_invalid
         self.log_periodic = log_periodic
         self.log_rate = log_rate
         self.log_deadband = log_deadband
@@ -95,7 +97,17 @@ class Block(object):
         Returns:
             dict : The block's details
         """
-        return {"name": self.name, "pv": self._get_pv(), "local": self.local,
-                "visible": self.visible, "component": self.component, "runcontrol": self.rc_enabled,
-                "lowlimit": self.rc_lowlimit, "highlimit": self.rc_highlimit,
-                "log_periodic": self.log_periodic, "log_rate": self.log_rate, "log_deadband": self.log_deadband}
+        return {
+            "name": self.name,
+            "pv": self._get_pv(),
+            "local": self.local,
+            "visible": self.visible,
+            "component": self.component,
+            "runcontrol": self.rc_enabled,
+            "lowlimit": self.rc_lowlimit,
+            "highlimit": self.rc_highlimit,
+            "log_periodic": self.log_periodic,
+            "log_rate": self.log_rate,
+            "log_deadband": self.log_deadband,
+            "suspend_on_invalid": self.rc_suspend_on_invalid,
+        }

--- a/BlockServer/config/configuration.py
+++ b/BlockServer/config/configuration.py
@@ -102,19 +102,6 @@ class Configuration(object):
             self.iocs[name.upper()] = IOC(name, autostart, restart, component, macros, pvs, pvsets, simlevel,
                                           remotePvPrefix)
 
-    def update_runcontrol_settings_for_saving(self, rc_data):
-        """ Updates the run-control settings for the configuration's blocks.
-
-        Args:
-            rc_data (dict): A dictionary containing all the run-control settings
-        """
-        # Only do it for blocks that are not in a component
-        for bn, blk in self.blocks.items():
-            if blk.component is None and blk.name in rc_data.keys():
-                blk.rc_enabled = rc_data[blk.name]['ENABLE']
-                blk.rc_lowlimit = rc_data[blk.name]['LOW']
-                blk.rc_highlimit = rc_data[blk.name]['HIGH']
-
     def get_name(self):
         """ Gets the name of the configuration.
 

--- a/BlockServer/config/xml_converter.py
+++ b/BlockServer/config/xml_converter.py
@@ -208,6 +208,9 @@ class ConfigurationXmlConverter(object):
             high = ElementTree.SubElement(block_xml, TAG_RUNCONTROL_HIGH)
             high.text = str(block.rc_highlimit)
 
+        suspend_on_invalid = ElementTree.SubElement(block_xml, TAG_RUNCONTROL_SUSPEND_ON_INVALID)
+        suspend_on_invalid.text = str(block.rc_suspend_on_invalid)
+
         # Logging
         log_periodic = ElementTree.SubElement(block_xml, TAG_LOG_PERIODIC)
         log_periodic.text = str(block.log_periodic)
@@ -283,12 +286,12 @@ class ConfigurationXmlConverter(object):
 
                 # Check to see if not local
                 loc = ConfigurationXmlConverter._find_single_node(b, NS_TAG_BLOCK, TAG_LOCAL)
-                if not (loc is None) and loc.text == "False":
+                if loc is not None and loc.text == "False":
                     blocks[name.lower()].local = False
 
                 # Check for visibility
                 vis = ConfigurationXmlConverter._find_single_node(b, NS_TAG_BLOCK, TAG_VISIBLE)
-                if not (vis is None) and vis.text == "False":
+                if vis is not None and vis.text == "False":
                     blocks[name.lower()].visible = False
 
                 # Runcontrol
@@ -302,6 +305,10 @@ class ConfigurationXmlConverter(object):
                 rc_high = ConfigurationXmlConverter._find_single_node(b, NS_TAG_BLOCK, TAG_RUNCONTROL_HIGH)
                 if rc_high is not None:
                     blocks[name.lower()].rc_highlimit = float(rc_high.text)
+
+                rc_suspend_on_invalid = ConfigurationXmlConverter._find_single_node(b, NS_TAG_BLOCK, TAG_RUNCONTROL_SUSPEND_ON_INVALID)
+                if rc_suspend_on_invalid is not None:
+                    blocks[name.lower()].rc_suspend_on_invalid = (rc_suspend_on_invalid.text == "True")
 
                 # Logging
                 log_periodic = ConfigurationXmlConverter._find_single_node(b, NS_TAG_BLOCK, TAG_LOG_PERIODIC)

--- a/BlockServer/core/config_holder.py
+++ b/BlockServer/core/config_holder.py
@@ -457,14 +457,6 @@ class ConfigHolder(object):
         else:
             self._is_component = False
 
-    def update_runcontrol_settings_for_saving(self, rc_data):
-        """ Updates the run-control settings stored in the configuration so they can be saved.
-
-        Args:
-            rc_data (dict): The current run-control settings
-        """
-        self._config.update_runcontrol_settings_for_saving(rc_data)
-
     def _cache_config(self):
         self._cached_config = copy.deepcopy(self._config)
         self._cached_components = copy.deepcopy(self._components)

--- a/BlockServer/core/constants.py
+++ b/BlockServer/core/constants.py
@@ -46,6 +46,7 @@ TAG_VISIBLE = 'visible'
 TAG_RUNCONTROL_ENABLED = 'rc_enabled'
 TAG_RUNCONTROL_LOW = 'rc_lowlimit'
 TAG_RUNCONTROL_HIGH = 'rc_highlimit'
+TAG_RUNCONTROL_SUSPEND_ON_INVALID = 'rc_suspend_on_invalid'
 TAG_LOG_PERIODIC = 'log_periodic'
 TAG_LOG_RATE = 'log_rate'
 TAG_LOG_DEADBAND = 'log_deadband'
@@ -58,6 +59,7 @@ TAG_REMOTE_PREFIX = 'remotePvPrefix'
 TAG_RC_LOW = ":RC:LOW"
 TAG_RC_HIGH = ":RC:HIGH"
 TAG_RC_ENABLE = ":RC:ENABLE"
+TAG_RC_SUSPEND_ON_INVALID = ":RC:SUSPEND_ON_INVALID"
 TAG_RC_OUT_LIST = "CS:RC:OUT:LIST"
 
 SIMLEVELS = ['recsim', 'devsim']

--- a/BlockServer/test_modules/test_configuration_xml.py
+++ b/BlockServer/test_modules/test_configuration_xml.py
@@ -41,6 +41,7 @@ BLOCKS_XML = u"""
         <rc_enabled>True</rc_enabled>
         <rc_lowlimit>1</rc_lowlimit>
         <rc_highlimit>2</rc_highlimit>
+        <rc_suspend_on_invalid>False</rc_suspend_on_invalid>
         <log_periodic>False</log_periodic>
         <log_rate>5</log_rate>
         <log_deadband>0</log_deadband>
@@ -53,6 +54,7 @@ BLOCKS_XML = u"""
         <rc_enabled>True</rc_enabled>
         <rc_lowlimit>1</rc_lowlimit>
         <rc_highlimit>2</rc_highlimit>
+        <rc_suspend_on_invalid>False</rc_suspend_on_invalid>
         <log_periodic>False</log_periodic>
         <log_rate>5</log_rate>
         <log_deadband>0</log_deadband>
@@ -65,6 +67,7 @@ BLOCKS_XML = u"""
         <rc_enabled>True</rc_enabled>
         <rc_lowlimit>1</rc_lowlimit>
         <rc_highlimit>2</rc_highlimit>
+        <rc_suspend_on_invalid>False</rc_suspend_on_invalid>
         <log_periodic>False</log_periodic>
         <log_rate>5</log_rate>
         <log_deadband>0</log_deadband>
@@ -77,6 +80,7 @@ BLOCKS_XML = u"""
         <rc_enabled>True</rc_enabled>
         <rc_lowlimit>1</rc_lowlimit>
         <rc_highlimit>2</rc_highlimit>
+        <rc_suspend_on_invalid>False</rc_suspend_on_invalid>
         <log_periodic>False</log_periodic>
         <log_rate>5</log_rate>
         <log_deadband>0</log_deadband>

--- a/BlockServer/test_modules/test_configuration_xml.py
+++ b/BlockServer/test_modules/test_configuration_xml.py
@@ -17,6 +17,7 @@
 import os
 import re
 import unittest
+import six
 from xml.etree import ElementTree
 from collections import OrderedDict
 
@@ -291,7 +292,7 @@ class TestConfigurationXmlConverterSequence(unittest.TestCase):
 
         # Assert
         self.assertEqual(len(blocks), len(expected_blocks))
-        for key, value in blocks.iteritems():
+        for key, value in six.iteritems(blocks):
             self.assertTrue(key in expected_blocks)
             expected = expected_blocks[key]
             self.assertEqual(value.name, expected.name)

--- a/BlockServer/test_modules/test_runcontrol_manager.py
+++ b/BlockServer/test_modules/test_runcontrol_manager.py
@@ -130,22 +130,6 @@ class TestRunControlSequence(unittest.TestCase):
         self.assertTrue(ans["TESTBLOCK1"]["HIGH"] == 5)
         self.assertTrue(ans["TESTBLOCK1"]["LOW"] == -5)
 
-    @patch("BlockServer.runcontrol.runcontrol_manager.sleep")
-    def test_set_runcontrol_settings_limits(self, sleep_patch):
-        data = {'name': "TESTBLOCK1", 'pv': "PV1",
-                'runcontrol': True, 'lowlimit': -5, 'highlimit': 5}
-        add_block(self.activech, data)
-        self.set_start_time_of_run_control()
-        self.rcm.create_runcontrol_pvs(False, 0)
-        ans = self.rcm.get_current_settings()
-        ans["TESTBLOCK1"]["LOW"] = 0
-        ans["TESTBLOCK1"]["HIGH"] = 10
-        ans["TESTBLOCK1"]["ENABLE"] = False
-        self.rcm.set_runcontrol_settings(ans)
-        ans = self.rcm.get_current_settings()
-        self.assertEqual(ans["TESTBLOCK1"]["HIGH"], 10)
-        self.assertEqual(ans["TESTBLOCK1"]["LOW"], 0)
-
     def test_GIVEN_non_restarting_runcontrol_WHEN_create_PVs_THAT_code_is_not_stuck_in_loop(self):
         rc_pv = RC_START_PV
 

--- a/schema/blocks.xsd
+++ b/schema/blocks.xsd
@@ -20,6 +20,7 @@
         <xs:element ref="blk:rc_enabled" minOccurs="0"/>
         <xs:element ref="blk:rc_lowlimit" minOccurs="0"/>
         <xs:element ref="blk:rc_highlimit" minOccurs="0"/>
+        <xs:element ref="blk:rc_suspend_on_invalid" minOccurs="0"/>
         <xs:element ref="blk:log_periodic" minOccurs="0"/>
         <xs:element ref="blk:log_rate" minOccurs="0"/>
         <xs:element ref="blk:log_deadband" minOccurs="0"/>
@@ -33,6 +34,7 @@
   <xs:element name="rc_lowlimit" type="xs:decimal"/>
   <xs:element name="rc_highlimit" type="xs:decimal"/>
   <xs:element name="rc_enabled" type="xs:string"/>
+  <xs:element name="rc_suspend_on_invalid" type="xs:string"/>
   <xs:element name="log_periodic" type="xs:string"/>
   <xs:element name="log_rate" type="xs:decimal"/>
   <xs:element name="log_deadband" type="xs:decimal"/>


### PR DESCRIPTION
### Description of work

Add flag to runcontrol to control behaviour when pv is invalid or disconnected.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4703

### Acceptance criteria

- Flag works as expected

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Has the author taken into account the multi-threaded nature of the code?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
