### PR TITLE
Add optional int autosave parameter

### DIFF
--- a/server_common/autosave.py
+++ b/server_common/autosave.py
@@ -93,6 +93,26 @@ class BoolConversion(Conversion):
         raise ValueError("String is not True or False")
 
 
+class OptionalIntConversion(Conversion):
+    """
+    Take a value and convert it to and from a integer or None
+    """
+
+    @staticmethod
+    def autosave_convert_for_read(auto_save_value_read):
+        """
+        Convert values read from autosave into given values
+        Args:
+            auto_save_value_read: value read as a string from autosave
+
+        Returns:
+            value
+        """
+        if auto_save_value_read == 'None':
+            return None
+        return int(auto_save_value_read)
+
+
 class AutosaveFile(object):
     """
     An Autosave object useful for saving values that can be read and written at sensible points in time.

--- a/server_common/test_modules/test_autosave.py
+++ b/server_common/test_modules/test_autosave.py
@@ -6,7 +6,7 @@ import os
 from hamcrest import *
 from parameterized import parameterized
 
-from server_common.autosave import AutosaveFile, FloatConversion, BoolConversion
+from server_common.autosave import AutosaveFile, FloatConversion, BoolConversion, OptionalIntConversion
 
 TEMP_FOLDER = os.path.join("C:\\", "instrument", "var", "tmp", "autosave_tests")
 
@@ -93,6 +93,18 @@ class TestAutosave(unittest.TestCase):
         result = autosave.read_parameter(key, None)
 
         assert_that(result, is_(None))
+
+    @parameterized.expand([(1,), (None,)])
+    def test_GIVEN_int_or_None_WHEN_get_parameter_from_autosave_THEN_value_returned(self, value):
+        key = "parameter"
+        autosave = AutosaveFile(service_name="unittests",
+                                file_name="test_file", folder=TEMP_FOLDER, conversion=OptionalIntConversion())
+
+        autosave.write_parameter(key, value)
+        result = autosave.read_parameter(key, "not read")
+
+        assert_that(result, is_(value))
+
 
     def tearDown(self):
         try:


### PR DESCRIPTION
### Description of work

Add int optional autosave param

### To test

https://github.com/ISISComputingGroup/IBEX/issues/5783

### Acceptance criteria

Acn auto save a parameter which is an int or None

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
