### PR TITLE
Return empty dict if not defined rather than error

### DIFF
--- a/server_common/helpers.py
+++ b/server_common/helpers.py
@@ -34,6 +34,6 @@ def get_macro_values():
 
     Returns: Macro Key:Value pairs as dict
     """
-    macros = json.loads(os.environ.get("REFL_MACROS", ""))
+    macros = json.loads(os.environ.get("REFL_MACROS", "{}"))
     macros = {key: value for (key, value) in macros.items()}
     return macros


### PR DESCRIPTION
### Description of work

get_macro_values was erroring because the default value was an empty string which cannot be parsed as json, so just give an empty dictionary. The values are accessed as a dictionary normally.

### To test

*Which ticket does this PR fix?*

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
