### PR TITLE
Blockserver synoptics: handle bytes and string correctly

### DIFF
--- a/BlockServer/fileIO/schema_checker.py
+++ b/BlockServer/fileIO/schema_checker.py
@@ -55,7 +55,7 @@ class ConfigurationSchemaChecker:
 
         Args:
             schema_filepath (string): The location of the schema file
-            xml_data (string): The XML data of the configuration
+            xml_data (bytes): The XML data of the configuration
         """
         if len(xml_data) == 0:
             raise ConfigurationFileBlank("Invalid XML: File is blank.")

--- a/BlockServer/test_modules/test_synoptic_manager.py
+++ b/BlockServer/test_modules/test_synoptic_manager.py
@@ -25,9 +25,9 @@ from BlockServer.synoptic.synoptic_file_io import SynopticFileIO
 
 TEST_DIR = os.path.abspath(".")
 
-EXAMPLE_SYNOPTIC = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+EXAMPLE_SYNOPTIC = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
                       <instrument xmlns="http://www.isis.stfc.ac.uk//instrument">
-                      <name>%s</name>
+                      <name>{}</name>
                       </instrument>"""
 
 SCHEMA_FOLDER = "schema"
@@ -72,7 +72,7 @@ class TestSynopticManagerSequence(unittest.TestCase):
         self.sm = SynopticManager(self.bs, os.path.join(self.dir, SCHEMA_FOLDER), None, self.fileIO)
 
     def _create_a_synoptic(self, name, sm):
-        sm.save_synoptic_xml(EXAMPLE_SYNOPTIC % name.encode("utf-8"))
+        sm.save_synoptic_xml(bytes(EXAMPLE_SYNOPTIC.format(name), encoding="utf-8"))
 
     def test_get_synoptic_names_returns_names_alphabetically(self):
         # Arrange
@@ -104,13 +104,13 @@ class TestSynopticManagerSequence(unittest.TestCase):
         xml = self.sm.get_default_synoptic_xml()
 
         # Assert
-        self.assertEqual(xml, "")
+        self.assertEqual(xml, b"")
 
     def test_set_default_synoptic_xml_sets_something(self):
         # Arrange
         self._create_a_synoptic(SYNOPTIC_1, self.sm)
         # Act
-        self.sm.save_synoptic_xml(EXAMPLE_SYNOPTIC % "synoptic0".encode("utf-8"))
+        self.sm.save_synoptic_xml(bytes(EXAMPLE_SYNOPTIC.format("synoptic0"), encoding="utf-8"))
         self.sm.set_default_synoptic("synoptic0")
 
         # Assert
@@ -125,10 +125,10 @@ class TestSynopticManagerSequence(unittest.TestCase):
         syn_name = "synopt"
 
         # Act
-        self.sm.save_synoptic_xml(EXAMPLE_SYNOPTIC % syn_name.encode("utf-8"))
+        self.sm.save_synoptic_xml(bytes(EXAMPLE_SYNOPTIC.format(syn_name), encoding="utf-8"))
 
         # Assert
-        self.assertTrue(self.bs.does_pv_exist("%sSYNOPT%s" % (SYNOPTIC_PRE, SYNOPTIC_GET)))
+        self.assertTrue(self.bs.does_pv_exist("{}SYNOPT{}".format(SYNOPTIC_PRE, SYNOPTIC_GET)))
 
     def test_delete_synoptics_empty(self):
         # Arrange


### PR DESCRIPTION
### Description of work

Correctly handle bytes and string when passing xml_data around the blockserver synoptic_manager.

### To test

- Attempt to reproduce using https://github.com/ISISComputingGroup/IBEX/issues/6162#issue-798487838 and confirm the log contains no bytes error. 
- Run inst_servers tests and confirm no failures
- Confirm handling of bytes and strings in the code is appropriate

https://github.com/ISISComputingGroup/IBEX/issues/6162

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
