### PR TITLE
Ticket7656

### DIFF
--- a/server_common/common_exceptions.py
+++ b/server_common/common_exceptions.py
@@ -1,6 +1,2 @@
 class MaxAttemptsExceededException(Exception):
-    def __init__(self, err=""):
-        self.message = str(err)
-
-    def __str__(self):
-        return self.message
+    pass

--- a/server_common/utilities.py
+++ b/server_common/utilities.py
@@ -307,15 +307,16 @@ def retry(max_attempts, interval, exception):
     def _tags_decorator(func):
         def _wrapper(*args, **kwargs):
             attempts = 0
-            ex = ValueError("Max attempts should be > 0, it is {}".format(max_attempts))
+            last_exception = ValueError("Max attempts should be > 0, it is {}".format(max_attempts))
             while attempts < max_attempts:
                 try:
                     return func(*args, **kwargs)
                 except exception as ex:
+                    last_exception = ex
                     attempts += 1
                     time.sleep(interval)
 
-            raise MaxAttemptsExceededException(ex)
+            raise MaxAttemptsExceededException(last_exception)
         return _wrapper
     return _tags_decorator
 


### PR DESCRIPTION
### Description of work

This reduces the restart frequency of the database server when MySQL is down before the server is started. Should probably make connecting to the databases more robust, but the server will restart if there is no connection anyways.

If MySQL stops while the database server is running, logging seems to be a lot more reasonable.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/7656

### Acceptance criteria

See ticket.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
