### PR TITLE
Address arguments correctly and remove prints.

### DIFF
--- a/ReflectometryServer/config_helper.py
+++ b/ReflectometryServer/config_helper.py
@@ -258,7 +258,6 @@ def add_slit_parameters(slit_number, rbv_to_sp_tolerance=DEFAULT_RBV_TO_SP_TOLER
         is_gap_not_centre = name[1] == "G"
 
         vg_param_name = "S{}{}".format(slit_number, name)
-        print("Calling create_jaws_pv_driver with '{}', '{}' and '{}'".format(jaws_pv_prefix, is_vertical, is_gap_not_centre))
         driver = create_jaws_pv_driver(jaws_pv_prefix, is_vertical, is_gap_not_centre)
         parameter = SlitGapParameter(vg_param_name, driver, rbv_to_sp_tolerance=rbv_to_sp_tolerance)
         add_parameter(parameter, modes, mode_inits)

--- a/ReflectometryServer/test_modules/test_config_helper.py
+++ b/ReflectometryServer/test_modules/test_config_helper.py
@@ -187,7 +187,6 @@ class TestConfigHelper(unittest.TestCase):
 
             assert_that([parameter.name for parameter in result], contains_inanyorder("S1VG", "S1HG"))
 
-            print("Slit gap kwargslist {}", jaws_wrapper_mock.call_args_list)
             assert_that([call[0][0] for call in jaws_wrapper_mock.call_args_list], only_contains("MOT:JAWS1"))
             assert_that([call[0][1] for call in jaws_wrapper_mock.call_args_list], contains(True, False))
             assert_that([call[0][2] for call in jaws_wrapper_mock.call_args_list], contains(True, True))
@@ -202,10 +201,9 @@ class TestConfigHelper(unittest.TestCase):
 
             assert_that([parameter.name for parameter in result], contains_inanyorder("S1VG", "S1VC", "S1HG", "S1HC"))
 
-            print("Slit gap kwargslist {}", jaws_wrapper_mock.call_args_list)
-            assert_that([call.args[0] for call in jaws_wrapper_mock.call_args_list], only_contains("MOT:JAWS1"))
-            assert_that([call.args[1] for call in jaws_wrapper_mock.call_args_list], contains(True, True, False, False))
-            assert_that([call.args[2] for call in jaws_wrapper_mock.call_args_list], contains(True, False, True, False))
+            assert_that([call[0][0] for call in jaws_wrapper_mock.call_args_list], only_contains("MOT:JAWS1"))
+            assert_that([call[0][1] for call in jaws_wrapper_mock.call_args_list], contains(True, True, False, False))
+            assert_that([call[0][2] for call in jaws_wrapper_mock.call_args_list], contains(True, False, True, False))
 
 
     def test_GVIEN_add_slits_and_gaps_into_modes_WHEN_get_parameters_in_config_THEN_parameters_for_all_slit_gaps_exist(self):


### PR DESCRIPTION
Fix test don't use Call.args use Call[0]
