### PR TITLE
Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,9 @@ pipeline {
     stage("Collate Unit Tests") {
       steps {
         junit '**/test-reports/TEST-*.xml'
-        cobertura coberturaReportFile: '**/cobertura.xml'
+        if (fileExists('**/cobertura.xml')) {
+          cobertura coberturaReportFile: '**/cobertura.xml'
+        }
       }
     }
 


### PR DESCRIPTION
### Description of work

As of https://github.com/ISISComputingGroup/EPICS-inst_servers/pull/235, we only produce coverage reports for python 3. This results in build pipeline failures on machines where the report file does not exist - on other machines it shows outdated coverage reports.

Since neither of these are particularly useful, these changes simply skip the relevant step if the file does not exist. The coverage report should just reappear once we are on python 3.
