### PR TITLE
Add initial fix for SOI issue

### DIFF
--- a/BlockServer/epics/gateway.py
+++ b/BlockServer/epics/gateway.py
@@ -33,7 +33,8 @@ EVALUATION ORDER ALLOW, DENY
 
 # Alias e.g. INST:CS:SB:MyMotor:RC:INRANGE to INST:CS:MYMOTOR:RC:INRANGE
 # Also handle AC (alerts) and DC (device actions, such as LOQ fast shutter)
-RUNCONTROL_ALIAS = '{}\\(:[ADR]C:.*\\)    ALIAS    {}\\1'
+MATCH_RUNCONTROL_SUFFIX = "\\(:[ADR]C:.*\\)"
+RUNCONTROL_ALIAS = '{}{}    ALIAS    {}\\1'.format("{}", MATCH_RUNCONTROL_SUFFIX, "{}")
 
 
 def build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv, include_comments=True):
@@ -65,8 +66,6 @@ def build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv, include_com
         # Pattern match is for picking up any any SP or SP:RBV
         lines.append('{}\\([.:].*\\)    ALIAS    {}\\1'.format(full_block_pv, underlying_pv))
     lines.append('{}    ALIAS    {}'.format(full_block_pv, underlying_pv))
-    lines.append("## Runcontrol settings should not be diverted to underlying PV")
-    lines.append(RUNCONTROL_ALIAS.format(full_block_pv, full_block_pv.upper()))
     return lines
 
 
@@ -139,11 +138,14 @@ class Gateway(object):
         full_block_pv = "{}{}".format(self._block_prefix, block_name)
 
         lines = build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv)
+        lines.append("## Runcontrol settings should not be diverted to underlying PV")
+        lines.append("{}{}    DENY".format(full_block_pv.upper(), MATCH_RUNCONTROL_SUFFIX))
 
         # Create a case insensitive alias so clients don't have to worry about getting case right
         if full_block_pv != full_block_pv.upper():
             lines.append("## Add full caps equivilant so clients need not be case sensitive")
             lines.extend(build_block_alias_lines(full_block_pv.upper(), pv_suffix, underlying_pv, False))
+            lines.append(RUNCONTROL_ALIAS.format(full_block_pv, full_block_pv.upper()))
 
         lines.append("")  # New line to seperate out each block
         return lines

--- a/BlockServer/epics/gateway.py
+++ b/BlockServer/epics/gateway.py
@@ -33,7 +33,7 @@ EVALUATION ORDER ALLOW, DENY
 
 # Alias e.g. INST:CS:SB:MyMotor:RC:INRANGE to INST:CS:MYMOTOR:RC:INRANGE
 # Also handle AC (alerts) and DC (device actions, such as LOQ fast shutter)
-RUNCONTROL_ALIAS = '{}\\(:[ADR]C:.*\\)    ALIAS    {}{}\\1'
+RUNCONTROL_ALIAS = '{}\\(:[ADR]C:.*\\)    ALIAS    {}\\1'
 
 
 def build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv, include_comments=True):
@@ -65,6 +65,8 @@ def build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv, include_com
         # Pattern match is for picking up any any SP or SP:RBV
         lines.append('{}\\([.:].*\\)    ALIAS    {}\\1'.format(full_block_pv, underlying_pv))
     lines.append('{}    ALIAS    {}'.format(full_block_pv, underlying_pv))
+    lines.append("## Runcontrol settings should not be diverted to underlying PV")
+    lines.append(RUNCONTROL_ALIAS.format(full_block_pv, full_block_pv.upper()))
     return lines
 
 
@@ -137,17 +139,11 @@ class Gateway(object):
         full_block_pv = "{}{}".format(self._block_prefix, block_name)
 
         lines = build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv)
-        lines.append(RUNCONTROL_ALIAS.format(full_block_pv, self._control_sys_prefix, block_name.upper()))
-        lines.append('{}{}\\([.].*\\)    ALIAS    {}\\1'.format(self._control_sys_prefix, block_name.upper(), full_block_pv))
-        lines.append('{}{}    ALIAS    {}'.format(self._control_sys_prefix, block_name.upper(), full_block_pv))
 
         # Create a case insensitive alias so clients don't have to worry about getting case right
         if full_block_pv != full_block_pv.upper():
             lines.append("## Add full caps equivilant so clients need not be case sensitive")
             lines.extend(build_block_alias_lines(full_block_pv.upper(), pv_suffix, underlying_pv, False))
-            lines.append(RUNCONTROL_ALIAS.format(full_block_pv.upper(), self._control_sys_prefix, block_name.upper()))
-            lines.append('{}{}\\([.].*\\)    ALIAS    {}\\1'.format(self._control_sys_prefix, block_name.upper(), full_block_pv))
-            lines.append('{}{}    ALIAS    {}'.format(self._control_sys_prefix, block_name.upper(), full_block_pv))
 
         lines.append("")  # New line to seperate out each block
         return lines

--- a/BlockServer/epics/gateway.py
+++ b/BlockServer/epics/gateway.py
@@ -31,8 +31,9 @@ EVALUATION ORDER ALLOW, DENY
 
 """
 
-# Alias e.g. INST:CS:SB:MyMotor:RC:INRANGE to INST:CS:MYMOTOR:RC:ENABLE
-RUNCONTROL_ALIAS = '{}\\(:RC.*\\)    ALIAS    {}{}\\1'
+# Alias e.g. INST:CS:SB:MyMotor:RC:INRANGE to INST:CS:MYMOTOR:RC:INRANGE
+# Also handle AC (alerts) and DC (device actions, such as LOQ fast shutter)
+RUNCONTROL_ALIAS = '{}\\(:[ADR]C:.*\\)    ALIAS    {}{}\\1'
 
 
 def build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv, include_comments=True):
@@ -137,12 +138,16 @@ class Gateway(object):
 
         lines = build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv)
         lines.append(RUNCONTROL_ALIAS.format(full_block_pv, self._control_sys_prefix, block_name.upper()))
+        lines.append('{}{}\\([.].*\\)    ALIAS    {}\\1'.format(self._control_sys_prefix, block_name.upper(), full_block_pv))
+        lines.append('{}{}    ALIAS    {}'.format(self._control_sys_prefix, block_name.upper(), full_block_pv))
 
         # Create a case insensitive alias so clients don't have to worry about getting case right
         if full_block_pv != full_block_pv.upper():
             lines.append("## Add full caps equivilant so clients need not be case sensitive")
             lines.extend(build_block_alias_lines(full_block_pv.upper(), pv_suffix, underlying_pv, False))
             lines.append(RUNCONTROL_ALIAS.format(full_block_pv.upper(), self._control_sys_prefix, block_name.upper()))
+            lines.append('{}{}\\([.].*\\)    ALIAS    {}\\1'.format(self._control_sys_prefix, block_name.upper(), full_block_pv))
+            lines.append('{}{}    ALIAS    {}'.format(self._control_sys_prefix, block_name.upper(), full_block_pv))
 
         lines.append("")  # New line to seperate out each block
         return lines

--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -51,7 +51,7 @@ MAX_LOOPS_TO_WAIT_FOR_START = 60  # roughly 2 minutes at standard time
 def create_db_load_string(block):
     load_record_string = 'dbLoadRecords("$(RUNCONTROL)/db/{file}.db", "{macros}")\n'
     return load_record_string.format(file="runcontrol",
-                                     macros="P=$(MYPVPREFIX),PV=$(MYPVPREFIX)CS:{}".format(block.name.upper()))
+                                     macros="P=$(MYPVPREFIX),PV=$(MYPVPREFIX)CS:SB:{}".format(block.name.upper()))
 
 
 class _RunControlAutoSaveHelper(object):

--- a/BlockServer/test_modules/test_epics_gateway.py
+++ b/BlockServer/test_modules/test_epics_gateway.py
@@ -57,7 +57,7 @@ class TestEpicsGateway(unittest.TestCase):
         alias = "INST:BLOCK:MY_BLOCK"
         expected_lines = [[r"{}\([.:].*\)".format(alias), "ALIAS", "INST:MY_PV\\1"],
                           [alias, "ALIAS", "INST:MY_PV"],
-                          [r"{}\(:RC.*\)".format(alias), "ALIAS", "INST:CONTROL:{}\\1".format(blockname)]]
+                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, True)
 
@@ -68,7 +68,7 @@ class TestEpicsGateway(unittest.TestCase):
         alias = "INST:BLOCK:MY_BLOCK"
         expected_lines = [[r"{}\([.:].*\)".format(alias), "ALIAS", "MY_PV\\1"],
                           [alias, "ALIAS", "MY_PV"],
-                          [r"{}\(:RC.*\)".format(alias), "ALIAS", "INST:CONTROL:{}\\1".format(blockname)]]
+                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, False)
 
@@ -80,7 +80,7 @@ class TestEpicsGateway(unittest.TestCase):
         expected_lines = [[r"{}\([.:].*\)".format(alias), "ALIAS", "INST:MY_PV\\1"],
                           ["{}[.]VAL".format(alias), "ALIAS", "INST:MY_PV.EGU"],
                           [alias, "ALIAS", "INST:MY_PV.EGU"],
-                          [r"{}\(:RC.*\)".format(alias), "ALIAS", "INST:CONTROL:{}\\1".format(blockname)]]
+                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, True)
 
@@ -92,7 +92,7 @@ class TestEpicsGateway(unittest.TestCase):
         expected_lines = [[r"{}\([.:].*\)".format(alias), "ALIAS", "MY_PV\\1"],
                           ["{}[.]VAL".format(alias), "ALIAS", "MY_PV.RBV"],
                           [alias, "ALIAS", "MY_PV.RBV"],
-                          [r"{}\(:RC.*\)".format(alias), "ALIAS", "INST:CONTROL:{}\\1".format(blockname)]]
+                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, False)
 
@@ -103,7 +103,7 @@ class TestEpicsGateway(unittest.TestCase):
         alias = "INST:BLOCK:MY_BLOCK"
         expected_lines = [[r"{}\(:SP\)?\([.:].*\)".format(alias), "ALIAS", "INST:MY_PV:SP\\2"],
                           [r"{}\(:SP\)?".format(alias), "ALIAS", "INST:MY_PV:SP"],
-                          [r"{}\(:RC.*\)".format(alias), "ALIAS", "INST:CONTROL:{}\\1".format(blockname.upper())]]
+                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, True)
 
@@ -114,7 +114,7 @@ class TestEpicsGateway(unittest.TestCase):
         alias = "INST:BLOCK:MY_BLOCK"
         expected_lines = [[r"{}\(:SP\)?\([.:].*\)".format(alias), "ALIAS", "MY_PV:SP\\2"],
                           [r"{}\(:SP\)?".format(alias), "ALIAS", "MY_PV:SP"],
-                          [r"{}\(:RC.*\)".format(alias), "ALIAS", "INST:CONTROL:{}\\1".format(blockname.upper())]]
+                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, False)
 
@@ -125,7 +125,7 @@ class TestEpicsGateway(unittest.TestCase):
         alias = "INST:BLOCK:MY_BLOCK"
         expected_lines = [[r"{}\([.:].*\)".format(alias), "ALIAS", "MY_TEST\\1"],
                           ["{}".format(alias), "ALIAS", "MY_TEST"],
-                          [r"{}\(:RC.*\)".format(alias), "ALIAS", "INST:CONTROL:{}\\1".format(blockname)]]
+                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, False)
 
@@ -136,11 +136,12 @@ class TestEpicsGateway(unittest.TestCase):
         alias = "INST:BLOCK:My_Block"
         expected_lines = [[r"{}\([.:].*\)".format(alias), "ALIAS", "MY_PV\\1"],
                           [alias, "ALIAS", "MY_PV"],
-                          [r"{}\(:RC.*\)".format(alias), "ALIAS", "INST:CONTROL:{}\\1".format(blockname.upper())],
+                          [r"{}\(:[ADR]C:.*\)".format(alias.upper()), "DENY"],
                           [r"{}\([.:].*\)".format(alias.upper()), "ALIAS", "MY_PV\\1"],
                           [alias.upper(), "ALIAS", "MY_PV"],
-                          [r"{}\(:RC.*\)".format(alias.upper()), "ALIAS", "INST:CONTROL:{}\\1".format(blockname.upper())]]
+                          [r"{}\(:[ADR]C:.*\)".format(alias), "ALIAS", "INST:BLOCK:{}\\1".format(blockname.upper())]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, False)
 
         self._assert_lines_correct(lines, expected_lines)
+


### PR DESCRIPTION
Fixes two issues:
- aliases were not being created for AC and DC, just for RC, so alerts and detector overcount would not work
- the reading of SOI in runcontrol was now pointing at a non exisiting PV and it then disabled run control. I have fixed this, but i am not completely happy with the fix as it is starting to look a bit circular in aliases. I am not sure if I need original or upper cse only in this alias 

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
