### PR TITLE
Fix rh build

### DIFF
--- a/ReflectometryServer/__init__.py
+++ b/ReflectometryServer/__init__.py
@@ -1,20 +1,24 @@
 """
 Classes used by configuration for easy import
 """
+import six
 
-from ReflectometryServer.beamline import Beamline, BeamlineMode
-from ReflectometryServer.beamline_constant import BeamlineConstant
-from ReflectometryServer.components import Component, ReflectingComponent, ThetaComponent, TiltingComponent
-from ReflectometryServer.engineering_corrections import ConstantCorrection, UserFunctionCorrection, \
-    InterpolateGridDataCorrection, SymmetricEngineeringCorrection, NoCorrection, EngineeringCorrection, \
-    GridDataFileReader, InterpolateGridDataCorrectionFromProvider, COLUMN_NAME_FOR_DRIVER_SETPOINT
-from ReflectometryServer.footprint_manager import FootprintSetup, BaseFootprintSetup
-from ReflectometryServer.geometry import PositionAndAngle, Position
-from ReflectometryServer.ioc_driver import AngleDriver, DisplacementDriver
-from ReflectometryServer.out_of_beam import OutOfBeamPosition
-from ReflectometryServer.parameters import InBeamParameter, AngleParameter, TrackingPosition, DirectParameter, \
-    SlitGapParameter
-from ReflectometryServer.pv_wrapper import MotorPVWrapper, JawsCentrePVWrapper, JawsGapPVWrapper, PVWrapper
-from ReflectometryServer.config_helper import ConfigHelper, get_configured_beamline, add_constant, add_component, \
-    add_parameter, add_mode, add_driver, add_slit_parameters, add_beam_start, add_footprint_setup, \
-    add_component_marker, add_driver_marker, add_parameter_marker
+if six.PY2:
+    print("Reflectometry IOC can not be run in python 2!!")
+else:
+    from ReflectometryServer.beamline import Beamline, BeamlineMode
+    from ReflectometryServer.beamline_constant import BeamlineConstant
+    from ReflectometryServer.components import Component, ReflectingComponent, ThetaComponent, TiltingComponent
+    from ReflectometryServer.engineering_corrections import ConstantCorrection, UserFunctionCorrection, \
+        InterpolateGridDataCorrection, SymmetricEngineeringCorrection, NoCorrection, EngineeringCorrection, \
+        GridDataFileReader, InterpolateGridDataCorrectionFromProvider, COLUMN_NAME_FOR_DRIVER_SETPOINT
+    from ReflectometryServer.footprint_manager import FootprintSetup, BaseFootprintSetup
+    from ReflectometryServer.geometry import PositionAndAngle, Position
+    from ReflectometryServer.ioc_driver import AngleDriver, DisplacementDriver
+    from ReflectometryServer.out_of_beam import OutOfBeamPosition
+    from ReflectometryServer.parameters import InBeamParameter, AngleParameter, TrackingPosition, DirectParameter, \
+        SlitGapParameter
+    from ReflectometryServer.pv_wrapper import MotorPVWrapper, JawsCentrePVWrapper, JawsGapPVWrapper, PVWrapper
+    from ReflectometryServer.config_helper import ConfigHelper, get_configured_beamline, add_constant, add_component, \
+        add_parameter, add_mode, add_driver, add_slit_parameters, add_beam_start, add_footprint_setup, \
+        add_component_marker, add_driver_marker, add_parameter_marker

--- a/ReflectometryServer/movement_strategy.py
+++ b/ReflectometryServer/movement_strategy.py
@@ -3,7 +3,6 @@ Classes and objects describing the movement of items
 """
 from __future__ import division
 
-from builtins import object
 from math import fabs, tan, radians, sqrt
 
 from ReflectometryServer.geometry import PositionAndAngle, Position, position_from_radial_coords


### PR DESCRIPTION
### Description of work

Allow python2 to pass inst_servers by not importing reflectometry in python 2

### To test

Fix tests

### Acceptance criteria

- tests pass on red hat linux

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
