### PR TITLE
Ticket5905 convert remote ioc server

### DIFF
--- a/RemoteIocServer/config_monitor.py
+++ b/RemoteIocServer/config_monitor.py
@@ -138,7 +138,7 @@ class ConfigurationMonitor(object):
             config_json_as_str: remote configuration on which to base the xml
         """
         print_and_log("ConfigMonitor: Got new config monitor, writing new config files")
-        config_json = json.loads(config_json_as_str, "ascii")
+        config_json = json.loads(config_json_as_str)
 
         config = self._create_config_from_instrument_config(config_json)
 

--- a/RemoteIocServer/gateway.py
+++ b/RemoteIocServer/gateway.py
@@ -86,7 +86,7 @@ class GateWay(object):
     def _get_access_security_file_content(self):
         hostname = get_hostname_from_prefix(self._remote_pv_prefix)
         return textwrap.dedent("""\
-            HAG(allowed_write) { localhost, 127.0.0.1, """ + six.binary_type(hostname) + """ }
+            HAG(allowed_write) { localhost, 127.0.0.1, """ + six.binary_type(hostname).decode("utf-8") + """ }
             
             ASG(DEFAULT) {
                RULE(1, READ)
@@ -107,7 +107,7 @@ class GateWay(object):
             ASG(ANYBODY) {
                 RULE(1, READ)
             }
-            """.encode("ascii") if hostname is not None else "")
+            """ if hostname is not None else "")
 
     def _restart_gateway(self):
         with GATEWAY_RESTART_LOCK:

--- a/RemoteIocServer/gateway.py
+++ b/RemoteIocServer/gateway.py
@@ -86,7 +86,7 @@ class GateWay(object):
     def _get_access_security_file_content(self):
         hostname = get_hostname_from_prefix(self._remote_pv_prefix)
         return textwrap.dedent("""\
-            HAG(allowed_write) { localhost, 127.0.0.1, """ + six.binary_type(hostname).decode("utf-8") + """ }
+            HAG(allowed_write) { localhost, 127.0.0.1, """ + hostname + """ }
             
             ASG(DEFAULT) {
                RULE(1, READ)

--- a/RemoteIocServer/remote_ioc_server.py
+++ b/RemoteIocServer/remote_ioc_server.py
@@ -103,7 +103,7 @@ class RemoteIocListDriver(Driver):
         self.updatePVs()  # Update PVs before any read so that they are up to date.
 
         if reason == PvNames.INSTRUMENT:
-            return six.binary_type(self._remote_pv_prefix if self._remote_pv_prefix is not None else "NONE")
+            return six.binary_type(self._remote_pv_prefix if self._remote_pv_prefix is not None else "NONE", encoding="utf-8")
         else:
             print_and_log("RemoteIocListDriver: Could not read from PV '{}': not known".format(reason), "MAJOR")
 

--- a/RemoteIocServer/remote_ioc_server.py
+++ b/RemoteIocServer/remote_ioc_server.py
@@ -155,7 +155,7 @@ def serve_forever(pv_prefix, subsystem_prefix, gateway_pvlist_path, gateway_acf_
     """
     server = SimpleServer()
 
-    server.createPV("{}{}".format(pv_prefix, subsystem_prefix).encode('ascii'), STATIC_PV_DATABASE)
+    server.createPV("{}{}".format(pv_prefix, subsystem_prefix), STATIC_PV_DATABASE)
 
     # Looks like it does nothing, but this creates *and automatically registers* the driver
     # (via metaclasses in pcaspy). See declaration of DriverType in pcaspy/driver.py for details

--- a/RemoteIocServer/test_modules/__init__.py
+++ b/RemoteIocServer/test_modules/__init__.py
@@ -10,4 +10,8 @@ def load_tests(loader, standard_tests, pattern):
 
     The tests in this module are only added under Python 2 and don't run under linux.
     """
-    return unittest.TestSuite()
+    if six.PY3 and os.name == "nt":
+        standard_tests.addTests(loader.discover(os.path.dirname(__file__), pattern=pattern))
+        return standard_tests
+    else:
+        return unittest.TestSuite()

--- a/RemoteIocServer/test_modules/test_config_monitor.py
+++ b/RemoteIocServer/test_modules/test_config_monitor.py
@@ -161,23 +161,24 @@ class TestConfigMonitor(unittest.TestCase):
 
         mock_open.assert_any_call(os.path.join("test_dir", "iocs.xml"), "w")
         mock_open.return_value.__enter__.return_value.write.assert_any_call(
-            '<?xml version="1.0" ?>\n'
-            '<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">\n'
-            '\t<ioc autostart="true" name="INSTETC_01" remotePvPrefix="{pf}" restart="true" simlevel="none">\n'
-            '\t\t<macros>\n'
-            '\t\t\t<macro name="ACF_IH1" value="None"/>\n'
-            '\t\t</macros>\n'
-            '\t\t<pvs/>\n'
-            '\t\t<pvsets/>\n'
-            '\t</ioc>\n'
-            '\t<ioc autostart="true" name="ISISDAE_01" remotePvPrefix="{pf}" restart="true" simlevel="none">\n'
-            '\t\t<macros>\n'
-            '\t\t\t<macro name="ACF_IH1" value="None"/>\n'
-            '\t\t</macros>\n'
-            '\t\t<pvs/>\n'
-            '\t\t<pvsets/>\n'
-            '\t</ioc>\n'
-            '</iocs>\n'.format(pf=LOCAL_TEST_PREFIX))
+            """<?xml version="1.0" ?>
+<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<ioc name="INSTETC_01" autostart="true" restart="true" remotePvPrefix="{pf}" simlevel="none">
+		<macros>
+			<macro name="ACF_IH1" value="None"/>
+		</macros>
+		<pvs/>
+		<pvsets/>
+	</ioc>
+	<ioc name="ISISDAE_01" autostart="true" restart="true" remotePvPrefix="{pf}" simlevel="none">
+		<macros>
+			<macro name="ACF_IH1" value="None"/>
+		</macros>
+		<pvs/>
+		<pvsets/>
+	</ioc>
+</iocs>
+""".format(pf=LOCAL_TEST_PREFIX))
 
     @patch("RemoteIocServer.config_monitor._EpicsMonitor")
     @patch("builtins.open")

--- a/RemoteIocServer/test_modules/test_config_monitor.py
+++ b/RemoteIocServer/test_modules/test_config_monitor.py
@@ -78,7 +78,7 @@ class TestConfigMonitor(unittest.TestCase):
         monitor = ConfigurationMonitor(LOCAL_TEST_PREFIX, lambda *a, **k: None)
         write_new = MagicMock()
         monitor.write_new_config_as_xml = write_new
-        monitor._config_updated([ord(a) for a in compress_and_hex(str(""))])
+        monitor._config_updated([ord(a) for a in compress_and_hex(str("")).decode("utf-8")])
 
         write_new.assert_called_once()
         print_and_log.assert_not_called()
@@ -98,7 +98,7 @@ class TestConfigMonitor(unittest.TestCase):
         print_and_log.assert_called()
 
     @patch("RemoteIocServer.config_monitor.print_and_log")
-    @patch("__builtin__.open")
+    @patch("builtins.open")
     @patch("BlockServer.fileIO.file_manager.os")
     @patch("RemoteIocServer.config_monitor._EpicsMonitor")
     def test_GIVEN_config_dir_not_existent_WHEN_write_config_as_xml_THEN_config_dir_created(
@@ -113,7 +113,7 @@ class TestConfigMonitor(unittest.TestCase):
         os_mock.makedirs.assert_called_once()
 
     @patch("RemoteIocServer.config_monitor.print_and_log")
-    @patch("__builtin__.open")
+    @patch("builtins.open")
     @patch("BlockServer.fileIO.file_manager.os")
     @patch("RemoteIocServer.config_monitor._EpicsMonitor")
     def test_GIVEN_config_dir_exists_WHEN_write_config_as_xml_THEN_config_dir_not_recreated(
@@ -128,7 +128,7 @@ class TestConfigMonitor(unittest.TestCase):
         os_mock.mkdir.assert_not_called()
 
     @patch("RemoteIocServer.config_monitor.print_and_log")
-    @patch("__builtin__.open")
+    @patch("builtins.open")
     @patch("RemoteIocServer.config_monitor._EpicsMonitor")
     def test_GIVEN_write_ioc_xml_called_WHEN_no_iocs_from_blockserver_THEN_appropriate_empty_xml_created(
             self, epicsmonitor, mock_open, print_and_log):
@@ -143,7 +143,7 @@ class TestConfigMonitor(unittest.TestCase):
             """<?xml version="1.0" ?>\n<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>\n""")
 
     @patch("RemoteIocServer.config_monitor.print_and_log")
-    @patch("__builtin__.open")
+    @patch("builtins.open")
     @patch("RemoteIocServer.config_monitor._EpicsMonitor")
     def test_GIVEN_write_ioc_xml_called_WHEN_iocs_from_blockserver_THEN_appropriate_xml_created(
             self, epicsmonitor, mock_open, print_and_log):
@@ -180,7 +180,7 @@ class TestConfigMonitor(unittest.TestCase):
             '</iocs>\n'.format(pf=LOCAL_TEST_PREFIX))
 
     @patch("RemoteIocServer.config_monitor._EpicsMonitor")
-    @patch("__builtin__.open")
+    @patch("builtins.open")
     @patch("RemoteIocServer.config_monitor.print_and_log")
     def test_GIVEN_write_standard_config_files_called_THEN_standard_config_files_written(
             self, epicsmonitor, mock_open, print_and_log):
@@ -205,7 +205,7 @@ class TestConfigMonitor(unittest.TestCase):
             assert_that(all_writes, has_item(META_XML))
 
     @patch("RemoteIocServer.config_monitor.print_and_log")
-    @patch("__builtin__.open")
+    @patch("builtins.open")
     @patch("RemoteIocServer.config_monitor._EpicsMonitor")
     def test_GIVEN_update_last_config_called_THEN_standard_config_files_written(
             self, epicsmonitor, mock_open, print_and_log):

--- a/start_remote_ioc_server.bat
+++ b/start_remote_ioc_server.bat
@@ -13,5 +13,4 @@ set EPICS_CA_MAX_ARRAY_BYTES=65536
 
 set PYTHONUNBUFFERED=TRUE
 
-:: C:\instrument\apps\python\python.exe %MYDIRBLOCK%RemoteIocServer\remote_ioc_server.py --pv_prefix %MYPVPREFIX%
-:: Disabled until converted to python 3 - https://github.com/ISISComputingGroup/IBEX/issues/5905
+C:\instrument\apps\python3\python.exe %MYDIRBLOCK%RemoteIocServer\remote_ioc_server.py --pv_prefix %MYPVPREFIX%


### PR DESCRIPTION
### Description of work

Converts the remote IOC server to run under python 3. 
Have done the bare minimum for this, it was written with six anyway so didn't really need to change much. 

### To test

Run through https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Remote-IOCs and run an IOC on the remote machine, then see if you can access it from the local one running IBEX

__nb: this will likely not work on the VPN, i'm not sure why, i tried it with DEMO and my local machine but it didn't work__

### Acceptance criteria

See ticket - ISISComputingGroup/IBEX#5905

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
