### PR TITLE
Add WISH to instrument list and populate Crystallography group PV

### DIFF
--- a/scripts/set_instrument_list.py
+++ b/scripts/set_instrument_list.py
@@ -137,6 +137,7 @@ if __name__ == "__main__":
         inst_dictionary("POLREF", groups=["REFLECTOMETRY"]),
         inst_dictionary("SANS2D", groups=["SANS"]),
         inst_dictionary("MUSR", groups=["MUONS"]),
+        inst_dictionary("WISH", groups=["CRYSTALLOGRAPHY"]),
     ]
 
     set_instlist(instruments_list, pv_address) 
@@ -195,5 +196,17 @@ if __name__ == "__main__":
     instruments_list = [
         inst_dictionary("IMAT"),
         inst_dictionary("ENGINX"),
+    ]
+    set_instlist(instruments_list, pv_address)
+
+    pv_address = "CS:INSTLIST:CRYSTALLOGRAPHY"
+    instruments_list = [
+        inst_dictionary("HRPD_SETUP"),
+        inst_dictionary("HRPD"),
+        inst_dictionary("POLARIS"),
+        inst_dictionary("ENGINX"),
+        inst_dictionary("GEM"),
+        inst_dictionary("INES"),
+        inst_dictionary("WISH"),
     ]
     set_instlist(instruments_list, pv_address)


### PR DESCRIPTION
### Description of work

Modified `set_instrument_list.py` script to add WISH to instrument list and populate Crystallography group PV.

### To test

see https://github.com/ISISComputingGroup/IBEX/issues/6822

### Acceptance criteria

WISH appears in instrument list PV, crystallography group PV contains appropriate instruments.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
