### PR TITLE
Updated name regex & error message

### DIFF
--- a/BlockServer/site_specific/default/block_rules.py
+++ b/BlockServer/site_specific/default/block_rules.py
@@ -19,7 +19,7 @@ from server_common.pv_names import BlockserverPVNames
 
 import json
 
-ALLOWED_BLOCK_NAME_REGEX = r"^[a-zA-Z]\w*$"
+ALLOWED_BLOCK_NAME_REGEX = r"^[a-zA-Z]\w{0,19}$"
 DISALLOWED_BLOCK_NAMES = ["lowlimit", "highlimit", "runcontrol", "wait"]
 BLOCK_REGEX_ERROR_MESSAGE = REGEX_ERROR_TEMPLATE_PV_NAME.format("Block name")
 

--- a/BlockServer/site_specific/default/block_rules.py
+++ b/BlockServer/site_specific/default/block_rules.py
@@ -19,7 +19,7 @@ from server_common.pv_names import BlockserverPVNames
 
 import json
 
-ALLOWED_BLOCK_NAME_REGEX = r"^[a-zA-Z]\w{0,19}$"
+ALLOWED_BLOCK_NAME_REGEX = r"^[a-zA-Z]\w{0,24}$"
 DISALLOWED_BLOCK_NAMES = ["lowlimit", "highlimit", "runcontrol", "wait"]
 BLOCK_REGEX_ERROR_MESSAGE = REGEX_ERROR_TEMPLATE_PV_NAME.format("Block name")
 

--- a/BlockServer/site_specific/default/general_rules.py
+++ b/BlockServer/site_specific/default/general_rules.py
@@ -29,7 +29,7 @@ REGEX_ALLOW_EVERYTHING = r".*$"
 
 """Standard Error message template for when regex for PV like names failes.
 Usage REGEX_ERROR_TEMPLATE_PV_NAME.format(<object name>)"""
-REGEX_ERROR_TEMPLATE_PV_NAME = "{0} must start with a letter and only contain letters, numbers and underscores, and be less than 25 characters long."
+REGEX_ERROR_TEMPLATE_PV_NAME = "{0} must start with a letter and only contain letters, numbers and underscores, and be 25 characters or less."
 REGEX_ERROR_TEMPLATE_ALLOW_EVERYTHING = "{0} should allow all characters"
 
 DISALLOWED_NAMES = ["lowlimit", "highlimit", "runcontrol", "wait"]

--- a/BlockServer/site_specific/default/general_rules.py
+++ b/BlockServer/site_specific/default/general_rules.py
@@ -29,7 +29,7 @@ REGEX_ALLOW_EVERYTHING = r".*$"
 
 """Standard Error message template for when regex for PV like names failes.
 Usage REGEX_ERROR_TEMPLATE_PV_NAME.format(<object name>)"""
-REGEX_ERROR_TEMPLATE_PV_NAME = "{0} must start with a letter and only contain letters, numbers and underscores"
+REGEX_ERROR_TEMPLATE_PV_NAME = "{0} must start with a letter and only contain letters, numbers and underscores, and be less than 20 characters long."
 REGEX_ERROR_TEMPLATE_ALLOW_EVERYTHING = "{0} should allow all characters"
 
 DISALLOWED_NAMES = ["lowlimit", "highlimit", "runcontrol", "wait"]

--- a/BlockServer/site_specific/default/general_rules.py
+++ b/BlockServer/site_specific/default/general_rules.py
@@ -29,7 +29,7 @@ REGEX_ALLOW_EVERYTHING = r".*$"
 
 """Standard Error message template for when regex for PV like names failes.
 Usage REGEX_ERROR_TEMPLATE_PV_NAME.format(<object name>)"""
-REGEX_ERROR_TEMPLATE_PV_NAME = "{0} must start with a letter and only contain letters, numbers and underscores, and be less than 20 characters long."
+REGEX_ERROR_TEMPLATE_PV_NAME = "{0} must start with a letter and only contain letters, numbers and underscores, and be less than 25 characters long."
 REGEX_ERROR_TEMPLATE_ALLOW_EVERYTHING = "{0} should allow all characters"
 
 DISALLOWED_NAMES = ["lowlimit", "highlimit", "runcontrol", "wait"]


### PR DESCRIPTION
### Description of work
Updated block name regex to **limit block name** entry in the GUI to ~~20~~ **25 characters**.
Updated error message to include correct name length.
 
### Ticket: 
https://github.com/ISISComputingGroup/IBEX/issues/3647

### To test
See manual test **20:27, #3647** 

### Acceptance criteria
- Find out what the limit is for this and place a restriction in the GUI configuration.
- Write a test which checks that the run control works for long PV names.
- Check all current configurations for block names that are too long.


### Documentation
Character limit justification: 
~~22 was found to be the actual limit (by checking run control log for different lengths), but to be completely safe, have enforced 20.~~
Using https://github.com/ISISComputingGroup/EPICS-RunControl/pull/14, limit is now 29 as mentioned in comments on ticket, 
**have enforced a limit of 25** for safety.


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
