### PR TITLE
change_users() not setting users correctly

### DIFF
--- a/DatabaseServer/exp_data.py
+++ b/DatabaseServer/exp_data.py
@@ -225,24 +225,16 @@ class ExpData(object):
         names = []
         surnames = []
         orgs = []
-        if len(users) > 3:
-            # Format the string into a list of JSON strings for decoding/encoding
-            users = users[1:-1]
-            users = users.split("},{")
-            if len(users) > 1:
-                # Strip the {} from the beginning and the end to allow for easier editing of the teammembers
-                users[0] = users[0][1:]
-                users[-1] = users[-1][:len(users[-1])-1]
-                # Add a {} to EACH teammember
-                for ndx, member in enumerate(users):
-                    users[ndx] = "{" + member + "}"
-
-            # Loop through the list of strings to generate the lists/similar for conversion to JSON
-            for teammember in users:
-                member = json.loads(teammember)
-                fullname = six.text_type(member['name'])
-                org = six.text_type(member['institute'])
-                role = six.text_type(member['role'])
+        users = json.loads(users)
+        # Find user details in deserialized json user data
+        for team_member in users:
+            fullname = team_member['name']
+            # If user only wants to change users not the whole table
+            if team_member.get("institute") is None:
+                surnames.append(self._get_surname_from_fullname(fullname))
+            else:
+                org = team_member['institute']
+                role = team_member['role']
                 if not role == "Contact":
                     surnames.append(self._get_surname_from_fullname(fullname))
                 orgs.append(org)

--- a/DatabaseServer/exp_data.py
+++ b/DatabaseServer/exp_data.py
@@ -250,7 +250,9 @@ class ExpData(object):
                 names.append(name.__dict__)
             orgs = list(set(orgs))
         self.ca.caput(self._simnames, self.encode_for_return(names))
-        self.ca.caput(self._surnamepv, self.encode_for_return(surnames))
+        # surname PV is set twice with g.change_users() once from genie python and from database server(here) wait=True
+        # makes sure that surname is updated in order. Database server to set it first followed by genie python
+        self.ca.caput(self._surnamepv, self.encode_for_return(surnames), wait=True)
         self.ca.caput(self._orgspv, self.encode_for_return(orgs))
         # The value put to the dae names pv will need changing in time to use compressed and hexed json etc. but
         # this is not available at this time in the ICP

--- a/DatabaseServer/exp_data.py
+++ b/DatabaseServer/exp_data.py
@@ -225,7 +225,9 @@ class ExpData(object):
         names = []
         surnames = []
         orgs = []
-        users = json.loads(users)
+
+        users = json.loads(users) if users else []
+
         # Find user details in deserialized json user data
         for team_member in users:
             fullname = team_member['name']
@@ -242,9 +244,7 @@ class ExpData(object):
                 names.append(name.__dict__)
             orgs = list(set(orgs))
         self.ca.caput(self._simnames, self.encode_for_return(names))
-        # surname PV is set twice with g.change_users() once from genie python and from database server(here) wait=True
-        # makes sure that surname is updated in order. Database server to set it first followed by genie python
-        self.ca.caput(self._surnamepv, self.encode_for_return(surnames), wait=True)
+        self.ca.caput(self._surnamepv, self.encode_for_return(surnames))
         self.ca.caput(self._orgspv, self.encode_for_return(orgs))
         # The value put to the dae names pv will need changing in time to use compressed and hexed json etc. but
         # this is not available at this time in the ICP

--- a/DatabaseServer/test_modules/test_exp_data.py
+++ b/DatabaseServer/test_modules/test_exp_data.py
@@ -107,10 +107,12 @@ class TestExpData(unittest.TestCase):
         simnames = self.decode_pv(self.exp_data._simnames)
         surnames = self.decode_pv(self.exp_data._surnamepv)
         orgs = self.decode_pv(self.exp_data._orgspv)
+        dae_surnames = self.ca.caget(self.exp_data._daenamespv)
 
         self.assertEqual(simnames[0]["name"], "Tom Jones")
         self.assertTrue("Jones" in surnames)
         self.assertTrue("STFC" in orgs)
+        self.assertEqual(dae_surnames, b"Jones")
 
     def test_update_username_for_multiple_users_same_institute(self):
         # Arrange
@@ -126,10 +128,12 @@ class TestExpData(unittest.TestCase):
         simnames = self.decode_pv(self.exp_data._simnames)
         surnames = self.decode_pv(self.exp_data._surnamepv)
         orgs = self.decode_pv(self.exp_data._orgspv)
+        dae_surnames = self.ca.caget(self.exp_data._daenamespv)
 
         self.assertEqual(len(simnames), 2)
         self.assertEqual(len(surnames), 2)
         self.assertEqual(len(orgs), 1)
+        self.assertEqual(dae_surnames, b"Jones,James")
 
     def test_update_username_for_blank_users(self):
         # Arrange
@@ -143,10 +147,76 @@ class TestExpData(unittest.TestCase):
         simnames = self.decode_pv(self.exp_data._simnames)
         surnames = self.decode_pv(self.exp_data._surnamepv)
         orgs = self.decode_pv(self.exp_data._orgspv)
+        dae_surnames = self.ca.caget(self.exp_data._daenamespv)
 
         self.assertEqual(len(simnames), 0)
         self.assertEqual(len(surnames), 0)
         self.assertEqual(len(orgs), 0)
+        self.assertEqual(dae_surnames, " ")
+
+    def test_update_username_for_single_user_no_further_data(self):
+        # Arrange
+        users = '[{"name":"Tom Jones"}]'
+
+        # Act
+        self.exp_data.update_username(users)
+
+        # Assert
+        simnames = self.decode_pv(self.exp_data._simnames)
+        surnames = self.decode_pv(self.exp_data._surnamepv)
+        orgs = self.decode_pv(self.exp_data._orgspv)
+        dae_surnames = self.ca.caget(self.exp_data._daenamespv)
+
+        self.assertEqual(len(simnames), 0)
+        self.assertTrue("Jones" in surnames)
+        self.assertEqual(len(orgs), 0)
+        self.assertEqual(dae_surnames, b"Jones")
+
+    def test_update_username_for_multiple_users_no_further_data(self):
+        # Arrange
+        users = '['
+        users += '{"name":"Tom Jones"},'
+        users += '{"name":"David James"}'
+        users += ']'
+
+        # Act
+        self.exp_data.update_username(users)
+
+        # Assert
+        simnames = self.decode_pv(self.exp_data._simnames)
+        surnames = self.decode_pv(self.exp_data._surnamepv)
+        orgs = self.decode_pv(self.exp_data._orgspv)
+        dae_surnames = self.ca.caget(self.exp_data._daenamespv)
+
+        self.assertEqual(len(simnames), 0)
+        self.assertEqual(len(surnames), 2)
+        self.assertTrue("Jones" in surnames)
+        self.assertTrue("James" in surnames)
+        self.assertEqual(len(orgs), 0)
+        self.assertEqual(dae_surnames, b"Jones,James")
+
+    def test_update_username_for_multiple_users_no_firstname_and_no_further_data_then_assumed_surname(self):
+        # Arrange
+        users = '['
+        users += '{"name":"Jones"},'
+        users += '{"name":"James"}'
+        users += ']'
+
+        # Act
+        self.exp_data.update_username(users)
+
+        # Assert
+        simnames = self.decode_pv(self.exp_data._simnames)
+        surnames = self.decode_pv(self.exp_data._surnamepv)
+        orgs = self.decode_pv(self.exp_data._orgspv)
+        dae_surnames = self.ca.caget(self.exp_data._daenamespv)
+
+        self.assertEqual(len(simnames), 0)
+        self.assertEqual(len(surnames), 2)
+        self.assertTrue("Jones" in surnames)
+        self.assertTrue("James" in surnames)
+        self.assertEqual(len(orgs), 0)
+        self.assertEqual(dae_surnames, b"Jones,James")
 
     def test_remove_accents_from_name(self):
         # Arrange


### PR DESCRIPTION
### Description of work

Fix g.change_users() not setting users correctly from IBEX

### To test

https://github.com/ISISComputingGroup/IBEX/issues/5863

### Acceptance criteria

`g.change_users()` changes user correctly from GUI

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
