### PR TITLE
Push through macros to pcaspy iocs

### DIFF
--- a/server_common/helpers.py
+++ b/server_common/helpers.py
@@ -1,7 +1,6 @@
 import json
 import os
 import sys
-import xml.etree.ElementTree as ET
 
 from server_common.ioc_data_source import IocDataSource
 from server_common.mysql_abstraction_layer import SQLAbstraction

--- a/server_common/helpers.py
+++ b/server_common/helpers.py
@@ -42,9 +42,9 @@ def get_macro_values():
     test_recsim = os.environ.get("TESTRECSIM", "no").lower() == "yes"
     if test_devsim or test_recsim:
         # Set macros as is done in EPICS/iocstartup/ioctesting.cmd
-        macros["DEVSIM"] = 1 if test_devsim else 0
-        macros["RECSIM"] = 1 if test_recsim else 0
-        macros["SIMULATE"] = 1
+        macros["DEVSIM"] = "1" if test_devsim else "0"
+        macros["RECSIM"] = "1" if test_recsim else "0"
+        macros["SIMULATE"] = "1"
         macros["SIMSFX"] = "_RECSIM" if test_recsim else "_DEVSIM"
         # Load macros from test_config.txt
         test_macros_filepath = os.path.join(os.getenv("ICPVARDIR", r"C:\Instrument\Var"), "tmp", "test_config.txt")

--- a/server_common/helpers.py
+++ b/server_common/helpers.py
@@ -36,23 +36,5 @@ def get_macro_values():
     """
     macros = json.loads(os.environ.get("MACROS", "{}"))
     macros = {key: value for (key, value) in macros.items()}
-    # Get macros set by IocTestFramework
-    test_devsim = os.environ.get("TESTDEVSIM", "no").lower() == "yes"
-    test_recsim = os.environ.get("TESTRECSIM", "no").lower() == "yes"
-    if test_devsim or test_recsim:
-        # Set macros as is done in EPICS/iocstartup/ioctesting.cmd
-        macros["DEVSIM"] = "1" if test_devsim else "0"
-        macros["RECSIM"] = "1" if test_recsim else "0"
-        macros["SIMULATE"] = "1"
-        macros["SIMSFX"] = "_RECSIM" if test_recsim else "_DEVSIM"
-        # Load macros from test_config.txt
-        test_macros_filepath = os.path.join(os.getenv("ICPVARDIR", r"C:\Instrument\Var"), "tmp", "test_config.txt")
-        if os.path.exists(test_macros_filepath):
-            with open(test_macros_filepath, mode="r") as test_macros_file:
-                for line in test_macros_file.readlines():
-                    split_line = line.split('"')
-                    macro_name = split_line[1]
-                    macro_value = split_line[3]
-                    macros[macro_name] = macro_value
     print("Defined macros: " + str(macros))
     return macros

--- a/server_common/helpers.py
+++ b/server_common/helpers.py
@@ -34,7 +34,7 @@ def get_macro_values():
 
     Returns: Macro Key:Value pairs as dict
     """
-    macros = json.loads(os.environ.get("REFL_MACROS", "{}"))
+    macros = json.loads(os.environ.get("MACROS", "{}"))
     macros = {key: value for (key, value) in macros.items()}
     # Get macros set by IocTestFramework
     test_devsim = os.environ.get("TESTDEVSIM", "no").lower() == "yes"


### PR DESCRIPTION
### Description of work

EPICS/iocstartup/ioctesting.cmd is not run with pcaspy IOCs. Define the same macros for them here.

### To test
https://github.com/ISISComputingGroup/IBEX/issues/5633

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
