### PR TITLE
changed max size for macro values to 256 characters

### DIFF
--- a/schema/ioc_types.xsd
+++ b/schema/ioc_types.xsd
@@ -36,7 +36,7 @@
   </xs:simpleType>  
   <xs:simpleType name="macrovalue">
     <xs:restriction base="xs:string">
-      <xs:maxLength value="60"></xs:maxLength>
+      <xs:maxLength value="256"></xs:maxLength>
     </xs:restriction>
   </xs:simpleType>  
   <xs:simpleType name="simoptions">


### PR DESCRIPTION
### Description of work

Changed Macro values to 256 in Schema

### To test
[#4934](https://github.com/ISISComputingGroup/IBEX/issues/4934)

### Acceptance criteria
- [x] Macros are allowed to be 256 characters long if it is not loaded onto a field of a record which has character limit set 



---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
