### PR TITLE
If there is no remote pv prefix assume it is Empty not set

### DIFF
--- a/block_server.py
+++ b/block_server.py
@@ -383,7 +383,7 @@ class BlockServer(Driver):
         # Note: autostart means the IOC is started when the config is loaded,
         # restart means the IOC should automatically restart if it stops for some reason (e.g. it crashes)
         for name, ioc in self._active_configserver.get_all_ioc_details().items():
-            if ioc.remotePvPrefix != "":
+            if ioc.remotePvPrefix not in (None, ""):
                 print_and_log("IOC '{}' is set to run remotely - not starting it.".format(name))
                 continue
 
@@ -579,7 +579,7 @@ class BlockServer(Driver):
         # Once all IOC start requests issued, wait for running and apply auto restart as needed
         for i in iocs:
             if i in conf_iocs and conf_iocs[i].restart:
-                if conf_iocs[i].remotePvPrefix != "":
+                if conf_iocs[i].remotePvPrefix not in (None, ""):
                     print_and_log("IOC '{}' is set to run remotely - not applying auto-restart.".format(i))
                     continue
                 # Give it time to start as IOC has to be running to be able to set restart property


### PR DESCRIPTION
### Description of work

If the remote pv prefix is not set in the config then it is none during the check for empty

### To test

fix system tests which fail because the config has no remote_pv_prefix

### Acceptance criteria

A config with an ioc with no remote pv prefix starts on config change

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
