### PR TITLE
Only search for valid block syntax

### DIFF
--- a/BlockServer/epics/gateway.py
+++ b/BlockServer/epics/gateway.py
@@ -24,23 +24,18 @@ ALIAS_HEADER = """\
 ##
 EVALUATION ORDER ALLOW, DENY
 
+"""
+
+ALIAS_FOOTER = r"""\
 ## serve blockserver internal variables, including Flag variables needed by blockserver process to restart gateway
 {0}CS:GATEWAY:BLOCKSERVER:.*    				    ALLOW	ANYBODY	    1
 ## allow anybody to generate gateway reports
 {0}CS:GATEWAY:BLOCKSERVER:report[1-9]Flag		ALLOW	ANYBODY		1
-
+## ignore any request related to run control/alerts etc. (RC,AC,DC) on blocks, these are handled by RUNCTRL ioc
+{0}CS:SB:[^:]*:[ADR]C:.*                     DENY
+## ignore any request not related to local blocks or gateway itself
+!{0}CS:\(SB\|GATEWAY\):.*                    DENY
 """
-
-ALIAS_FOOTER = """\
-## ignore any request not related to local blocks
-!{0}CS:SB:.*       DENY
-"""
-
-# Alias e.g. INST:CS:SB:MyMotor:RC:INRANGE to INST:CS:MYMOTOR:RC:INRANGE
-# Also handle AC (alerts) and DC (device actions, such as LOQ fast shutter)
-MATCH_RUNCONTROL_SUFFIX = "\\(:[ADR]C:.*\\)"
-RUNCONTROL_ALIAS = '{}{}    ALIAS    {}\\1'.format("{}", MATCH_RUNCONTROL_SUFFIX, "{}")
-
 
 def build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv, include_comments=True):
     lines = list()
@@ -144,14 +139,11 @@ class Gateway(object):
         full_block_pv = "{}{}".format(self._block_prefix, block_name)
 
         lines = build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv)
-        lines.append("## Runcontrol settings should not be diverted to underlying PV")
-        lines.append("{}{}    DENY".format(full_block_pv.upper(), MATCH_RUNCONTROL_SUFFIX))
 
         # Create a case insensitive alias so clients don't have to worry about getting case right
         if full_block_pv != full_block_pv.upper():
             lines.append("## Add full caps equivilant so clients need not be case sensitive")
             lines.extend(build_block_alias_lines(full_block_pv.upper(), pv_suffix, underlying_pv, False))
-            lines.append(RUNCONTROL_ALIAS.format(full_block_pv, full_block_pv.upper()))
 
         lines.append("")  # New line to seperate out each block
         return lines

--- a/BlockServer/epics/gateway.py
+++ b/BlockServer/epics/gateway.py
@@ -26,7 +26,7 @@ EVALUATION ORDER ALLOW, DENY
 
 """
 
-ALIAS_FOOTER = r"""\
+ALIAS_FOOTER = r"""
 ## serve blockserver internal variables, including Flag variables needed by blockserver process to restart gateway
 {0}CS:GATEWAY:BLOCKSERVER:.*    				    ALLOW	ANYBODY	    1
 ## allow anybody to generate gateway reports

--- a/BlockServer/epics/gateway.py
+++ b/BlockServer/epics/gateway.py
@@ -31,6 +31,11 @@ EVALUATION ORDER ALLOW, DENY
 
 """
 
+ALIAS_FOOTER = """\
+## ignore any request not related to local blocks
+!{0}CS:SB:.*       DENY
+"""
+
 # Alias e.g. INST:CS:SB:MyMotor:RC:INRANGE to INST:CS:MYMOTOR:RC:INRANGE
 # Also handle AC (alerts) and DC (device actions, such as LOQ fast shutter)
 MATCH_RUNCONTROL_SUFFIX = "\\(:[ADR]C:.*\\)"
@@ -118,6 +123,7 @@ class Gateway(object):
                 for name, value in blocks.iteritems():
                     lines = self.generate_alias(value.name, value.pv, value.local)
                     f.write('\n'.join(lines) + '\n')
+            f.write(ALIAS_FOOTER.format(self._inst_prefix))
             # Add a blank line at the end!
             f.write("\n")
 

--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -47,9 +47,9 @@ RUNCONTROL_GET_PV = prepend_blockserver('GET_RC_PARS')
 # number of loops to wait for assuming the run control is not going to start
 MAX_LOOPS_TO_WAIT_FOR_START = 60  # roughly 2 minutes at standard time
 
-
 def create_db_load_string(block):
     load_record_string = 'dbLoadRecords("$(RUNCONTROL)/db/{file}.db", "{macros}")\n'
+    # PVA is PV Alias, NA is NoAlias
     macro_string="P=$(MYPVPREFIX),PV=$(MYPVPREFIX)CS:SB:{pv},PVA=$(MYPVPREFIX)CS:SB:{pva},NOALIAS={na}"
     if (block.name == block.name.upper()):
         return load_record_string.format(file="runcontrol",

--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -51,12 +51,12 @@ MAX_LOOPS_TO_WAIT_FOR_START = 60  # roughly 2 minutes at standard time
 def create_db_load_string(block):
     load_record_string = 'dbLoadRecords("$(RUNCONTROL)/db/{file}.db", "{macros}")\n'
     macro_string="P=$(MYPVPREFIX),PV=$(MYPVPREFIX)CS:SB:{pv},PVA=$(MYPVPREFIX)CS:SB:{pva},NOALIAS={na}"
-    if (block_name == block.name.upper()):
+    if (block.name == block.name.upper()):
         return load_record_string.format(file="runcontrol",
-                                     macros=macro_string.format(pv=block_name, pva="", na="#"))
+                                     macros=macro_string.format(pv=block.name, pva="", na="#"))
     else:
         return load_record_string.format(file="runcontrol",
-                                     macros=macro_string.format(pv=block_name, pva=block_name.upper(), na=""))
+                                     macros=macro_string.format(pv=block.name, pva=block.name.upper(), na=""))
 
 class RunControlManager(OnTheFlyPvInterface):
     """A class for taking care of setting up run-control."""

--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -50,9 +50,13 @@ MAX_LOOPS_TO_WAIT_FOR_START = 60  # roughly 2 minutes at standard time
 
 def create_db_load_string(block):
     load_record_string = 'dbLoadRecords("$(RUNCONTROL)/db/{file}.db", "{macros}")\n'
-    return load_record_string.format(file="runcontrol",
-                                     macros="P=$(MYPVPREFIX),PV=$(MYPVPREFIX)CS:SB:{}".format(block.name.upper()))
-
+    macro_string="P=$(MYPVPREFIX),PV=$(MYPVPREFIX)CS:SB:{pv},PVA=$(MYPVPREFIX)CS:SB:{pva},NOALIAS={na}"
+    if (block_name == block.name.upper()):
+        return load_record_string.format(file="runcontrol",
+                                     macros=macro_string.format(pv=block_name, pva="", na="#"))
+    else:
+        return load_record_string.format(file="runcontrol",
+                                     macros=macro_string.format(pv=block_name, pva=block_name.upper(), na=""))
 
 class RunControlManager(OnTheFlyPvInterface):
     """A class for taking care of setting up run-control."""

--- a/BlockServer/test_modules/test_epics_gateway.py
+++ b/BlockServer/test_modules/test_epics_gateway.py
@@ -56,8 +56,7 @@ class TestEpicsGateway(unittest.TestCase):
         blockname, block_pv = "MY_BLOCK", "MY_PV"
         alias = "INST:BLOCK:MY_BLOCK"
         expected_lines = [[r"{}\([.:].*\)".format(alias), "ALIAS", "INST:MY_PV\\1"],
-                          [alias, "ALIAS", "INST:MY_PV"],
-                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
+                          [alias, "ALIAS", "INST:MY_PV"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, True)
 
@@ -67,8 +66,7 @@ class TestEpicsGateway(unittest.TestCase):
         blockname, block_pv = "MY_BLOCK", "MY_PV"
         alias = "INST:BLOCK:MY_BLOCK"
         expected_lines = [[r"{}\([.:].*\)".format(alias), "ALIAS", "MY_PV\\1"],
-                          [alias, "ALIAS", "MY_PV"],
-                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
+                          [alias, "ALIAS", "MY_PV"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, False)
 
@@ -79,8 +77,7 @@ class TestEpicsGateway(unittest.TestCase):
         alias = "INST:BLOCK:MY_BLOCK"
         expected_lines = [[r"{}\([.:].*\)".format(alias), "ALIAS", "INST:MY_PV\\1"],
                           ["{}[.]VAL".format(alias), "ALIAS", "INST:MY_PV.EGU"],
-                          [alias, "ALIAS", "INST:MY_PV.EGU"],
-                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
+                          [alias, "ALIAS", "INST:MY_PV.EGU"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, True)
 
@@ -91,8 +88,7 @@ class TestEpicsGateway(unittest.TestCase):
         alias = "INST:BLOCK:MY_BLOCK"
         expected_lines = [[r"{}\([.:].*\)".format(alias), "ALIAS", "MY_PV\\1"],
                           ["{}[.]VAL".format(alias), "ALIAS", "MY_PV.RBV"],
-                          [alias, "ALIAS", "MY_PV.RBV"],
-                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
+                          [alias, "ALIAS", "MY_PV.RBV"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, False)
 
@@ -102,8 +98,7 @@ class TestEpicsGateway(unittest.TestCase):
         blockname, block_pv = "MY_BLOCK", "MY_PV:SP"
         alias = "INST:BLOCK:MY_BLOCK"
         expected_lines = [[r"{}\(:SP\)?\([.:].*\)".format(alias), "ALIAS", "INST:MY_PV:SP\\2"],
-                          [r"{}\(:SP\)?".format(alias), "ALIAS", "INST:MY_PV:SP"],
-                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
+                          [r"{}\(:SP\)?".format(alias), "ALIAS", "INST:MY_PV:SP"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, True)
 
@@ -113,8 +108,7 @@ class TestEpicsGateway(unittest.TestCase):
         blockname, block_pv = "MY_BLOCK", "MY_PV:SP"
         alias = "INST:BLOCK:MY_BLOCK"
         expected_lines = [[r"{}\(:SP\)?\([.:].*\)".format(alias), "ALIAS", "MY_PV:SP\\2"],
-                          [r"{}\(:SP\)?".format(alias), "ALIAS", "MY_PV:SP"],
-                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
+                          [r"{}\(:SP\)?".format(alias), "ALIAS", "MY_PV:SP"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, False)
 
@@ -124,8 +118,7 @@ class TestEpicsGateway(unittest.TestCase):
         blockname, block_pv = "MY_BLOCK", "MY_TEST.VAL"
         alias = "INST:BLOCK:MY_BLOCK"
         expected_lines = [[r"{}\([.:].*\)".format(alias), "ALIAS", "MY_TEST\\1"],
-                          ["{}".format(alias), "ALIAS", "MY_TEST"],
-                          [r"{}\(:[ADR]C:.*\)".format(alias), "DENY"]]
+                          ["{}".format(alias), "ALIAS", "MY_TEST"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, False)
 
@@ -136,10 +129,8 @@ class TestEpicsGateway(unittest.TestCase):
         alias = "INST:BLOCK:My_Block"
         expected_lines = [[r"{}\([.:].*\)".format(alias), "ALIAS", "MY_PV\\1"],
                           [alias, "ALIAS", "MY_PV"],
-                          [r"{}\(:[ADR]C:.*\)".format(alias.upper()), "DENY"],
                           [r"{}\([.:].*\)".format(alias.upper()), "ALIAS", "MY_PV\\1"],
-                          [alias.upper(), "ALIAS", "MY_PV"],
-                          [r"{}\(:[ADR]C:.*\)".format(alias), "ALIAS", "INST:BLOCK:{}\\1".format(blockname.upper())]]
+                          [alias.upper(), "ALIAS", "MY_PV"]]
 
         lines = self.gateway.generate_alias(blockname, block_pv, False)
 


### PR DESCRIPTION
### Description of work

Add rule to terminate block list searches early if the PV does not have block name syntax.
This includes removing of handling of uppercase versions of run control PVS which are now done vin the IOC itself

### To test

See ISISComputingGroup/IBEX#5925

### Acceptance criteria

* Block are still looked up OK, testing improved performance may be hard
* run control works as before

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
