### PR TITLE
Ticket6465 CRISP should not be scheduled

### DIFF
--- a/scripts/set_instrument_list.py
+++ b/scripts/set_instrument_list.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
         inst_dictionary("LOQ", groups=["SANS"]),
         inst_dictionary("LET", groups=["EXCITATIONS"]),
         inst_dictionary("MARI", groups=["EXCITATIONS"]),
-        inst_dictionary("CRISP", groups=["REFLECTOMETRY"]),
+        inst_dictionary("CRISP", groups=["REFLECTOMETRY"], is_scheduled=False),
         inst_dictionary("SOFTMAT", groups=["SUPPORT"], is_scheduled=False),
         inst_dictionary("SURF", groups=["REFLECTOMETRY"]),
         inst_dictionary("NIMROD", groups=["DISORDERED"]),


### PR DESCRIPTION
### Description of work

changed CRISP to not be Scheduled. is a test instrument so has no data for RB number populator.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/6465

### Acceptance criteria
CRISP not scheduled on the database populator

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
