### PR TITLE
Ensure position is set while still in SET context

### DIFF
--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -764,7 +764,8 @@ class _JawsAxisPVWrapper(PVWrapper):
                 logger.info("    Motor {name} initially at rbv {rbv} sp {sp}".format(name=motor, rbv=rbv, sp=sp))
 
             with self._motor_in_set_mode(mtr1), self._motor_in_set_mode(mtr2):
-                self._write_pv(self._sp_pv, new_position)
+                # Ensure the position has been redefined before leaving the "Set" context, otherwise the motor moves
+                self._ca.caput_retry_on_fail(self._sp_pv, new_position)
 
             for motor in self._pv_names_for_directions("MTR"):
                 rbv = self._read_pv("{}.RBV".format(motor))

--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -252,6 +252,7 @@ class PVWrapper(object):
     def _write_pv_with_retry(self, pv, value, retry_count=5):
         """
         Write a value to a given PV, check it was successful and retry if not.
+        Note that a retry implies wait=True (completion callback).
 
         Args:
             pv: pv name to write to


### PR DESCRIPTION
There was a bug with redefining a motor position through a reflectometry parameter, where the reflectometry IOC would write 

`MTRXXXX.SET` --> `SET`
`MTRXXXX.SET` --> `USE`
`MTRXXXX.VAL` --> `(new position)`

instead of 

`MTRXXXX.SET` --> `SET`
`MTRXXXX.VAL` --> `(new position)`
`MTRXXXX.SET` --> `USE`

resulting in the motor to move to the given position instead of accepting it as the new current position. This change just ensures the new position is set before leaving the `SET` context.