### PR TITLE
Ticket4967 refl opi improvements

### DIFF
--- a/ReflectometryServer/__init__.py
+++ b/ReflectometryServer/__init__.py
@@ -10,5 +10,6 @@ from ReflectometryServer.footprint_manager import FootprintSetup, BaseFootprintS
 from ReflectometryServer.geometry import PositionAndAngle, Position
 from ReflectometryServer.ioc_driver import AngleDriver, DisplacementDriver
 from ReflectometryServer.out_of_beam import OutOfBeamPosition
-from ReflectometryServer.parameters import InBeamParameter, AngleParameter, TrackingPosition, SlitGapParameter
+from ReflectometryServer.parameters import InBeamParameter, AngleParameter, TrackingPosition, DirectParameter, \
+    SlitGapParameter
 from ReflectometryServer.pv_wrapper import MotorPVWrapper, JawsCentrePVWrapper, JawsGapPVWrapper, PVWrapper

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -439,6 +439,7 @@ class AngleParameter(BeamlineParameter):
             self._reflection_component.beam_path_set_point.add_listener(InitUpdate, self._initialise_sp_from_motor)
 
         self._reflection_component.beam_path_rbv.add_listener(PhysicalMoveUpdate, self._on_update_rbv)
+        self._reflection_component.beam_path_rbv.add_listener(BeamPathUpdate, self._on_update_rbv)
         self._reflection_component.beam_path_rbv.add_listener(ComponentChangingUpdate,
                                                               self._on_update_changing_state)
 

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -701,35 +701,32 @@ class InBeamParameter(BeamlineParameter):
         return self._component.beam_path_rbv.is_displacing
 
 
-class SlitGapParameter(BeamlineParameter):
+class DirectParameter(BeamlineParameter):
     """
-    Parameter which sets the gap on a slit. This differs from other beamline parameters in that it is not linked to the
-    beamline component layer but hooks directly into a motor axis.
+    Parameter which is not linked to the beamline component layer but hooks directly into a motor axis. This parameter
+    is just a wrapper to present a motor PV as a reflectometry style PV and does not track the beam path.
     """
-
     def __init__(self, name, pv_wrapper, sim=False, init=0, description=None, autosave=False,
                  rbv_to_sp_tolerance=0.002):
         """
         Args:
             name (str): The name of the parameter
-            pv_wrapper (ReflectometryServer.pv_wrapper._JawsAxisPVWrapper): The jaws pv wrapper this parameter talks to
+            pv_wrapper (ReflectometryServer.pv_wrapper.PVWrapper): The pv wrapper this parameter talks to
             sim (bool): Whether it is a simulated parameter
             init (float): Initialisation value if simulated
             description (str): The description
+            autosave (bool): Whether the setpoint for this parameter should be autosaved
+            rbv_to_sp_tolerance (float): The max difference between setpoint and readback value for considering the
+                parameter to be "at readback value"
         """
-        super(SlitGapParameter, self).__init__(name, sim, init, description, autosave,
-                                               rbv_to_sp_tolerance=rbv_to_sp_tolerance)
+        super(DirectParameter, self).__init__(name, sim, init, description, autosave,
+                                              rbv_to_sp_tolerance=rbv_to_sp_tolerance)
         self._last_update = None
 
         self._pv_wrapper = pv_wrapper
-        self._pv_wrapper.add_listener(ReadbackUpdate, self._on_update_slit_rbv)
+        self._pv_wrapper.add_listener(ReadbackUpdate, self._cache_and_update_rbv)
         self._pv_wrapper.add_listener(IsChangingUpdate, self._on_is_changing_change)
         self._pv_wrapper.initialise()
-        if pv_wrapper.is_vertical:
-            self.group_names.append(BeamlineParameterGroup.FOOTPRINT_PARAMETER)
-            self.group_names.append(BeamlineParameterGroup.GAP_VERTICAL)
-        else:
-            self.group_names.append(BeamlineParameterGroup.GAP_HORIZONTAL)
 
         if self._autosave:
             self._initialise_sp_from_file()
@@ -756,7 +753,7 @@ class SlitGapParameter(BeamlineParameter):
         """
         self._set_initial_sp(self._pv_wrapper.sp)
 
-    def _on_update_slit_rbv(self, update):
+    def _cache_and_update_rbv(self, update):
         """
         Update the readback value.
 
@@ -823,3 +820,29 @@ class SlitGapParameter(BeamlineParameter):
         Returns: Is the parameter changing (displacing)
         """
         return self._pv_wrapper.is_moving
+
+
+class SlitGapParameter(DirectParameter):
+    """
+    Parameter which sets the gap on a slit.
+    """
+    def __init__(self, name, pv_wrapper, sim=False, init=0, description=None, autosave=False,
+                 rbv_to_sp_tolerance=0.002):
+        """
+        Args:
+            name (str): The name of the parameter
+            pv_wrapper (ReflectometryServer.pv_wrapper._JawsAxisPVWrapper): The pv wrapper this parameter talks to
+            sim (bool): Whether it is a simulated parameter
+            init (float): Initialisation value if simulated
+            description (str): The description
+            autosave (bool): Whether the setpoint for this parameter should be autosaved
+            rbv_to_sp_tolerance (float): The max difference between setpoint and readback value for considering the
+                parameter to be "at readback value"
+        """
+        super(SlitGapParameter, self).__init__(name, pv_wrapper, sim, init, description, autosave,
+                                               rbv_to_sp_tolerance=rbv_to_sp_tolerance)
+        if pv_wrapper.is_vertical:
+            self.group_names.append(BeamlineParameterGroup.FOOTPRINT_PARAMETER)
+            self.group_names.append(BeamlineParameterGroup.GAP_VERTICAL)
+        else:
+            self.group_names.append(BeamlineParameterGroup.GAP_HORIZONTAL)

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 
 from pcaspy import Severity
 
-from ReflectometryServer.beam_path_calc import BeamPathUpdate, ComponentChangingUpdate, InitUpdate
+from ReflectometryServer.beam_path_calc import BeamPathUpdate, ComponentChangingUpdate, InitUpdate, PhysicalMoveUpdate
 from ReflectometryServer.file_io import param_float_autosave, param_bool_autosave
 import logging
 
@@ -438,7 +438,7 @@ class AngleParameter(BeamlineParameter):
         if self._set_point_rbv is None:
             self._reflection_component.beam_path_set_point.add_listener(InitUpdate, self._initialise_sp_from_motor)
 
-        self._reflection_component.beam_path_rbv.add_listener(BeamPathUpdate, self._on_update_rbv)
+        self._reflection_component.beam_path_rbv.add_listener(PhysicalMoveUpdate, self._on_update_rbv)
         self._reflection_component.beam_path_rbv.add_listener(ComponentChangingUpdate,
                                                               self._on_update_changing_state)
 

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -15,7 +15,8 @@ from ReflectometryServer.beamline import BeamlineMode, Beamline
 from ReflectometryServer.components import Component, TiltingComponent, ThetaComponent, ReflectingComponent
 from ReflectometryServer.geometry import PositionAndAngle
 from ReflectometryServer.ioc_driver import DisplacementDriver, AngleDriver
-from ReflectometryServer.parameters import BeamlineParameter, TrackingPosition, AngleParameter, SlitGapParameter
+from ReflectometryServer.parameters import BeamlineParameter, TrackingPosition, AngleParameter, DirectParameter, \
+    SlitGapParameter
 import numpy as np
 
 

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -534,12 +534,25 @@ class TestBeamlineParameterReadback(unittest.TestCase):
         angle = 3.0
         beam_angle = 1.0
         sample.beam_path_rbv.set_incoming_beam(PositionAndAngle(0, 0, beam_angle))
-        displacement_parameter = AngleParameter("param", sample)
+        angle_parameter = AngleParameter("param", sample)
         listener = Mock()
-        displacement_parameter.add_listener(ParameterReadbackUpdate, listener)
+        angle_parameter.add_listener(ParameterReadbackUpdate, listener)
         sample.beam_path_rbv.set_angular_displacement(angle)
 
-        listener.assert_called_once_with(ParameterReadbackUpdate(angle-beam_angle, None, None))
+        listener.assert_called_with(ParameterReadbackUpdate(angle-beam_angle, None, None))
+
+    def test_GIVEN_reflection_angle_on_tilting_component_WHEN_set_readback_on_component_THEN_call_back_triggered_on_component_change(self):
+
+        sample = TiltingComponent("sample", setup=PositionAndAngle(0, 10, 90))
+        angle = 3.0
+        beam_angle = 1.0
+        sample.beam_path_rbv.set_incoming_beam(PositionAndAngle(0, 0, beam_angle))
+        angle_parameter = AngleParameter("param", sample)
+        listener = Mock()
+        angle_parameter.add_listener(ParameterReadbackUpdate, listener)
+        sample.beam_path_rbv.set_angular_displacement(angle)
+
+        listener.assert_called_with(ParameterReadbackUpdate(angle-beam_angle, None, None))
 
     def test_GIVEN_component_in_beam_WHEN_set_readback_on_component_THEN_call_back_triggered_on_component_change(self):
 
@@ -640,7 +653,7 @@ class TestBeamlineParameterReadback(unittest.TestCase):
 
         component.beam_path_rbv.angle_update(CorrectedReadbackUpdate(new_angle, alarm_severity, alarm_status))
 
-        listener.assert_called_once_with(ParameterReadbackUpdate(True, alarm_severity, alarm_status))
+        listener.assert_called_with(ParameterReadbackUpdate(True, alarm_severity, alarm_status))
         self.assertEqual(angle_parameter.alarm_severity, alarm_severity)
         self.assertEqual(angle_parameter.alarm_status, alarm_status)
 
@@ -655,7 +668,7 @@ class TestBeamlineParameterReadback(unittest.TestCase):
 
         component.beam_path_rbv.displacement_update(CorrectedReadbackUpdate(new_angle, alarm_severity, alarm_status))
 
-        listener.assert_called_once_with(ParameterReadbackUpdate(0.0, None, None))
+        listener.assert_called_with(ParameterReadbackUpdate(0.0, None, None))
         self.assertEqual(angle_parameter.alarm_severity, None)
         self.assertEqual(angle_parameter.alarm_status, None)
 

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -689,20 +689,20 @@ class TestBeamlineParameterReadback(unittest.TestCase):
         self.assertEqual(in_beam_parameter.alarm_severity, None)
         self.assertEqual(in_beam_parameter.alarm_status, None)
 
-    def test_GIVEN_slit_gap_parameter_WHEN_updating_gap_with_alarm_on_pv_wrapper_THEN_parameter_is_in_alarm_and_propagates_alarm(self):
+    def test_GIVEN_direct_parameter_WHEN_updating_value_with_alarm_on_pv_wrapper_THEN_parameter_is_in_alarm_and_propagates_alarm(self):
         pv_wrapper = create_mock_axis("s1vg", 0.0, 1)
         new_value = 1.0
         alarm_severity = 1
         alarm_status = 2
-        in_beam_parameter = SlitGapParameter("param", pv_wrapper)
+        parameter = DirectParameter("param", pv_wrapper)
         listener = Mock()
-        in_beam_parameter.add_listener(ParameterReadbackUpdate, listener)
+        parameter.add_listener(ParameterReadbackUpdate, listener)
 
         pv_wrapper.trigger_listeners(ReadbackUpdate(new_value, alarm_severity, alarm_status))
 
         listener.assert_called_once_with(ParameterReadbackUpdate(new_value, alarm_severity, alarm_status))
-        self.assertEqual(in_beam_parameter.alarm_severity, alarm_severity)
-        self.assertEqual(in_beam_parameter.alarm_status, alarm_status)
+        self.assertEqual(parameter.alarm_severity, alarm_severity)
+        self.assertEqual(parameter.alarm_status, alarm_status)
 
 
 class TestBeamlineThetaComponentWhenDisabled(unittest.TestCase):
@@ -881,29 +881,29 @@ class TestInitSetpoints(unittest.TestCase):
         self.assertIsNone(param.sp)
         self.assertIsNone(param.sp_rbv)
 
-    def test_GIVEN_autosave_is_true_and_autosave_value_exists_WHEN_creating_slit_gap_parameter_THEN_sp_is_autosave_value(self):
+    def test_GIVEN_autosave_is_true_and_autosave_value_exists_WHEN_creating_direct_parameter_THEN_sp_is_autosave_value(self):
         expected = 0.1
         param_name = "param_float"
 
-        param = SlitGapParameter(param_name, self.jaws, autosave=True)
+        param = DirectParameter(param_name, self.jaws, autosave=True)
 
         self.assertEqual(expected, param.sp)
         self.assertEqual(expected, param.sp_rbv)
 
-    def test_GIVEN_autosave_is_true_and_autosave_value_does_not_exist_WHEN_creating_slit_gap_parameter_THEN_sp_is_taken_from_motor_instead(self):
+    def test_GIVEN_autosave_is_true_and_autosave_value_does_not_exist_WHEN_creating_direct_parameter_THEN_sp_is_taken_from_motor_instead(self):
         expected = 0.2
         param_name = "param_not_in_file"
 
-        param = SlitGapParameter(param_name, self.jaws, autosave=True)
+        param = DirectParameter(param_name, self.jaws, autosave=True)
 
         self.assertEqual(expected, param.sp)
         self.assertEqual(expected, param.sp_rbv)
 
-    def test_GIVEN_autosave_parameter_value_of_wrong_type_WHEN_creating_slit_gap_parameter_THEN_sp_is_taken_from_motor_instead(self):
+    def test_GIVEN_autosave_parameter_value_of_wrong_type_WHEN_creating_direct_parameter_THEN_sp_is_taken_from_motor_instead(self):
         expected = 0.2
         param_name = "param_bool"
 
-        param = SlitGapParameter(param_name, self.jaws, autosave=True)
+        param = DirectParameter(param_name, self.jaws, autosave=True)
 
         self.assertEqual(expected, param.sp)
         self.assertEqual(expected, param.sp_rbv)

--- a/ReflectometryServer/test_modules/test_set_current_motor_position.py
+++ b/ReflectometryServer/test_modules/test_set_current_motor_position.py
@@ -93,14 +93,14 @@ class TestCurrentMotorPositionParametersToEven_inDriver(unittest.TestCase):
 
         assert_that(parameter.define_current_value_as, is_(None))
 
-    def test_GIVEN_beamline_parameter_and_SlitGapParameter_component_WHEN_set_position_to_THEN_component_has_set_position_on(self):
+    def test_GIVEN_beamline_parameter_and_DirectParameter_component_WHEN_set_position_to_THEN_component_has_set_position_on(self):
 
         def _listener(set_position_to):
             self.set_position_to = set_position_to
 
         expected_position = 1
         mock_jaws_wrapper = create_mock_JawsCentrePVWrapper("jaws_centre", expected_position, 1)
-        parameter = SlitGapParameter("param", mock_jaws_wrapper, sim=True)
+        parameter = DirectParameter("param", mock_jaws_wrapper, sim=True)
 
         parameter.define_current_value_as.new_value = expected_position
 
@@ -144,13 +144,13 @@ class TestCurrentMotorPositionParametersToEven_inDriver(unittest.TestCase):
         assert_that(parameter.sp, is_(expected_position), "Parameter setpoint")
         assert_that(parameter.sp_rbv, is_(expected_position), "Parameter setpoint read back")
 
-    def test_GIVEN_beamline_parameter_and_SlitGapParameter_component_WHEN_set_position_to_THEN_setpoint_is_set_to_new_position(self):
+    def test_GIVEN_beamline_parameter_and_DirectParameter_component_WHEN_set_position_to_THEN_setpoint_is_set_to_new_position(self):
 
         expected_position = 1
         expected_mock_jaws_wrapper_value = 10
         mock_jaws_wrapper = create_mock_JawsCentrePVWrapper("jaws_centre", expected_mock_jaws_wrapper_value, 1)
 
-        parameter = SlitGapParameter("param", mock_jaws_wrapper, sim=True)
+        parameter = DirectParameter("param", mock_jaws_wrapper, sim=True)
         parameter.sp = expected_mock_jaws_wrapper_value
 
         parameter.define_current_value_as.new_value = expected_position


### PR DESCRIPTION
### Description of work

- Generalised class for parameters that do not require the component layer for beam tracking, but talk directly to motor PVs.
- Fixed a bug where Angle Parameters RBVs on a `TiltingComponent` would not update properly . They should listen for `PhysicalMoveUpdate` rather than `BeamPathUpdate` - just happened to work on most angles as they also triggered a `BeamPathUpdate`)

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4967

### Acceptance criteria

- SlitGapParameters behaviour is unchanged
- DirectParameters work for any PV Wrapper
- Create a `TiltingComponent` with an `AngleParameter` not linked to anything else (e.g. Theta) - parameter RBV should stay in sync with motor RBV when moved

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
