### PR TITLE
Ticket5334 cap number of threads

### DIFF
--- a/server_common/channel_access.py
+++ b/server_common/channel_access.py
@@ -95,17 +95,19 @@ except ImportError:
 class ChannelAccess(object):
     # Create a thread poll so that threads are reused and so ca contexts that each thread gets are shared. This also
     # caps the number of ca library threads. 20 is chosen as being probably enough but limited.
-    thread_pool = ThreadPoolExecutor(max_workers=NUMBER_OF_CAPUT_THREADS)
+    thread_pool = ThreadPoolExecutor(max_workers=NUMBER_OF_CAPUT_THREADS, thread_name_prefix="ChannelAccess_Pool")
 
     @staticmethod
     def wait_for_tasks():
+        """
+        Wait for all requested tasks to complete, i.e. all caputs.
+
+        It does this by shutting down the current threadpool waiting for all tasks to complete and then create a new
+        pool.
+        """
         ChannelAccess.thread_pool.shutdown()
         ChannelAccess.thread_pool = ThreadPoolExecutor(max_workers=NUMBER_OF_CAPUT_THREADS)
 
-    """
-    Channel access methods. Items from genie_python are imported locally so that this module can be imported without
-    installing genie_python.
-    """
     @staticmethod
     def caget(name, as_string=False, timeout=None):
         """Uses CaChannelWrapper from genie_python to get a pv value. We import CaChannelWrapper when used as this means
@@ -257,7 +259,7 @@ def verify_manager_mode(channel_access=ChannelAccess(), message="Operation must 
         raise ManagerModeRequiredException("Manager mode is required, but the manager mode PV could not be read "
                                            "(caused by: {})".format(e))
     except Exception as e:
-        raise ManagerModeRequiredException("Manager mode is required, but an unknown exception occured "
+        raise ManagerModeRequiredException("Manager mode is required, but an unknown exception occurred "
                                            "(caused by: {})".format(e))
 
     if not is_manager:

--- a/server_common/channel_access.py
+++ b/server_common/channel_access.py
@@ -128,7 +128,7 @@ class ChannelAccess(object):
         Args:
             name (string): The name of the PV to be set
             value (object): The data to send to the PV
-            wait (bool, optional): Wait for the PV t set before returning
+            wait (bool, optional): Wait for the PV to set before returning
         Returns:
             None: if wait is False
             Future: if wait if True

--- a/server_common/channel_access.py
+++ b/server_common/channel_access.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
+
 """
 Make channel access not dependent on genie_python.
 """
@@ -21,8 +22,10 @@ from enum import Enum
 
 from BlockServer.core.macros import MACROS
 from server_common.utilities import print_and_log
-import threading
+from concurrent.futures import ThreadPoolExecutor
 
+# Number of threads to serve caputs
+NUMBER_OF_CAPUT_THREADS = 20
 
 try:
     from genie_python.channel_access_exceptions import UnableToConnectToPVException, ReadAccessException
@@ -82,6 +85,10 @@ except ImportError:
 
 
 class ChannelAccess(object):
+    # Create a thread poll so that threads are reused and so ca contexts that each thread gets are shared. This also
+    # caps the number of ca library threads. 20 is chosen as being probably enough but limited.
+    thread_pool = ThreadPoolExecutor(max_workers=NUMBER_OF_CAPUT_THREADS)
+
     """
     Channel access methods. Items from genie_python are imported locally so that this module can be imported without
     installing genie_python.
@@ -112,13 +119,19 @@ class ChannelAccess(object):
 
     @staticmethod
     def caput(name, value, wait=False):
-        """Uses CaChannelWrapper from genie_python to set a pv value. We import CaChannelWrapper when used as this means
-        the tests can run without having genie_python installed
+        """
+        Uses CaChannelWrapper from genie_python to set a pv value. Waiting will put the call in a thread so the order
+        is no longer guarenteed. Also if the call take time a queue will be formed of put tasks.
+
+        We import CaChannelWrapper when used as this means the tests can run without having genie_python installed
 
         Args:
             name (string): The name of the PV to be set
             value (object): The data to send to the PV
             wait (bool, optional): Wait for the PV t set before returning
+        Returns:
+            None: if wait is False
+            Future: if wait if True
         """
         def _put_value():
             CaChannelWrapper.set_pv_value(name, value, wait)
@@ -126,11 +139,11 @@ class ChannelAccess(object):
         if wait:
             # If waiting then run in this thread.
             _put_value()
+            return None
         else:
             # If not waiting, run in a different thread.
             # Even if not waiting genie_python sometimes takes a while to return from a set_pv_value call.
-            thread = threading.Thread(target=_put_value)
-            thread.start()
+            return ChannelAccess.thread_pool.submit(_put_value)
 
     @staticmethod
     def caput_retry_on_fail(pv_name, value, retry_count=5):

--- a/server_common/test_modules/test_channel_access.py
+++ b/server_common/test_modules/test_channel_access.py
@@ -1,0 +1,50 @@
+import threading
+import time
+import unittest
+
+from concurrent.futures import wait
+from mock import Mock, patch
+
+from hamcrest import *
+
+import server_common
+from server_common.channel_access import ChannelAccess, NUMBER_OF_CAPUT_THREADS
+
+
+def set_pv_value(name, value, wait=False, timeout=0):
+    """ Mock method with set pv value signature, must take some time to work"""
+    time.sleep(1)
+
+
+class TestChannelAccess(unittest.TestCase):
+
+    @patch("server_common.channel_access.CaChannelWrapper.set_pv_value")
+    def test_WHEN_ca_put_and_not_wait_THEN_get_pv_value_is_called(self, mock_set_pv_value):
+        expected_val = 10
+
+        future = ChannelAccess.caput("block", expected_val, False)
+
+        wait([future])
+        mock_set_pv_value.assert_called_once_with("block", expected_val, False)
+
+    @patch("server_common.channel_access.CaChannelWrapper.set_pv_value", side_effect=set_pv_value)
+    def test_WHEN_multiple_ca_puts_and_not_wait_THEN_thread_count_is_limited(self, mock_set_pv_value):
+        initial_thread_count = threading.active_count()
+
+        the_future = []
+        for thread_val in range(2 * NUMBER_OF_CAPUT_THREADS):
+            the_future.append(ChannelAccess.caput("Non_existant_block", thread_val, False))
+
+        current_count = threading.active_count()
+
+        newly_created_threads = current_count - initial_thread_count
+        assert_that(newly_created_threads, is_(greater_than(NUMBER_OF_CAPUT_THREADS / 2)),
+                    "Number of threads running (thread count: initial {} current {})".format(initial_thread_count,
+                                                                                             current_count))
+
+        assert_that(newly_created_threads, is_(less_than_or_equal_to(NUMBER_OF_CAPUT_THREADS)),
+                    "Number of threads running (thread count: initial {} current {})".format(initial_thread_count,
+                                                                                             current_count))
+
+        wait(the_future)
+        assert_that(mock_set_pv_value.call_count, is_(2 * NUMBER_OF_CAPUT_THREADS))

--- a/server_common/test_modules/test_channel_access.py
+++ b/server_common/test_modules/test_channel_access.py
@@ -1,6 +1,7 @@
 import threading
 import time
 import unittest
+from Queue import Queue, Empty
 
 from concurrent.futures import wait
 from mock import Mock, patch
@@ -11,29 +12,51 @@ import server_common
 from server_common.channel_access import ChannelAccess, NUMBER_OF_CAPUT_THREADS
 
 
+thread_ids = Queue()
+thread_calls = Queue()
+
 def set_pv_value(name, value, wait=False, timeout=0):
     """ Mock method with set pv value signature, must take some time to work"""
-    time.sleep(1)
+    thread_calls.put((name, value, wait, timeout))
+    thread_ids.put(threading.currentThread().ident)
+    time.sleep(0.5)
+
+def empty_queue(queue):
+    contents = []
+    try:
+        while True:
+            contents.append(queue.get(block=False))
+    except Empty:
+        pass
+    return contents
 
 
 class TestChannelAccess(unittest.TestCase):
+    # throughout this class I would like to have patch the static method set_pv_value but it doesn't work because it is
+    # static is a thread
 
-    @patch("server_common.channel_access.CaChannelWrapper.set_pv_value")
-    def test_WHEN_ca_put_and_not_wait_THEN_get_pv_value_is_called(self, mock_set_pv_value):
+    def setUp(self):
+        empty_queue(thread_ids)
+        empty_queue(thread_calls)
+        ChannelAccess.wait_for_tasks()
+
+
+    def test_WHEN_ca_put_and_not_wait_THEN_get_pv_value_is_called(self):
         expected_val = 10
 
-        future = ChannelAccess.caput("block", expected_val, False)
+        future = ChannelAccess.caput("block", expected_val, False, set_pv_value=set_pv_value)
 
         wait([future])
-        mock_set_pv_value.assert_called_once_with("block", expected_val, False)
+        time.sleep(3)  # wait for all items to finish
+        assert_that(len(empty_queue(thread_calls)), is_(1), "call is called once")
 
-    @patch("server_common.channel_access.CaChannelWrapper.set_pv_value", side_effect=set_pv_value)
-    def test_WHEN_multiple_ca_puts_and_not_wait_THEN_thread_count_is_limited(self, mock_set_pv_value):
+
+    def test_WHEN_multiple_ca_puts_and_not_wait_THEN_thread_count_is_limited(self):
         initial_thread_count = threading.active_count()
 
         the_future = []
         for thread_val in range(2 * NUMBER_OF_CAPUT_THREADS):
-            the_future.append(ChannelAccess.caput("Non_existant_block", thread_val, False))
+            the_future.append(ChannelAccess.caput("Non_existant_block", thread_val, False, set_pv_value=set_pv_value))
 
         current_count = threading.active_count()
 
@@ -47,4 +70,20 @@ class TestChannelAccess(unittest.TestCase):
                                                                                              current_count))
 
         wait(the_future)
-        assert_that(mock_set_pv_value.call_count, is_(2 * NUMBER_OF_CAPUT_THREADS))
+        time.sleep(3)  # wait for all items to finish
+        assert_that(len(empty_queue(thread_calls)), is_(2 * NUMBER_OF_CAPUT_THREADS))
+
+    def test_WHEN_multiple_ca_puts_THEN_a_limited_number_of_threads_are_used(self):
+        # This is so the same ca context and channels are used
+
+        the_future = []
+        for thread_val in range(2 * NUMBER_OF_CAPUT_THREADS):
+            the_future.append(ChannelAccess.caput("Non_existent_block", thread_val, False, set_pv_value=set_pv_value))
+
+        wait(the_future)
+        time.sleep(3)  # wait for all items to finish
+
+        ids=set(empty_queue(thread_ids))
+
+        assert_that(ids, has_length(NUMBER_OF_CAPUT_THREADS),
+                    "Number of ids should be the same as number of threads so that multiple tasks use the same thread")


### PR DESCRIPTION
### Description of work

Ensure number of threads are capped by using a thread pool

### To test

https://github.com/ISISComputingGroup/IBEX/issues/5334

### Acceptance criteria

Number of threads does not increase over time on multiple puts from, for instance, ca server

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
