### PR TITLE
Added a SNMP walker. Added logic to invoke it while building Moxa data

### DIFF
--- a/DatabaseServer/database_server.py
+++ b/DatabaseServer/database_server.py
@@ -205,7 +205,7 @@ class DatabaseServer(Driver):
             if self._iocs is not None:
                 self._iocs.update_iocs_status()
                 for pv in [DbPVNames.IOCS, DbPVNames.HIGH_INTEREST, DbPVNames.MEDIUM_INTEREST, DbPVNames.FACILITY,
-                           DbPVNames.ACTIVE_PVS, DbPVNames.ALL_PVS]:
+                           DbPVNames.ACTIVE_PVS, DbPVNames.ALL_PVS, DbPVNames.MOXA_MAPPINGS]:
                     encoded_data = self.get_data_for_pv(pv)
                     # No need to update monitors if data hasn't changed
                     if not self.getParam(pv) == encoded_data:

--- a/DatabaseServer/moxa_data.py
+++ b/DatabaseServer/moxa_data.py
@@ -172,7 +172,7 @@ class MoxaData():
             with self._snmp_lock:
                 self._snmp_map = newmap
             
-            time.sleep(15)
+            time.sleep(30)
     
     def _get_moxa_num(self):
         return str(len(self._mappings[0].keys()))

--- a/server_common/snmpWalker.py
+++ b/server_common/snmpWalker.py
@@ -1,0 +1,64 @@
+from pysnmp.hlapi import *
+import sys
+from pysnmp.smi import builder, view, compiler, rfc1902
+
+from server_common.utilities import print_and_log, SEVERITY
+
+# Assemble MIB browser
+mibBuilder = builder.MibBuilder()
+mibViewController = view.MibViewController(mibBuilder)
+compiler.addMibCompiler(mibBuilder, sources=['file:///usr/share/snmp/mibs',
+                                             'https://mibs.pysnmp.com/asn1/@mib@'])
+
+# Pre-load MIB modules we expect to work with
+mibBuilder.loadModules("SNMPv2-MIB", "SNMP-COMMUNITY-MIB", "DISMAN-EXPRESSION-MIB", "RFC1213-MIB", "IF-MIB")
+
+INTERESTING_MIBS = ["DISMAN-EXPRESSION-MIB::sysUpTimeInstance", "SNMPv2-MIB::sysName", "IF-MIB::ifOperStatus", "IF-MIB::ifSpeed", "IF-MIB::ifInOctets", "IF-MIB::ifOutOctets"]
+                                             
+def walk(host, oid, requestedMIBs=INTERESTING_MIBS):
+    mibmap = dict()
+    for (errorIndication,
+         errorStatus,
+         errorIndex,
+         varBinds) in nextCmd(SnmpEngine(),
+                              CommunityData('public', mpModel=0),
+                              UdpTransportTarget((host, 161)),
+                              ContextData(),
+                              ObjectType(ObjectIdentity(oid)),
+                              lookupMib=False,
+                              lexicographicMode=False,
+                              lookupNames=True, lookupValues=True):
+
+        if errorIndication:
+            print_and_log("Error:: %s" % errorIndication, severity=SEVERITY.MINOR)
+            #print(errorIndication, file=sys.stderr)
+            break
+
+        elif errorStatus:
+            print_and_log('%s at %s' % (errorStatus.prettyPrint(),
+                                errorIndex and varBinds[int(errorIndex) - 1][0] or '?'), severity=SEVERITY.MAJOR)
+            #print('%s at %s' % (errorStatus.prettyPrint(),
+             #                   errorIndex and varBinds[int(errorIndex) - 1][0] or '?'), file=sys.stderr)
+            break
+
+        else:
+        # Run var-binds through MIB resolver
+        # You may want to catch and ignore resolution errors here
+            varBinds = [
+                rfc1902.ObjectType(rfc1902.ObjectIdentity(x[0]), x[1]).resolveWithMib(mibViewController)
+                for x in varBinds
+            ]
+            for name, value in varBinds:
+                #name, value = varBind[0]
+                mib, exists, port = name.prettyPrint().partition(".")
+                if not exists: port = ''
+                #print(name.prettyPrint(), ' = ', value.prettyPrint())
+                if mib in requestedMIBs:
+                    mibmap[name.prettyPrint()] = value.prettyPrint();
+                    #print('MIB-->', mib, ' port-->', port, ' = ', value.prettyPrint())
+                    #print_and_log('MIB -->%s, port --> %s, = %s' % (mib, port, value)) 
+            
+    print_and_log(mibmap)
+    return mibmap
+
+#walk('130.246.49.46', '1.3.6.1.2.1')

--- a/server_common/snmpWalker.py
+++ b/server_common/snmpWalker.py
@@ -30,15 +30,14 @@ def walk(host, oid, requestedMIBs=INTERESTING_MIBS):
                               lookupNames=True, lookupValues=True):
 
         if errorIndication:
-            print_and_log("Error:: %s" % errorIndication, severity=SEVERITY.MINOR)
-            #print(errorIndication, file=sys.stderr)
+            ## we need to look at later - currently will print forever for a moxa that is
+            ## not on the network. Maybe return status and let caller decide whether to print
+            #print_and_log(f"Error:: for {host}: {errorIndication}", severity=SEVERITY.MINOR)
             break
 
         elif errorStatus:
-            print_and_log('%s at %s' % (errorStatus.prettyPrint(),
+            print_and_log('host %s: %s at %s' % (host, errorStatus.prettyPrint(),
                                 errorIndex and varBinds[int(errorIndex) - 1][0] or '?'), severity=SEVERITY.MAJOR)
-            #print('%s at %s' % (errorStatus.prettyPrint(),
-            #                    errorIndex and varBinds[int(errorIndex) - 1][0] or '?'), file=sys.stderr)
             break
 
         else:
@@ -57,7 +56,6 @@ def walk(host, oid, requestedMIBs=INTERESTING_MIBS):
                     #print('MIB-->', mib, ' port-->', port, ' = ', value.prettyPrint())
                     #print_and_log('MIB -->%s, port --> %s, = %s' % (mib, port, value)) 
             
-    print_and_log(mibmap)
     return mibmap
 
 #walk('130.246.49.46', '1.3.6.1.2.1')


### PR DESCRIPTION
### Description of work

Added a new file to perform SNMP walk and construct the result in a map of user-readable key-value pair.
Modified Moxa data build logic to include MIB level SNMP data. Code doesn't impact the structure of the response that it finally sends to the IBEX GUI.

### To test
https://github.com/ISISComputingGroup/IBEX/issues/8109

### Acceptance criteria
The python module should compile, and all tests should pass.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
