### PR TITLE
Only update PVs when data has changed

### DIFF
--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -202,7 +202,9 @@ class DatabaseServer(Driver):
                 for pv in [DbPVNames.IOCS, DbPVNames.HIGH_INTEREST, DbPVNames.MEDIUM_INTEREST, DbPVNames.FACILITY,
                            DbPVNames.ACTIVE_PVS, DbPVNames.ALL_PVS]:
                     encoded_data = self.get_data_for_pv(pv)
-                    self.setParam(pv, encoded_data)
+                    # No need to update monitors if data hasn't changed
+                    if not self.getParam(pv) == encoded_data:
+                        self.setParam(pv, encoded_data)
                 # Update them
                 with self.monitor_lock:
                     self.updatePVs()


### PR DESCRIPTION
### Description of work

Only updates database PVs when they actually change to reduce client side load.

### To test

On master:
* `camonitor %MYPVPREFIX%CS:BLOCKSERVER:IOCS` and confirm it continues to update despite the database not changing
* Use the JVisualVM to monitor the client CPU usage

On this branch:
* Confirm `camonitor %MYPVPREFIX%CS:BLOCKSERVER:IOCS` only gives one update
* Confirm client CPU usage has decreased, see below where the branches were switched a couple of times:

![image](https://user-images.githubusercontent.com/10086797/76166224-e8da7700-6154-11ea-841d-a637b207def2.png)

* On the new branch confirm that the dbserver still updates when expected i.e. start an IOC and confirm it shows as started in the start/stop dialog

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
