### PR TITLE
Fixing .decode on string error when loading default synoptic

### DIFF
--- a/BlockServer/synoptic/synoptic_file_io.py
+++ b/BlockServer/synoptic/synoptic_file_io.py
@@ -39,7 +39,7 @@ class SynopticFileIO:
     def read_synoptic_file(self, directory, fullname):
         path = os.path.join(directory, fullname)
 
-        with open(path, 'rb') as synfile:
+        with open(path, 'r') as synfile:
             data = synfile.read()
 
         return data

--- a/BlockServer/synoptic/synoptic_manager.py
+++ b/BlockServer/synoptic/synoptic_manager.py
@@ -129,11 +129,11 @@ class SynopticManager(OnTheFlyPvInterface):
             except Exception as err:
                 print_and_log(f"Error creating synoptic PV: {err}", "MAJOR")
 
-    def _create_pv(self, data: bytes):
+    def _create_pv(self, data: str):
         """Creates a single PV based on a name and data. Adds this PV to the dictionary returned on get_synoptic_list
 
         Args:
-            data (bytes): Starting data for the pv, the pv name is derived from the name tag of this
+            data (str): Starting data for the pv, the pv name is derived from the name tag of this
         """
         name = self._get_synoptic_name_from_xml(data)
         if name not in self._synoptic_pvs:
@@ -147,7 +147,7 @@ class SynopticManager(OnTheFlyPvInterface):
         # Create the PV
         self._bs.add_string_pv_to_db(SYNOPTIC_PRE + self._synoptic_pvs[name] + SYNOPTIC_GET, 16000)
         # Update the value
-        self.update_pv_value(SYNOPTIC_PRE + self._synoptic_pvs[name] + SYNOPTIC_GET, compress_and_hex(data.decode("utf-8")))
+        self.update_pv_value(SYNOPTIC_PRE + self._synoptic_pvs[name] + SYNOPTIC_GET, compress_and_hex(data))
 
     def update_pv_value(self, name, data):
         """ Updates value of a PV holding synoptic information with new data
@@ -203,7 +203,7 @@ class SynopticManager(OnTheFlyPvInterface):
         """Gets the XML for the default synoptic.
 
         Returns:
-            bytes : The XML for the synoptic
+            str : The XML for the synoptic
         """
         return self._default_syn_xml
 


### PR DESCRIPTION
### Description of work

Previously when loading a synoptic the file io manager tried to open the xml file as bytes. This led to a compress_and_hex issue that threw when trying to load the default synoptic for a configuration and therefore fell over. 

### To test

- Set a default synoptic config in "edit current configuration"
- Restart Blockserver 
- Should now be loaded correctly with no exceptions. 

Beforehand the synoptic was not loaded correctly and threw a large as compress_and_hex was trying to push the xml file as bytes. 

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
