### PR TITLE
Fix regex error message to have char limit for blocks only

### DIFF
--- a/BlockServer/site_specific/default/block_rules.py
+++ b/BlockServer/site_specific/default/block_rules.py
@@ -21,7 +21,7 @@ import json
 
 ALLOWED_BLOCK_NAME_REGEX = r"^[a-zA-Z]\w{0,24}$"
 DISALLOWED_BLOCK_NAMES = ["lowlimit", "highlimit", "runcontrol", "wait"]
-BLOCK_REGEX_ERROR_MESSAGE = REGEX_ERROR_TEMPLATE_PV_NAME.format("Block name")
+BLOCK_REGEX_ERROR_MESSAGE = REGEX_ERROR_TEMPLATE_PV_NAME.format("Block name") + ", and be 25 characters or less."
 
 
 class BlockRules:

--- a/BlockServer/site_specific/default/general_rules.py
+++ b/BlockServer/site_specific/default/general_rules.py
@@ -29,7 +29,7 @@ REGEX_ALLOW_EVERYTHING = r".*$"
 
 """Standard Error message template for when regex for PV like names failes.
 Usage REGEX_ERROR_TEMPLATE_PV_NAME.format(<object name>)"""
-REGEX_ERROR_TEMPLATE_PV_NAME = "{0} must start with a letter and only contain letters, numbers and underscores, and be 25 characters or less."
+REGEX_ERROR_TEMPLATE_PV_NAME = "{0} must start with a letter and only contain letters, numbers and underscores"
 REGEX_ERROR_TEMPLATE_ALLOW_EVERYTHING = "{0} should allow all characters"
 
 DISALLOWED_NAMES = ["lowlimit", "highlimit", "runcontrol", "wait"]


### PR DESCRIPTION
Refactored edit from this [PR](https://github.com/ISISComputingGroup/EPICS-inst_servers/pull/368) from [Ticket #3647](https://github.com/ISISComputingGroup/IBEX/issues/3647). 
Reverted `REGEX_ERROR_TEMPLATE_PV_NAME` message and specified name length limit in `block_rules.py` locally (as it was being used for group name validation also).
