### PR TITLE
ioc startup fix

### DIFF
--- a/server_common/ioc_data_source.py
+++ b/server_common/ioc_data_source.py
@@ -72,7 +72,7 @@ INSERT_PV_DETAILS = "INSERT INTO pvs (pvname, record_type, record_desc, iocname)
 """Insert PV details into the pvs table"""
 
 INSERT_IOC_STARTED_DETAILS = "INSERT INTO iocrt (iocname, pid, start_time, stop_time, running, exe_path) " \
-                 "VALUES (%s,%s,NOW(),'0000-00-00 00:00:00',1,%s)"
+                 "VALUES (%s,%s,NOW(),'1970-01-01 00:00:01',1,%s)"
 """Insert details about the start of an IOC"""
 
 DELETE_IOC_RUN_STATE = "DELETE FROM iocrt WHERE iocname=%s"


### PR DESCRIPTION
### Description of work

Change timestamp to one that will be accepted in the latest version of mysql

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4918

### Acceptance criteria

- [ ] LSI correlator IOC boots without error in the log

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
