### PR TITLE
On successful PV write value is sent to put log

### DIFF
--- a/server_common/loggers/isis_logger.py
+++ b/server_common/loggers/isis_logger.py
@@ -1,3 +1,7 @@
+"""
+Access to external loggers at ISIS
+"""
+
 from __future__ import print_function, absolute_import, division, unicode_literals
 # This file is part of the ISIS IBEX application.
 # Copyright (C) 2012-2016 Science & Technology Facilities Council.
@@ -21,24 +25,70 @@ import contextlib
 import traceback
 import codecs
 
+from concurrent.futures import ThreadPoolExecutor
 
-class IsisLogger(object):
-    def __init__(self):
+from server_common.loggers.logger import Logger
+
+# Server for the log servers
+LOCALHOST = "127.0.0.1"
+
+# TCP Port for the epics message logger
+MESSAGE_LOG_LOGGER_PORT = 7004
+
+# TCP for the put log logger
+PUT_LOG_LOGGER_PORT = 7011
+
+
+class IsisLogger(Logger):
+    """
+    Log messages into the IBEX server message log
+    """
+
+    executor = None
+
+    def __init__(self, logger_port=MESSAGE_LOG_LOGGER_PORT, ioc_name="BLOCKSRV"):
         super(IsisLogger, self).__init__()
-        self.ioclog_host = "127.0.0.1"
-        self.ioclog_port = 7004
+        self.ioc_log_host = LOCALHOST
+        self.ioc_log_port = logger_port
+        self._ioc_name = ioc_name
+        self.start_thread_pool()
 
-    def write_to_log(self, message, severity="INFO", src="BLOCKSVR"):
+    @classmethod
+    def start_thread_pool(cls):
+        """
+        Start the thread pool if not started
+        """
+        if cls.executor is None:
+            cls.executor = ThreadPoolExecutor(max_workers=1)
+
+    @classmethod
+    def stop_thread_pool(cls):
+        """
+        Stop the thread pool; wait for pool to finish
+        """
+        if cls.executor is not None:
+            cls.executor.shutdown(wait=True)
+            cls.executor = None
+
+    def write_to_log(self, message, severity="INFO", src=None):
         """Writes a message to the IOC log. It is preferable to use print_and_log for easier debugging.
         Args:
-            severity (string, optional): Gives the severity of the message. Expected serverities are MAJOR, MINOR and INFO.
-                                        Default severity is INFO
-            src (string, optional): Gives the source of the message. Default source is BLOCKSVR
+            message (string): message to write to the log
+            severity (string, optional): Gives the severity of the message. Expected severities are MAJOR, MINOR and
+                INFO. Default severity is INFO
+            src (string, optional): Gives the source of the message. Defaults to loggers source.
         """
+        if src is None:
+            src = self._ioc_name
+        msg_time = datetime.datetime.now()
+        IsisLogger.executor.submit(
+            self._queued_write_to_log, message, severity, src, self.ioc_log_host, self.ioc_log_port, msg_time)
+
+    @staticmethod
+    def _queued_write_to_log(message, severity, src, ioc_log_host, ioc_log_port, msg_time):
         if severity not in ['INFO', 'MINOR', 'MAJOR', 'FATAL']:
             print("write_to_ioc_log: invalid severity ", severity)
             return
-        msg_time = datetime.datetime.utcnow()
         msg_time_str = msg_time.isoformat()
         if msg_time.utcoffset() is None:
             msg_time_str += "Z"
@@ -54,7 +104,31 @@ class IsisLogger(object):
 
         with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
             try:
-                sock.connect((self.ioclog_host, self.ioclog_port))
+                sock.connect((ioc_log_host, ioc_log_port))
                 sock.sendall(codecs.encode(xml, "utf-8"))
             except Exception:
                 traceback.print_exc()
+
+
+class IsisPutLog:
+    """
+    ISIS Put Log records puts to a PV from sources external to the IOC/server. These are ultimately written to the put
+    log if the ISIS IOC Log Sever is running.
+    """
+
+    def __init__(self, ioc_name):
+        self.logger = IsisLogger(PUT_LOG_LOGGER_PORT, ioc_name)
+        self._ioc_name = ioc_name
+
+    def write_pv_put(self, pv_name, new_value, old_value):
+        """
+        Write a pv put to the put log
+        Args:
+            pv_name: name of the pv (should include instrument and server prefix)
+            new_value: new value
+            old_value:  original value
+        """
+        time_now = datetime.datetime.now()
+        time_str = time_now.strftime("%d-%b-%y %H:%M:%S")
+        message = "{} {} {} {} {} {}".format(time_str, LOCALHOST, self._ioc_name, pv_name, new_value, old_value)
+        self.logger.write_to_log(message)

--- a/server_common/test_modules/test_log_writer.py
+++ b/server_common/test_modules/test_log_writer.py
@@ -1,20 +1,16 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import re
-import time
 import unittest
-import shutil
 import os
 from datetime import datetime
 
 from hamcrest import *
-from mock import Mock, patch, MagicMock
+from mock import Mock, patch
 
-from server_common.autosave import AutosaveFile
 from server_common.loggers.isis_logger import IsisLogger, IsisPutLog
 
 TEMP_FOLDER = os.path.join("C:\\", "instrument", "var", "tmp", "autosave_tests")
-
 
 
 class TestISISLog(unittest.TestCase):
@@ -38,7 +34,7 @@ class TestISISLog(unittest.TestCase):
         assert_that(sent_xml, contains_string(message))
 
     @patch('socket.socket')
-    def test_GIVEN_logger_WHEN_message_sent_THEN_connection_on_logger_port_is_opebed_and_close(self, socket_mock):
+    def test_GIVEN_logger_WHEN_message_sent_THEN_connection_on_logger_port_is_opened_and_close(self, socket_mock):
         logger = IsisLogger()
         mock_socket = Mock()
         socket_mock.return_value = mock_socket
@@ -78,7 +74,7 @@ class TestISISLog(unittest.TestCase):
         assert_that(sent_xml, contains_string(expected_ioc_name))
 
     @patch('socket.socket')
-    def test_GIVEN_logger_with_ioc_name_WHEN_message_sent_with_ioc_name_THEN_message_contains_sendt_ioc_name(
+    def test_GIVEN_logger_with_ioc_name_WHEN_message_sent_with_ioc_name_THEN_message_contains_sent_ioc_name(
             self, socket_mock):
         expected_ioc_name = "my_ioc_name"
 

--- a/server_common/test_modules/test_log_writer.py
+++ b/server_common/test_modules/test_log_writer.py
@@ -1,0 +1,116 @@
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import re
+import time
+import unittest
+import shutil
+import os
+from datetime import datetime
+
+from hamcrest import *
+from mock import Mock, patch, MagicMock
+
+from server_common.autosave import AutosaveFile
+from server_common.loggers.isis_logger import IsisLogger, IsisPutLog
+
+TEMP_FOLDER = os.path.join("C:\\", "instrument", "var", "tmp", "autosave_tests")
+
+
+
+class TestISISLog(unittest.TestCase):
+
+    def setUp(self):
+        IsisLogger.executor = None
+        IsisLogger.start_thread_pool()
+
+    @patch('socket.socket')
+    def test_GIVEN_logger_WHEN_message_sent_THEN_message_contents_is_correct(self, socket_mock):
+        message = "my message"
+
+        logger = IsisLogger()
+        mock_socket = Mock()
+        socket_mock.return_value = mock_socket
+
+        logger.write_to_log(message)
+        logger.stop_thread_pool()
+
+        sent_xml = mock_socket.sendall.args
+        assert_that(sent_xml, contains_string(message))
+
+    @patch('socket.socket')
+    def test_GIVEN_logger_WHEN_message_sent_THEN_connection_on_logger_port_is_opebed_and_close(self, socket_mock):
+        logger = IsisLogger()
+        mock_socket = Mock()
+        socket_mock.return_value = mock_socket
+
+        logger.write_to_log("hi")
+        logger.stop_thread_pool()
+
+        mock_socket.connect.assert_called_once_with(("127.0.0.1", 7004))
+        mock_socket.close.assert_called_once()
+
+    @patch('socket.socket')
+    def test_GIVEN_logger_WHEN_message_sent_THEN_message_contains_ioc_name(self, socket_mock):
+        expected_ioc_name = "my_ioc_name"
+
+        logger = IsisLogger()
+        mock_socket = Mock()
+        socket_mock.return_value = mock_socket
+
+        logger.write_to_log("message", src=expected_ioc_name)
+        IsisLogger.executor.shutdown(wait=True)
+
+        sent_xml = mock_socket.sendall.args
+        assert_that(sent_xml, contains_string(expected_ioc_name))
+
+    @patch('socket.socket')
+    def test_GIVEN_logger_with_ioc_name_WHEN_message_sent_THEN_message_contains_ioc_name(self, socket_mock):
+        expected_ioc_name = "my_ioc_name"
+
+        logger = IsisLogger(expected_ioc_name)
+        mock_socket = Mock()
+        socket_mock.return_value = mock_socket
+
+        logger.write_to_log("message")
+        IsisLogger.executor.shutdown(wait=True)
+
+        sent_xml = mock_socket.sendall.args
+        assert_that(sent_xml, contains_string(expected_ioc_name))
+
+    @patch('socket.socket')
+    def test_GIVEN_logger_with_ioc_name_WHEN_message_sent_with_ioc_name_THEN_message_contains_sendt_ioc_name(
+            self, socket_mock):
+        expected_ioc_name = "my_ioc_name"
+
+        logger = IsisLogger("different_ioc_name")
+        mock_socket = Mock()
+        socket_mock.return_value = mock_socket
+
+        logger.write_to_log("message", src=expected_ioc_name)
+        IsisLogger.executor.shutdown(wait=True)
+
+        sent_xml = mock_socket.sendall.call_args[0][0]
+        assert_that(sent_xml, contains_string(expected_ioc_name))
+
+    @patch('socket.socket')
+    @patch('datetime.datetime')
+    def test_GIVEN_isis_put_log_WHEN_pv_set_THEN_message_is_correct(self, datetime_mock, socket_mock):
+        expected_ioc_name = "my_ioc_name"
+        expected_date = "10-Jan-19 12:34:56"
+        datetime_mock.now.return_value = datetime(2019, 1, 10, 12, 34, 56)
+        pv_name = "pv:name"
+        new_value = 19
+        old_value = 10.23
+        expected_message = "{} 127.0.0.1 {} {} {} {}".format(
+            expected_date, expected_ioc_name, pv_name, new_value, old_value)
+
+        logger = IsisPutLog(expected_ioc_name)
+        mock_socket = Mock()
+        socket_mock.return_value = mock_socket
+
+        logger.write_pv_put(pv_name, new_value, old_value)
+        IsisLogger.executor.shutdown(wait=True)
+
+        sent_xml = mock_socket.sendall.call_args[0][0]
+        match = re.search("<!\[CDATA\[(.*)\]\]>", sent_xml)
+        assert_that(match.group(1), is_(expected_message))

--- a/server_common/test_modules/test_log_writer.py
+++ b/server_common/test_modules/test_log_writer.py
@@ -30,7 +30,7 @@ class TestISISLog(unittest.TestCase):
         logger.write_to_log(message)
         logger.stop_thread_pool()
 
-        sent_xml = mock_socket.sendall.args
+        sent_xml = mock_socket.sendall.call_args[0][0]
         assert_that(sent_xml, contains_string(message))
 
     @patch('socket.socket')
@@ -56,21 +56,21 @@ class TestISISLog(unittest.TestCase):
         logger.write_to_log("message", src=expected_ioc_name)
         IsisLogger.executor.shutdown(wait=True)
 
-        sent_xml = mock_socket.sendall.args
+        sent_xml = mock_socket.sendall.call_args[0][0]
         assert_that(sent_xml, contains_string(expected_ioc_name))
 
     @patch('socket.socket')
     def test_GIVEN_logger_with_ioc_name_WHEN_message_sent_THEN_message_contains_ioc_name(self, socket_mock):
         expected_ioc_name = "my_ioc_name"
 
-        logger = IsisLogger(expected_ioc_name)
+        logger = IsisLogger(ioc_name=expected_ioc_name)
         mock_socket = Mock()
         socket_mock.return_value = mock_socket
 
         logger.write_to_log("message")
         IsisLogger.executor.shutdown(wait=True)
 
-        sent_xml = mock_socket.sendall.args
+        sent_xml = mock_socket.sendall.call_args[0][0]
         assert_that(sent_xml, contains_string(expected_ioc_name))
 
     @patch('socket.socket')


### PR DESCRIPTION
Made ioc log threaded

### Description of work

ISIS Pv Log which gets called on any write in the reflectometry server

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3904

### Acceptance criteria

1. Successful write to a PV is logged in the put log (`C:\data\<latest>_ICPputlog.txt`)

There are currently no automated tests for this I do not know how to test that a value will get written to the put log. Is that ok because it is diagnostics (added a manual test)

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
