### PR TITLE
print out when hostname lookup fails

### DIFF
--- a/DatabaseServer/moxa_data.py
+++ b/DatabaseServer/moxa_data.py
@@ -184,13 +184,14 @@ class MoxaData:
 
             time.sleep(30)
 
-    def _get_moxa_num(self):
+    def _get_moxa_num(self) -> str:
         return str(len(self._mappings[0].keys()))
 
-    def _get_hostname(self, ip_addr):
+    def _get_hostname(self, ip_addr: str) -> str:
         try:
             return socket.gethostbyaddr(ip_addr)[0]
         except socket.herror:
+            print(f"unknown hostname for IP address {ip_addr}")
             return "unknown"
 
     def _get_mappings(self) -> Tuple[Dict[str, str], Dict[int, List[Tuple[int, int]]]]:


### PR DESCRIPTION
### Description of work

when a hostname lookup fails (or if a bad IP is given ie `1.1.1.1.` - notice the trailing period) t would be nice to print it out for debugging purposes as it means if you accidentally type the wrong ip in nport driver manager then apply and close it you then need to re-open nport driver manager to see your mistake

### To test

*Which ticket does this PR fix?*

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
