### PR TITLE
Print message to console on logger connect failure

### DIFF
--- a/server_common/loggers/isis_logger.py
+++ b/server_common/loggers/isis_logger.py
@@ -108,6 +108,7 @@ class IsisLogger(Logger):
                 sock.sendall(codecs.encode(xml, "utf-8"))
             except Exception:
                 traceback.print_exc()
+                print("While trying to log: \"{}\"".format(message))
 
 
 class IsisPutLog:


### PR DESCRIPTION
### Description of work

On logging failure, print message that was attempted to be logged - this particularly affected caPutLog messages
 
### To test

See ISISComputingGroup/IBEX#6950


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
