### PR TITLE
Ticket8411 Moved motor_in_set_mode func to genie_advanced

### DIFF
--- a/server_common/helpers.py
+++ b/server_common/helpers.py
@@ -7,6 +7,7 @@ from server_common.channel_access import ChannelAccess
 from server_common.ioc_data_source import IocDataSource
 from genie_python.mysql_abstraction_layer import SQLAbstraction
 from server_common.utilities import print_and_log, SEVERITY
+from genie_python import genie as g
 
 
 def register_ioc_start(ioc_name, pv_database=None, prefix=None):
@@ -42,32 +43,4 @@ def get_macro_values():
     return macros
 
 
-@contextmanager
-def motor_in_set_mode(motor_pv):
-    """
-    Uses a context to place motor into set mode and ensure that it leaves set mode after context has ended. If it
-    can not set the mode correctly will not run the yield.
-    Args:
-        motor_pv: motor pv on which to set the mode
-
-    Returns:
-    """
-
-    calibration_set_pv = "{}.SET".format(motor_pv)
-    offset_freeze_switch_pv = "{}.FOFF".format(motor_pv)
-
-    try:
-        ChannelAccess.caput_retry_on_fail(calibration_set_pv, "Set")
-        offset_freeze_switch = ChannelAccess.caget(offset_freeze_switch_pv)
-        ChannelAccess.caput_retry_on_fail(offset_freeze_switch_pv, "Frozen")
-    except IOError as ex:
-        raise ValueError("Can not set motor set and frozen offset mode: {}".format(ex))
-
-    try:
-        yield
-    finally:
-        try:
-            ChannelAccess.caput_retry_on_fail(calibration_set_pv, "Use")
-            ChannelAccess.caput_retry_on_fail(offset_freeze_switch_pv, offset_freeze_switch)
-        except IOError as ex:
-            raise ValueError("Can not reset motor set and frozen offset mode: {}".format(ex))
+motor_in_set_mode = g.adv.motor_in_set_mode


### PR DESCRIPTION
### Description of work

Moved the motor_in_set_mode function to genie_advanced.py. Keeps a reference in helpers.py to this function so no further changes have to be made.

### To test

*Which ticket does this PR fix?*
[Ticket8411](https://github.com/ISISComputingGroup/IBEX/issues/8411)

### Acceptance criteria

- There are no problems using motor_in_set_mode from the helpers.py file.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
