### PR TITLE
Allow numbers smaller than 1E-4 for block deadband

### DIFF
--- a/schema/blocks.xsd
+++ b/schema/blocks.xsd
@@ -37,5 +37,5 @@
   <xs:element name="rc_suspend_on_invalid" type="xs:string"/>
   <xs:element name="log_periodic" type="xs:string"/>
   <xs:element name="log_rate" type="xs:decimal"/>
-  <xs:element name="log_deadband" type="xs:decimal"/>
+  <xs:element name="log_deadband" type="xs:double"/>
 </xs:schema>


### PR DESCRIPTION
### Description of work

Changed type of block deadband in xml schema from decimal to double. This allows values of less than 1E-4 to be entered and allows scientific notation to be used.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4958

### Acceptance criteria

When the following deadbands are set, the configuration saves and changes of value less than the deadband are not archived in the database (this can be tested by going to http://localhost:4813/group?name=BLOCKS and selecting the block you're setting, then seeing if last archived value updates or not):

* 1E-6
* 0.000001
* 1e6
* 1000000
* 0

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
