### PR TITLE
Use subprocess.run to avoid output hang issue

### DIFF
--- a/BlockServer/epics/archiver_manager.py
+++ b/BlockServer/epics/archiver_manager.py
@@ -20,7 +20,7 @@ import os
 from shutil import copyfile
 import datetime
 import time
-from subprocess import Popen, PIPE, STDOUT
+from subprocess import run, PIPE, STDOUT
 import xml.etree.ElementTree as eTree
 from xml.dom import minidom
 from server_common.utilities import print_and_log
@@ -120,13 +120,18 @@ class ArchiverManager:
         f = os.path.abspath(self._uploader_path)
         if os.path.isfile(f):
             print_and_log(f"Running archiver settings uploader: {f}")
-            p = Popen(f, stdout=PIPE, stderr=STDOUT)
-            if p.wait() != 0:
-                print_and_log("Retrying as error {} returned from Popen".format(p.returncode))
+            p = run(f, stdout=PIPE, stderr=STDOUT)
+            print_and_log(p.stdout)
+            if p.returncode != 0:
+                print_and_log("Retrying as status {} returned from subproccess.run".format(p.returncode))
                 time.sleep(1)
-                p = Popen(f, stdout=PIPE, stderr=STDOUT)
-                if p.wait() != 0:
-                    raise Exception("Error {} returned from Popen when running {}".format(p.returncode, f))
+                p = run(f, stdout=PIPE, stderr=STDOUT)
+                print_and_log(p.stdout)
+                ## this would throw a CalledProcessError exception, but may cause more harm than good at moment
+                # p.check_returncode()
+                ## for the moment just print an error like before, so rest of config change happens
+                if p.returncode != 0:
+                    print_and_log("Error {} returned from subproccess.run for {}".format(p.returncode, f))
             print_and_log(f"Finished running archiver settings uploader: {f}")
         else:
             print_and_log(f"Could not find specified archiver uploader batch file: {self._uploader_path}")


### PR DESCRIPTION
### Description of work

Change to use subprocess.run as current implementation hangs
if too much output. Currently we do not throw an exception which
is the same behaviour as the original code

### To test

Run up instrument, on startup/change of config you should now see output from  running `set_block_config.bat` that looks a biy like
```
INFO: b'\r\nC:\\Instrument\\Apps\\EPICS-DEBUG2\\ISIS\\inst_servers\\master>set STARTARCHIVEDIR=C:\\Instrument\\Apps\\EPICS-DEBUG2\\CSS\\master\\ArchiveEngine\\ \r\n\r\nC:\\Instrument\\Apps\\EPICS-DEBUG2\\ISIS\\inst_servers\\master>set ARCT_EXE=C:\\Instrument\\Apps\\EPICS-DEBUG2\\CSS\\master\\ArchiveEngine\\..\\css-win.x86_64\\css_archive_config_tool\\ArchiveConfigTool.exe \r\n\r\nC:\\Instrument\\Apps\\EPICS-DEBUG2\\ISIS\\inst_servers\\master>if not exist "C:\\Instrument\\Apps\\EPICS-DEBUG2\\CSS\\master\\ArchiveEngine\\block_config.xml" (set BLOCKCONFIGFILE=C:\\Instrument\\Apps\\EPICS-DEBUG2\\CSS\\master\\ArchiveEngine\\empty_block_config.xml )  else (set BLOCKCONFIGFILE=C:\\Instrument\\Apps\\EPICS-DEBUG2\\CSS\\master\\ArchiveEngine\\block_config.xml ) \r\n\r\nC:\\Instrument\\Apps\\EPICS-DEBUG2\\ISIS\\inst_servers\\master>if exist "" (set BLOCKCONFIGFILE= )  
```
### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
