### PR TITLE
Only push on branches with the same name as your machine

### DIFF
--- a/ConfigVersionControl/git_version_control.py
+++ b/ConfigVersionControl/git_version_control.py
@@ -82,13 +82,8 @@ class GitVersionControl:
         Returns:
             bool : Whether the branch is allowed
         """
-        branch_name = branch_name.lower()
-
-        if branch_name == socket.gethostname().lower():
-            # Only automatically push branches named after your instrument
-            return True
-
-        return False
+        # Only automatically push branches named after your instrument
+        return branch_name.lower() == socket.gethostname().lower()
 
     def setup(self):
         """ Call when first starting the version control.

--- a/ConfigVersionControl/git_version_control.py
+++ b/ConfigVersionControl/git_version_control.py
@@ -84,14 +84,11 @@ class GitVersionControl:
         """
         branch_name = branch_name.lower()
 
-        if "master" in branch_name:
-            return False
+        if branch_name == socket.gethostname().lower():
+            # Only automatically push branches named after your instrument
+            return True
 
-        if branch_name.startswith("nd") and branch_name != socket.gethostname().lower():
-            # You're trying to push to a different instrument
-            return False
-
-        return True
+        return False
 
     def setup(self):
         """ Call when first starting the version control.

--- a/ConfigVersionControl/test_modules/test_version_contol.py
+++ b/ConfigVersionControl/test_modules/test_version_contol.py
@@ -31,5 +31,5 @@ class TestVersionControl(unittest.TestCase):
     def test_WHEN_branch_begins_with_nd_THEN_branch_not_allowed(self):
         self.assertFalse(GitVersionControl.branch_allowed("NDTEST"))
 
-    def test_WHEN_branch_begins_contains_nd_THEN_branch_allowed(self):
-        self.assertTrue(GitVersionControl.branch_allowed("testNDtest"))
+    def test_WHEN_branch_is_another_random_name_THEN_branch_not_allowed(self):
+        self.assertFalse(GitVersionControl.branch_allowed("random"))


### PR DESCRIPTION
### Description of work

Be more cautious on which branches to push

### To test

Run the unit tests, confirm that branches that are not named after your machine are not being pushed

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
