### PR TITLE
Correct the byte conversion in device screens

### DIFF
--- a/BlockServer/core/on_the_fly_pv_interface.py
+++ b/BlockServer/core/on_the_fly_pv_interface.py
@@ -50,14 +50,14 @@ class OnTheFlyPvInterface:
         return pv in self.pvs_to_write
 
     @abstractmethod
-    def handle_pv_write(self, pv, data):
+    def handle_pv_write(self, pv: str, data: str):
         """ Handles the request to write to the PV.
 
         Note: implementations of this method MUST run on a separate thread.
 
         Args:
-            pv (string): The PV's name
-            data (object): The value to write
+            pv: The PV's name
+            data: The value to write
         """
         pass
 

--- a/BlockServer/runcontrol/runcontrol_manager.py
+++ b/BlockServer/runcontrol/runcontrol_manager.py
@@ -87,7 +87,7 @@ class RunControlManager(OnTheFlyPvInterface):
         print_and_log(f"RUNCONTROL SETTINGS FILE: {self._settings_file}")
         self._intialise_runcontrol_ioc()
 
-    def handle_pv_write(self, pv, data):
+    def handle_pv_write(self, pv: str, data: str):
         """
         Unimplemented.
         """

--- a/BlockServer/synoptic/synoptic_manager.py
+++ b/BlockServer/synoptic/synoptic_manager.py
@@ -15,8 +15,11 @@
 # http://opensource.org/licenses/eclipse-1.0.php
 
 import os
-from typing import List
+from typing import List, TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from block_server import BlockServer
+from BlockServer.core.active_config_holder import ActiveConfigHolder
 from BlockServer.core.config_list_manager import InvalidDeleteException
 from BlockServer.core.file_path_manager import FILEPATH_MANAGER
 from BlockServer.core.on_the_fly_pv_interface import OnTheFlyPvInterface
@@ -44,14 +47,14 @@ SYNOPTIC_SCHEMA_FILE = "synoptic.xsd"
 
 class SynopticManager(OnTheFlyPvInterface):
     """Class for managing the PVs associated with synoptics"""
-    def __init__(self, block_server, schema_folder, active_configholder, file_io=SynopticFileIO()):
+    def __init__(self, block_server: 'BlockServer', schema_folder: str, active_configholder: ActiveConfigHolder, file_io: SynopticFileIO = SynopticFileIO()):
         """Constructor.
 
         Args:
-            block_server (BlockServer): A reference to the BlockServer instance
-            schema_folder (string): The filepath for the synoptic schema
-            active_configholder (ActiveConfigHolder): A reference to the active configuration
-            file_io (SynopticFileIO): Responsible for file IO
+            block_server: A reference to the BlockServer instance
+            schema_folder: The filepath for the synoptic schema
+            active_configholder: A reference to the active configuration
+            file_io: Responsible for file IO
         """
         super(SynopticManager, self).__init__()
         self.pvs_to_write.extend([SYNOPTIC_PRE + SYNOPTIC_DELETE, SYNOPTIC_PRE + SYNOPTIC_SET_DETAILS])
@@ -65,7 +68,7 @@ class SynopticManager(OnTheFlyPvInterface):
         self._create_standard_pvs()
         self._load_initial()
 
-    def handle_pv_write(self, pv, data):
+    def handle_pv_write(self, pv: str, data: str):
         try:
             if pv == SYNOPTIC_PRE + SYNOPTIC_DELETE:
                 self.delete(convert_from_json(data))

--- a/BlockServer/test_modules/test_devices_manager.py
+++ b/BlockServer/test_modules/test_devices_manager.py
@@ -28,7 +28,7 @@ BASE_PATH = "example_base"
 SCREENS_FILE = "screens.xml"
 SCHEMA_FOLDER = "schema"
 
-EXAMPLE_DEVICES = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+EXAMPLE_DEVICES = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <devices xmlns="http://epics.isis.rl.ac.uk/schema/screens/1.0/">
     <device>
         <name>Eurotherm 1</name>
@@ -43,7 +43,7 @@ EXAMPLE_DEVICES = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     </device>
 </devices>"""
 
-EXAMPLE_DEVICES_2 = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+EXAMPLE_DEVICES_2 = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <devices xmlns="http://epics.isis.rl.ac.uk/schema/screens/1.0/">
     <device>
         <name>Eurotherm 2</name>
@@ -58,7 +58,7 @@ EXAMPLE_DEVICES_2 = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     </device>
 </devices>"""
 
-INVALID_DEVICES = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+INVALID_DEVICES = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <devices xmlns="http://epics.isis.rl.ac.uk/schema/screens/1.0/">
     <device>
         <name>Eurotherm 1</name>
@@ -142,4 +142,4 @@ class TestDevicesManagerSequence(unittest.TestCase):
 
         # Assert:
         # Device screens in blockserver should have been updated with value written to device manager
-        self.assertEqual(EXAMPLE_DEVICES, dehex_and_decompress(self.bs.pvs[GET_SCREENS]))
+        self.assertEqual(bytes(EXAMPLE_DEVICES,"utf-8"), dehex_and_decompress(self.bs.pvs[GET_SCREENS]))

--- a/block_server.py
+++ b/block_server.py
@@ -22,7 +22,7 @@ import traceback
 
 from server_common.channel_access import verify_manager_mode, ManagerModeRequiredException
 
-sys.path.insert(0, os.path.abspath(os.environ["MYDIRBLOCK"]))
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 # Standard imports
 from pcaspy import Driver, SimpleServer

--- a/server_common/utilities.py
+++ b/server_common/utilities.py
@@ -70,7 +70,7 @@ def print_and_log(message, severity=SEVERITY.INFO, src="BLOCKSVR"):
     """Prints the specified message to the console and writes it to the log.
 
     Args:
-        message (string): The message to log
+        message (string|exception): The message to log
         severity (string, optional): Gives the severity of the message. Expected serverities are MAJOR, MINOR and INFO.
                                     Default severity is INFO.
         src (string, optional): Gives the source of the message. Default source is BLOCKSVR.


### PR DESCRIPTION
### Description of work

Update pv is a string but was treated as a bytes.

### To test

N/A

### Acceptance criteria

Device screens can be saved

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
