### PR TITLE
Prevent restarting IOCs that don't need restarting

### DIFF
--- a/BlockServer/core/active_config_holder.py
+++ b/BlockServer/core/active_config_holder.py
@@ -259,6 +259,7 @@ class ActiveConfigHolder(ConfigHolder):
                     print_and_log(f"Found manually-started IOC {ioc_name}. Restarting as present in new config.")
                     if ioc_name in new_iocs:
                         new_iocs.remove(ioc_name)
+
                     changed_iocs.add(ioc_name)
                 else:
                     # If the IOC is not in the new config, we should stop the IOC to ensure it does not accidentally

--- a/BlockServer/core/active_config_holder.py
+++ b/BlockServer/core/active_config_holder.py
@@ -256,12 +256,14 @@ class ActiveConfigHolder(ConfigHolder):
                 if ioc_name in iocs_in_new_config:
                     # If the IOC is in the new config, we need to restart it as the new config may have macros which
                     # were not used when the IOC was manually started outside the config.
+                    print_and_log(f"Found manually-started IOC {ioc_name}. Restarting as present in new config.")
                     if ioc_name in new_iocs:
                         new_iocs.remove(ioc_name)
                     changed_iocs.add(ioc_name)
                 else:
                     # If the IOC is not in the new config, we should stop the IOC to ensure it does not accidentally
                     # interfere with any items being loaded in the new config.
+                    print_and_log(f"Found manually-started IOC {ioc_name}. Stopping as not present in new config")
                     removed_iocs.add(ioc_name)
 
         print_and_log(f"New IOCS = {new_iocs}")

--- a/BlockServer/core/active_config_holder.py
+++ b/BlockServer/core/active_config_holder.py
@@ -15,7 +15,9 @@
 # https://www.eclipse.org/org/documents/epl-v10.php or
 # http://opensource.org/licenses/eclipse-1.0.php
 import os
+from typing import Dict
 
+from BlockServer.config.ioc import IOC
 from server_common.constants import IOCS_NOT_TO_STOP
 from server_common.utilities import print_and_log
 from BlockServer.core.macros import BLOCK_PREFIX, MACROS, CONTROL_SYSTEM_PREFIX
@@ -73,7 +75,7 @@ def _blocks_changed_in_config(old_config, new_config, block_comparator=_blocks_c
     return False
 
 
-def _compare_ioc_properties(old, new):
+def _compare_ioc_properties(old: Dict[str, IOC], new: Dict[str, IOC]):
     """
     Compares the properties of IOCs in a component/configuration.
 
@@ -82,22 +84,27 @@ def _compare_ioc_properties(old, new):
         new: The corresponding new configuration or component
 
     Returns:
-        set, set : IOCs to start, IOCs to restart
+        set, set, set : added IOCs, changed IOCs, removed IOCs
     """
-    iocs_to_start = set()
-    iocs_to_restart = set()
+    new_iocs = set()
+    changed_iocs = set()
+    removed_iocs = set()
 
-    _attributes = ["macros", "pvs", "pvsets", "simlevel", "restart"]
+    _attributes = ["macros", "pvs", "pvsets", "simlevel", "restart", "autostart"]
 
-    for ioc_name in new.iocs.keys():
-        if ioc_name not in old.iocs.keys():
-            # If not in previously then add it to start
-            iocs_to_start.add(ioc_name)
-        elif any(getattr(old.iocs[ioc_name], attr) != getattr(new.iocs[ioc_name], attr) for attr in _attributes):
-            # If any attributes have changed, restart the IOC
-            iocs_to_restart.add(ioc_name)
+    for ioc_name in new.keys():
+        if ioc_name not in old.keys():
+            # If not in previously then add it to new iocs
+            new_iocs.add(ioc_name)
+        elif any(getattr(old[ioc_name], attr) != getattr(new[ioc_name], attr) for attr in _attributes):
+            # If any attributes have changed, add to changed iocs
+            changed_iocs.add(ioc_name)
 
-    return iocs_to_start, iocs_to_restart
+    for ioc_name in old.keys():
+        if ioc_name not in new:
+            removed_iocs.add(ioc_name)
+
+    return new_iocs, changed_iocs, removed_iocs
 
 
 class ActiveConfigHolder(ConfigHolder):
@@ -218,31 +225,21 @@ class ActiveConfigHolder(ConfigHolder):
         Returns:
             set, set, set : IOCs to start, IOCs to restart, IOCs to stop.
         """
-        # Look for modified IOCs
-        iocs_to_start, iocs_to_restart = _compare_ioc_properties(self._cached_config, self._config)
-        iocs_to_stop = set()
+        def _get_config_iocs(config, components):
+            iocs = {}
+            for ioc_name, ioc in config.iocs.items():
+                iocs[ioc_name] = ioc
 
-        # Look for any new/changed components
-        for name, component in self._components.items():
-            if name in self._cached_components:
-                _start, _restart = _compare_ioc_properties(
-                    self._cached_components[name], self._components[name])
+            for name, component in components.items():
+                for ioc_name, ioc in component.iocs.items():
+                    iocs[ioc_name] = ioc
+            return iocs
 
-                iocs_to_start |= _start
-                iocs_to_restart |= _restart
-            else:
-                for ioc_name in component.iocs.keys():
-                    iocs_to_start.add(ioc_name)
+        iocs_in_current_config = _get_config_iocs(self._cached_config, self._cached_components)
+        iocs_in_new_config = _get_config_iocs(self._config, self._components)
 
-        # Look for removed IOCs
-        for ioc_name in set(self._cached_config.iocs.keys()).difference(self._config.iocs.keys()):
-            iocs_to_stop.add(ioc_name)
-
-        # Look for any removed components
-        for name, component in self._cached_components.items():
-            if name not in self._components:
-                for ioc_name in component.iocs.keys():
-                    iocs_to_stop.add(ioc_name)
+        new_iocs, changed_iocs, removed_iocs = _compare_ioc_properties(old=iocs_in_current_config,
+                                                                       new=iocs_in_new_config)
 
         # Look for manually-started IOCS, which have been started with unknown macros and therefore should be assumed
         # to need stopping or restarting on config change.
@@ -252,27 +249,26 @@ class ActiveConfigHolder(ConfigHolder):
                 continue
 
             # IOCS which have already been considered as they're part of the cached config or components
-            if ioc_name in self._cached_config.iocs \
-                    or any(ioc_name in comp.iocs for comp in self._cached_components.values()):
+            if ioc_name in iocs_in_current_config:
                 continue
 
             if self._ioc_control.get_ioc_status(ioc_name) == "RUNNING":
-                if ioc_name in self.get_all_ioc_details():
+                if ioc_name in iocs_in_new_config:
                     # If the IOC is in the new config, we need to restart it as the new config may have macros which
                     # were not used when the IOC was manually started outside the config.
-                    if ioc_name in iocs_to_start:
-                        iocs_to_start.remove(ioc_name)
-                    iocs_to_restart.add(ioc_name)
+                    if ioc_name in new_iocs:
+                        new_iocs.remove(ioc_name)
+                    changed_iocs.add(ioc_name)
                 else:
                     # If the IOC is not in the new config, we should stop the IOC to ensure it does not accidentally
                     # interfere with any items being loaded in the new config.
-                    iocs_to_stop.add(ioc_name)
+                    removed_iocs.add(ioc_name)
 
-        print_and_log(f"IOCS to start = {iocs_to_start}")
-        print_and_log(f"IOCS to restart = {iocs_to_restart}")
-        print_and_log(f"IOCS to stop = {iocs_to_stop}")
+        print_and_log(f"New IOCS = {new_iocs}")
+        print_and_log(f"Changed IOCS = {changed_iocs}")
+        print_and_log(f"Removed IOCS = {removed_iocs}")
 
-        return iocs_to_start, iocs_to_restart, iocs_to_stop
+        return new_iocs, changed_iocs, removed_iocs
 
     def _blocks_in_top_level_config_changed(self):
         """

--- a/BlockServer/mocks/mock_procserv_utils.py
+++ b/BlockServer/mocks/mock_procserv_utils.py
@@ -45,7 +45,7 @@ class MockProcServWrapper:
 
     def get_ioc_status(self, ioc):
         if not ioc.lower() in self.ps_status.keys():
-            raise Exception(f"Could not find IOC ({self.prefix + ioc})")
+            return "SHUTDOWN"
         else:
             return self.ps_status[ioc.lower()]
 

--- a/block_server.py
+++ b/block_server.py
@@ -347,10 +347,10 @@ class BlockServer(Driver):
             full_init (bool, optional): whether this requires a full initialisation, e.g. on loading a new
                 configuration
         """
-        iocs_to_start, iocs_to_restart, iocs_to_stop = self._active_configserver.iocs_changed()
+        new_iocs, changed_iocs, removed_iocs = self._active_configserver.iocs_changed()
 
-        self._ioc_control.stop_iocs(iocs_to_stop)
-        self._start_config_iocs(iocs_to_start, iocs_to_restart)
+        self._ioc_control.stop_iocs(removed_iocs)
+        self._start_config_iocs(new_iocs, changed_iocs)
 
         if CAEN_DISCRIMINATOR_IOC_NAME in self._active_configserver.get_ioc_names():
             # See https://github.com/ISISComputingGroup/IBEX/issues/5590 for justification of why this ioc gets


### PR DESCRIPTION
### Description of work

Ensure the blockserver only restarts IOCS which have actually changed.

### To test

https://github.com/IsisComputingGroup/ibex/issues/7135

Also fixes https://github.com/ISISComputingGroup/IBEX/issues/5572

### Acceptance criteria

- Blockserver only restarts IOCs which have changed, even if switching between configs that have different IOCS.
  * Changed means that any of macros/sim level/autorestart/pv values etc have changed, for this particular IOC
- Unit tests in this repo pass
- System tests (see separate PR) also pass

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
