### PR TITLE
retry connection rather than quitting if broker not found/server not …

### DIFF
--- a/BlockServerToKafka/kafka_producer.py
+++ b/BlockServerToKafka/kafka_producer.py
@@ -20,7 +20,7 @@ from streaming_data_types.fbschemas.forwarder_config_update_rf5k.Protocol import
 )
 from kafka import KafkaProducer, errors, KafkaConsumer
 from server_common.utilities import print_and_log
-
+from time import sleep
 
 class ProducerWrapper:
     """
@@ -46,17 +46,19 @@ class ProducerWrapper:
                 print_and_log(f"WARNING: topic {self.topic} does not exist. It will be created by default.")
         except errors.NoBrokersAvailable:
             print_and_log(f"No brokers found on server: {server[0]}")
-            quit()
         except errors.ConnectionError:
             print_and_log("No server found, connection error")
-            quit()
         except errors.InvalidConfigurationError:
             print_and_log("Invalid configuration")
             quit()
         except errors.InvalidTopicError:
             print_and_log("Invalid topic, to enable auto creation of topics set"
                           " auto.create.topics.enable to false in broker configuration")
-            quit()
+        finally:
+            print_and_log("Retrying in 10s")
+            sleep(10)
+            # Recursive call after waiting
+            self._set_up_producer(server)
 
     def add_config(self, pvs: List[str]):
         """


### PR DESCRIPTION
…found/invalid topic

### Description of work

The data streaming cluster is down which has caused the process on all instruments to restart continuously. Procserv currently has a memory leak when something restarts quickly so this should fix it and instead of quitting bstokafka it'll retry connection instead after 10 seconds of waiting


### To test

Run an ibex server - see in the bstokafka ioc log that instead of restaritng the entire process it is just retrying comms

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
