### PR TITLE
remove server_common dependencies on blockserver and dbserver

### DIFF
--- a/BlockServer/component_switcher/component_switcher.py
+++ b/BlockServer/component_switcher/component_switcher.py
@@ -14,7 +14,7 @@ from server_common.utilities import SEVERITY
 from server_common.utilities import print_and_log as _common_print_and_log
 
 
-def print_and_log(message: str, *args, **kwargs):
+def print_and_log(message: str, *args, **kwargs) -> None:
     _common_print_and_log(f"ComponentSwitcher: {message}", *args, **kwargs)
 
 
@@ -47,7 +47,7 @@ class ComponentSwitcher(object):
         reload_current_config_func: types.FunctionType,
         file_manager: ComponentSwitcherConfigFileManager = None,
         channel_access_class: Type[ChannelAccess] = None,
-    ):
+    ) -> None:
         self._config_list = config_list
         self._blockserver_write_queue = blockserver_write_queue
         self._reload_current_config = reload_current_config_func
@@ -90,7 +90,7 @@ class ComponentSwitcher(object):
 
             print_and_log("Adding monitor to PV {}".format(pv))
 
-            def callback(val: Any, stat: int, sevr: int):
+            def callback(val: Any, stat: int, sevr: int) -> None:
                 """
                 Callback function called when the monitored PV changes.
 

--- a/BlockServer/component_switcher/component_switcher.py
+++ b/BlockServer/component_switcher/component_switcher.py
@@ -7,7 +7,8 @@ from queue import Queue
 from typing import Any, Dict, Iterable, List, Set, Type
 
 from BlockServer.core.config_list_manager import ConfigListManager
-from BlockServer.core.macros import MACROS, PVPREFIX_MACRO
+from BlockServer.core.macros import PVPREFIX_MACRO
+from server_common.helpers import MACROS
 from server_common.channel_access import ChannelAccess
 from server_common.utilities import SEVERITY
 from server_common.utilities import print_and_log as _common_print_and_log

--- a/BlockServer/component_switcher/component_switcher.py
+++ b/BlockServer/component_switcher/component_switcher.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, Iterable, List, Set, Type
 
 from BlockServer.core.config_list_manager import ConfigListManager
 from BlockServer.core.macros import PVPREFIX_MACRO
-from server_common.helpers import MACROS
 from server_common.channel_access import ChannelAccess
+from server_common.helpers import MACROS
 from server_common.utilities import SEVERITY
 from server_common.utilities import print_and_log as _common_print_and_log
 

--- a/BlockServer/component_switcher/component_switcher.py
+++ b/BlockServer/component_switcher/component_switcher.py
@@ -103,14 +103,16 @@ class ComponentSwitcher(object):
 
                 if stat != 0 or sevr != 0:
                     print_and_log(
-                        f"Got value '{val}' (stat={stat}, sevr={sevr}) for pv '{pv}', ignoring as it has "
+                        f"Got value '{val}' (stat={stat}, sevr={sevr}) for "
+                        f"pv '{pv}', ignoring as it has "
                         f"non-zero STAT/SEVR"
                     )
                     return
 
                 if val not in value_to_component_map:
                     print_and_log(
-                        f"Got value '{val}' (stat={stat}, sevr={sevr}) for pv '{pv}', ignoring as value did "
+                        f"Got value '{val}' (stat={stat}, sevr={sevr}) for "
+                        f"pv '{pv}', ignoring as value did "
                         f"not map to any component"
                     )
                     return
@@ -119,12 +121,14 @@ class ComponentSwitcher(object):
                 comps_to_add = {value_to_component_map[val]}
 
                 print_and_log(
-                    f"Got value '{val}' (stat={stat}, sevr={sevr}) for pv '{pv}'. Editing configurations to "
+                    f"Got value '{val}' (stat={stat}, sevr={sevr}) "
+                    f"for pv '{pv}'. Editing configurations to "
                     f"remove components {comps_to_remove} and add components {comps_to_add}."
                 )
 
-                # Put these actions onto the blockserver write queue so that we avoid any multithreading problems
-                # with concurrent edits from multiple sources in the blockserver. This also ensures we don't do any
+                # Put these actions onto the blockserver write queue so that we avoid
+                # any multithreading problems with concurrent edits from multiple sources in the
+                # blockserver. This also ensures we don't do any
                 # CA calls from within a monitor context, which would be invalid.
                 self._blockserver_write_queue.put(
                     (
@@ -143,8 +147,10 @@ class ComponentSwitcher(object):
         Edits all configurations by adding or removing the specified components.
 
         Args:
-            components_to_be_removed: A set of component names which will be removed from all configurations if present
-            components_to_be_added: A set of component names which will be added to all configurations
+            components_to_be_removed: A set of component names which will be removed from
+             all configurations if present
+            components_to_be_added: A set of component names which will be added to
+             all configurations
         """
 
         current_config_name = self._config_list.active_config_name

--- a/BlockServer/core/active_config_holder.py
+++ b/BlockServer/core/active_config_holder.py
@@ -50,12 +50,15 @@ def _blocks_changed(block1, block2) -> bool:
 
 def _blocks_changed_in_config(old_config, new_config, block_comparator=_blocks_changed) -> bool:
     """
-    Given a new configuration/component and an old one, find out whether blocks have changed between them.
+    Given a new configuration/component and an old one, find out whether blocks have changed between
+     them.
 
     Args:
-        old_config: A configuration or component object describing the "old" config to use as a reference.
+        old_config: A configuration or component object describing the "old" config to use as
+         a reference.
         new_config: A configuration or component object describing the "new" config/component.
-        block_comparator: A function that takes two blocks as arguments and returns True if they have changed.
+        block_comparator: A function that takes two blocks as arguments and returns True if they
+         have changed.
 
     Returns:
         True if the blocks have changed, False otherwise.
@@ -122,7 +125,8 @@ class ActiveConfigHolder(ConfigHolder):
         Args:
             macros (dict): The BlockServer macros
             archive_manager (ArchiverManager): Responsible for updating the archiver
-            file_manager (ConfigurationFileManager|MockVersionControl): Deals with writing the config files
+            file_manager (ConfigurationFileManager|MockVersionControl): Deals with writing the
+            config files
             ioc_control (IocControl): Manages stopping and starting IOCs
         """
         super(ActiveConfigHolder, self).__init__(macros, file_manager)
@@ -225,7 +229,8 @@ class ActiveConfigHolder(ConfigHolder):
         - IOCs removed from top level config
         - Added components which contain IOCs
         - Removed components which contained IOCs
-        - IOCs properties changed in the top level configuration ("macros", "pvs", "pvsets", "simlevel", "restart")
+        - IOCs properties changed in the top level configuration
+         ("macros", "pvs", "pvsets", "simlevel", "restart")
         - IOCs properties changed in components of the current configuration (as above)
 
         Returns:
@@ -249,33 +254,39 @@ class ActiveConfigHolder(ConfigHolder):
             old=iocs_in_current_config, new=iocs_in_new_config
         )
 
-        # Look for manually-started IOCS, which have been started with unknown macros and therefore should be assumed
+        # Look for manually-started IOCS, which have been started with unknown macros
+        # and therefore should be assumed
         # to need stopping or restarting on config change.
         for ioc_name in get_iocs(CONTROL_SYSTEM_PREFIX):
             # IOCS which shouldn't be stopped.
             if any(ioc_name.startswith(x) for x in IOCS_NOT_TO_STOP):
                 continue
 
-            # IOCS which have already been considered as they're part of the cached config or components
+            # IOCS which have already been considered as they're part of the
+            # cached config or components
             if ioc_name in iocs_in_current_config:
                 continue
 
             if self._ioc_control.get_ioc_status(ioc_name) == "RUNNING":
                 if ioc_name in iocs_in_new_config:
-                    # If the IOC is in the new config, we need to restart it as the new config may have macros which
-                    # were not used when the IOC was manually started outside the config.
+                    # If the IOC is in the new config, we need to restart it as the new config
+                    # may have macros which were not used when the IOC was manually
+                    # started outside the config.
                     print_and_log(
-                        f"Found manually-started IOC {ioc_name}. Restarting as present in new config."
+                        f"Found manually-started IOC {ioc_name}. Restarting as present "
+                        f"in new config."
                     )
                     if ioc_name in new_iocs:
                         new_iocs.remove(ioc_name)
 
                     changed_iocs.add(ioc_name)
                 else:
-                    # If the IOC is not in the new config, we should stop the IOC to ensure it does not accidentally
-                    # interfere with any items being loaded in the new config.
+                    # If the IOC is not in the new config, we should stop the IOC to ensure
+                    # it does not accidentally interfere with any items being loaded
+                    # in the new config.
                     print_and_log(
-                        f"Found manually-started IOC {ioc_name}. Stopping as not present in new config"
+                        f"Found manually-started IOC {ioc_name}. "
+                        f"Stopping as not present in new config"
                     )
                     removed_iocs.add(ioc_name)
 
@@ -309,7 +320,8 @@ class ActiveConfigHolder(ConfigHolder):
 
     def _blocks_removed_from_top_level_config(self):
         """
-        Checks whether any blocks have been removed from the top level configuration (does not recurse to components)
+        Checks whether any blocks have been removed from the top level configuration
+        (does not recurse to components)
 
         Returns:
             True if blocks have been removed from the top-level config; False otherwise
@@ -322,8 +334,10 @@ class ActiveConfigHolder(ConfigHolder):
         Checks whether there are any new blocks when moving between two sets of components.
 
         Args:
-            old_components (dict): Dictionary of components in the form {component_name: component, ...}
-            new_components (dict): Dictionary of components in the form {component_name: component, ...}
+            old_components (dict): Dictionary of components in the form
+             {component_name: component, ...}
+            new_components (dict): Dictionary of components in the form
+             {component_name: component, ...}
 
         Returns:
             True if switching from components1 to components2 would have added any blocks.
@@ -333,7 +347,7 @@ class ActiveConfigHolder(ConfigHolder):
                 return True
         return False
 
-    def _new_components_containing_blocks(self):
+    def _new_components_containing_blocks(self) -> bool:
         """
         Checks whether there are any new components which contain blocks.
 
@@ -342,7 +356,7 @@ class ActiveConfigHolder(ConfigHolder):
         """
         return ActiveConfigHolder._check_for_added_blocks(self._cached_components, self._components)
 
-    def _removed_components_containing_blocks(self):
+    def _removed_components_containing_blocks(self) -> bool:
         """
         Checks whether there are any removed components which contained blocks.
 
@@ -353,7 +367,7 @@ class ActiveConfigHolder(ConfigHolder):
         # Check for removed blocks == check for added blocks in the other direction.
         return ActiveConfigHolder._check_for_added_blocks(self._components, self._cached_components)
 
-    def blocks_changed(self):
+    def blocks_changed(self) -> bool:
         """
         Checks to see if the Blocks have changed on saving."
 
@@ -370,11 +384,11 @@ class ActiveConfigHolder(ConfigHolder):
             or self._removed_components_containing_blocks()
         )
 
-    def contains_rc_settings(self):
+    def contains_rc_settings(self) -> str:
         return os.path.exists(self.get_rc_settings_filepath())
 
-    def get_rc_settings_filepath(self):
+    def get_rc_settings_filepath(self) -> str:
         return os.path.join(self.get_active_config_dir(), "rc_settings.cmd")
 
-    def get_active_config_dir(self):
+    def get_active_config_dir(self) -> str:
         return os.path.join(self._config_dir, "configurations", self.get_config_name())

--- a/BlockServer/core/active_config_holder.py
+++ b/BlockServer/core/active_config_holder.py
@@ -20,7 +20,8 @@ from BlockServer.config.ioc import IOC
 from BlockServer.core.config_holder import ConfigHolder
 from BlockServer.core.database_client import get_iocs
 from BlockServer.core.file_path_manager import FILEPATH_MANAGER
-from BlockServer.core.macros import BLOCK_PREFIX, CONTROL_SYSTEM_PREFIX, MACROS
+from BlockServer.core.macros import BLOCK_PREFIX
+from server_common.helpers import MACROS, CONTROL_SYSTEM_PREFIX
 from server_common.constants import IOCS_NOT_TO_STOP
 from server_common.utilities import print_and_log
 

--- a/BlockServer/core/active_config_holder.py
+++ b/BlockServer/core/active_config_holder.py
@@ -26,7 +26,7 @@ from server_common.helpers import CONTROL_SYSTEM_PREFIX, MACROS
 from server_common.utilities import print_and_log
 
 
-def _blocks_changed(block1, block2):
+def _blocks_changed(block1, block2) -> bool:
     """
     Compare two Block objects
 
@@ -48,7 +48,7 @@ def _blocks_changed(block1, block2):
     return False
 
 
-def _blocks_changed_in_config(old_config, new_config, block_comparator=_blocks_changed):
+def _blocks_changed_in_config(old_config, new_config, block_comparator=_blocks_changed) -> bool:
     """
     Given a new configuration/component and an old one, find out whether blocks have changed between them.
 
@@ -116,7 +116,7 @@ class ActiveConfigHolder(ConfigHolder):
     Class to serve up the active configuration.
     """
 
-    def __init__(self, macros, archive_manager, file_manager, ioc_control, config_dir):
+    def __init__(self, macros, archive_manager, file_manager, ioc_control, config_dir) -> None:
         """Constructor.
 
         Args:
@@ -130,7 +130,7 @@ class ActiveConfigHolder(ConfigHolder):
         self._ioc_control = ioc_control
         self._config_dir = config_dir
 
-    def save_active(self, name, as_comp=False):
+    def save_active(self, name, as_comp=False) -> None:
         """Save the active configuration.
 
         Args:
@@ -143,7 +143,7 @@ class ActiveConfigHolder(ConfigHolder):
             self.save_configuration(name, False)
             self.set_last_config(name)
 
-    def load_active(self, name):
+    def load_active(self, name) -> None:
         """Load a configuration as the active configuration.
         Cannot load a component as the active configuration.
 
@@ -153,7 +153,7 @@ class ActiveConfigHolder(ConfigHolder):
         self.set_config(self.load_configuration(name))
         self.set_last_config(name)
 
-    def update_archiver(self, full_init=False):
+    def update_archiver(self, full_init=False) -> None:
         """Update the archiver configuration.
 
         Args:
@@ -167,7 +167,7 @@ class ActiveConfigHolder(ConfigHolder):
                 os.path.join(self._config_dir, "configurations", self.get_config_name()),
             )
 
-    def set_last_config(self, config_name):
+    def set_last_config(self, config_name) -> None:
         """Save the last configuration used to file.
 
         The last configuration is saved without any file path.
@@ -207,7 +207,7 @@ class ActiveConfigHolder(ConfigHolder):
         self.load_active(last_config_name)
         return last_config_name
 
-    def reload_current_config(self):
+    def reload_current_config(self) -> None:
         """Reload the current configuration."""
         current_config_name = self.get_config_name()
         if current_config_name == "":
@@ -294,7 +294,7 @@ class ActiveConfigHolder(ConfigHolder):
         """
         return _blocks_changed_in_config(self._cached_config, self._config)
 
-    def _blocks_in_components_changed(self):
+    def _blocks_in_components_changed(self) -> bool:
         """
         Checks whether blocks that appear in both the old and the new components have changed.
 
@@ -317,7 +317,7 @@ class ActiveConfigHolder(ConfigHolder):
         return any(name not in self._config.blocks for name in self._cached_config.blocks)
 
     @staticmethod
-    def _check_for_added_blocks(old_components, new_components):
+    def _check_for_added_blocks(old_components, new_components) -> bool:
         """
         Checks whether there are any new blocks when moving between two sets of components.
 

--- a/BlockServer/core/active_config_holder.py
+++ b/BlockServer/core/active_config_holder.py
@@ -21,8 +21,8 @@ from BlockServer.core.config_holder import ConfigHolder
 from BlockServer.core.database_client import get_iocs
 from BlockServer.core.file_path_manager import FILEPATH_MANAGER
 from BlockServer.core.macros import BLOCK_PREFIX
-from server_common.helpers import MACROS, CONTROL_SYSTEM_PREFIX
 from server_common.constants import IOCS_NOT_TO_STOP
+from server_common.helpers import CONTROL_SYSTEM_PREFIX, MACROS
 from server_common.utilities import print_and_log
 
 

--- a/BlockServer/core/active_config_holder.py
+++ b/BlockServer/core/active_config_holder.py
@@ -384,7 +384,7 @@ class ActiveConfigHolder(ConfigHolder):
             or self._removed_components_containing_blocks()
         )
 
-    def contains_rc_settings(self) -> str:
+    def contains_rc_settings(self) -> bool:
         return os.path.exists(self.get_rc_settings_filepath())
 
     def get_rc_settings_filepath(self) -> str:

--- a/BlockServer/core/config_list_manager.py
+++ b/BlockServer/core/config_list_manager.py
@@ -19,6 +19,7 @@ import os
 import traceback
 from functools import wraps
 from threading import RLock
+from typing import TYPE_CHECKING
 
 from BlockServer.core.config_list_manager_exceptions import InvalidDeleteException
 from BlockServer.core.constants import DEFAULT_COMPONENT
@@ -35,6 +36,10 @@ from server_common.utilities import (
     lowercase_and_make_unique,
     print_and_log,
 )
+
+if TYPE_CHECKING:
+    from block_server import BlockServer
+    from BlockServer.fileIO.file_manager import ConfigurationFileManager
 
 
 def needs_lock(func):
@@ -66,7 +71,8 @@ def update_monitors_when_finished(func):
 
 def deletion_context(func):
     """
-    Decorator which takes out the config manager lock, and updates monitors after decorated function has finished
+    Decorator which takes out the config manager lock,
+    and updates monitors after decorated function has finished
     """
     return needs_lock(update_monitors_when_finished(func))
 
@@ -79,7 +85,12 @@ class ConfigListManager:
         active_components (list): The names of the components in the active configuration
     """
 
-    def __init__(self, block_server, file_manager, channel_access=ChannelAccess()) -> None:
+    def __init__(
+        self,
+        block_server: "BlockServer",
+        file_manager: "ConfigurationFileManager",
+        channel_access: ChannelAccess = ChannelAccess(),
+    ) -> None:
         """Constructor.
 
         Args:
@@ -111,21 +122,22 @@ class ConfigListManager:
         self._bs.setParam(fullname, data)
         self._bs.updatePVs()
 
-    def _delete_pv(self, fullname) -> None:
+    def _delete_pv(self, fullname: str) -> None:
         self._bs.delete_pv_from_db(fullname)
 
-    def _get_config_names(self):
+    def _get_config_names(self) -> list:
         return self._get_file_list(os.path.abspath(self._conf_path))
 
-    def _get_component_names(self):
+    def _get_component_names(self) -> list:
         comp_list = self._get_file_list(os.path.abspath(self._comp_path))
         return [component_name for component_name in comp_list]
 
-    def _get_file_list(self, path):
+    def _get_file_list(self, path: str):
         return self.file_manager.get_files_in_directory(path)
 
     def get_configs(self):
-        """Returns all of the valid configurations, made up of those found on startup and those subsequently created.
+        """Returns all of the valid configurations,
+        made up of those found on startup and those subsequently created.
 
         Returns:
             list : A list of available configurations
@@ -136,7 +148,8 @@ class ConfigListManager:
         return configs_string
 
     def get_components(self):
-        """Returns all of the valid components, made up of those found on startup and those subsequently created.
+        """Returns all of the valid components,
+        made up of those found on startup and those subsequently created.
 
         Returns:
             list : A list of available components
@@ -175,7 +188,7 @@ class ConfigListManager:
                 print_and_log(f"Error in loading config: {err}", "MINOR")
                 print_and_log(traceback.format_exc())
 
-    def load_config(self, name, is_component=False):
+    def load_config(self, name: str, is_component: bool = False) -> InactiveConfigHolder:
         """Loads an inactive configuration or component.
 
         Args:
@@ -189,7 +202,7 @@ class ConfigListManager:
         config.load_inactive(name, is_component)
         return config
 
-    def _update_component_dependencies_pv(self, name) -> None:
+    def _update_component_dependencies_pv(self, name: str) -> None:
         # Updates PV with list of configs that depend on a component
         configs = []
         if name in self._comp_dependencies.keys():
@@ -210,7 +223,7 @@ class ConfigListManager:
         self._update_pv_value(pv_name, compress_and_hex(json.dumps(data)))
 
     @needs_lock
-    def update(self, config, is_component=False) -> None:
+    def update(self, config, is_component: bool = False) -> None:
         """Updates the PVs associated with a configuration
 
         Args:
@@ -237,7 +250,8 @@ class ConfigListManager:
 
     @update_monitors_when_finished
     def update_a_config_in_list(self, config, is_component=False) -> None:
-        """Takes a ConfigServerManager object and updates the list of meta data and the individual PVs.
+        """Takes a ConfigServerManager object and updates the list of meta data and
+        the individual PVs.
 
         Args:
             config (ConfigHolder): The configuration holder
@@ -284,8 +298,9 @@ class ConfigListManager:
                 self._comp_dependencies[comp.lower()].remove(config)
                 self._update_component_dependencies_pv(comp.lower())
 
-    def _get_pv_name(self, config_name, is_component=False):
-        """Returns the name of the pv corresponding to config_name, this name is generated if not already created."""
+    def _get_pv_name(self, config_name: str, is_component: bool = False) -> str:
+        """Returns the name of the pv corresponding to config_name,
+        this name is generated if not already created."""
         if not is_component:
             if config_name in self._config_metas:
                 pv_name = self._config_metas[config_name].pv
@@ -320,7 +335,7 @@ class ConfigListManager:
         for config in delete_list:
             self._delete_single_config(config)
 
-    def _delete_single_config(self, config) -> None:
+    def _delete_single_config(self, config: str) -> None:
         try:
             self.file_manager.delete(config, is_component=False)
         except MaxAttemptsExceededException:
@@ -337,7 +352,7 @@ class ConfigListManager:
         self._remove_config_from_dependencies(config)
 
     @deletion_context
-    def delete_components(self, delete_list) -> None:
+    def delete_components(self, delete_list: list[str]) -> None:
         """
         Deletes all components in supplied list
 
@@ -374,7 +389,7 @@ class ConfigListManager:
         for component in lower_delete_list:
             self._delete_single_component(component)
 
-    def _delete_single_component(self, component) -> None:
+    def _delete_single_component(self, component: str) -> None:
         """
         Deletes a single component
 
@@ -401,7 +416,7 @@ class ConfigListManager:
         del self.all_components[component]
 
     @needs_lock
-    def get_dependencies(self, comp_name):
+    def get_dependencies(self, comp_name: str) -> dict[str, list[str]]:
         """Get the names of any configurations that depend on this component.
 
         Args:

--- a/BlockServer/core/config_list_manager.py
+++ b/BlockServer/core/config_list_manager.py
@@ -24,9 +24,9 @@ from BlockServer.core.config_list_manager_exceptions import InvalidDeleteExcepti
 from BlockServer.core.constants import DEFAULT_COMPONENT
 from BlockServer.core.file_path_manager import FILEPATH_MANAGER
 from BlockServer.core.inactive_config_holder import InactiveConfigHolder
-from server_common.helpers import MACROS
 from server_common.channel_access import ChannelAccess, verify_manager_mode
 from server_common.common_exceptions import MaxAttemptsExceededException
+from server_common.helpers import MACROS
 from server_common.pv_names import BlockserverPVNames
 from server_common.utilities import (
     compress_and_hex,

--- a/BlockServer/core/config_list_manager.py
+++ b/BlockServer/core/config_list_manager.py
@@ -79,7 +79,7 @@ class ConfigListManager:
         active_components (list): The names of the components in the active configuration
     """
 
-    def __init__(self, block_server, file_manager, channel_access=ChannelAccess()):
+    def __init__(self, block_server, file_manager, channel_access=ChannelAccess()) -> None:
         """Constructor.
 
         Args:
@@ -103,7 +103,7 @@ class ConfigListManager:
         self._comp_path = FILEPATH_MANAGER.component_dir
         self._import_configs()
 
-    def _update_pv_value(self, fullname, data):
+    def _update_pv_value(self, fullname, data) -> None:
         # First check PV exists if not create it
         if not self._bs.does_pv_exist(fullname):
             self._bs.add_string_pv_to_db(fullname, count=16000)
@@ -111,7 +111,7 @@ class ConfigListManager:
         self._bs.setParam(fullname, data)
         self._bs.updatePVs()
 
-    def _delete_pv(self, fullname):
+    def _delete_pv(self, fullname) -> None:
         self._bs.delete_pv_from_db(fullname)
 
     def _get_config_names(self):
@@ -147,7 +147,7 @@ class ConfigListManager:
                 comps.append(cv.to_dict())
         return comps
 
-    def _import_configs(self):
+    def _import_configs(self) -> None:
         # Create the pvs and get meta data
         config_list = self._get_config_names()
         comp_list = self._get_component_names()
@@ -189,7 +189,7 @@ class ConfigListManager:
         config.load_inactive(name, is_component)
         return config
 
-    def _update_component_dependencies_pv(self, name):
+    def _update_component_dependencies_pv(self, name) -> None:
         # Updates PV with list of configs that depend on a component
         configs = []
         if name in self._comp_dependencies.keys():
@@ -199,18 +199,18 @@ class ConfigListManager:
             pv_name = BlockserverPVNames.get_dependencies_pv(self._component_metas[name].pv)
             self._update_pv_value(pv_name, compress_and_hex(json.dumps(configs)))
 
-    def _update_config_pv(self, name, data):
+    def _update_config_pv(self, name, data) -> None:
         # Updates pvs with new data
         pv_name = BlockserverPVNames.get_config_details_pv(self._config_metas[name].pv)
         self._update_pv_value(pv_name, compress_and_hex(json.dumps(data)))
 
-    def _update_component_pv(self, name, data):
+    def _update_component_pv(self, name, data) -> None:
         # Updates pvs with new data
         pv_name = BlockserverPVNames.get_component_details_pv(self._component_metas[name].pv)
         self._update_pv_value(pv_name, compress_and_hex(json.dumps(data)))
 
     @needs_lock
-    def update(self, config, is_component=False):
+    def update(self, config, is_component=False) -> None:
         """Updates the PVs associated with a configuration
 
         Args:
@@ -236,7 +236,7 @@ class ConfigListManager:
                 )
 
     @update_monitors_when_finished
-    def update_a_config_in_list(self, config, is_component=False):
+    def update_a_config_in_list(self, config, is_component=False) -> None:
         """Takes a ConfigServerManager object and updates the list of meta data and the individual PVs.
 
         Args:
@@ -277,7 +277,7 @@ class ConfigListManager:
                     self._comp_dependencies[comp.lower()] = [config.get_config_name()]
                 self._update_component_dependencies_pv(comp.lower())
 
-    def _remove_config_from_dependencies(self, config):
+    def _remove_config_from_dependencies(self, config) -> None:
         # Remove old config from dependencies list
         for comp, confs in self._comp_dependencies.items():
             if config in confs:
@@ -301,7 +301,7 @@ class ConfigListManager:
         return pv_name
 
     @deletion_context
-    def delete_configs(self, delete_list):
+    def delete_configs(self, delete_list) -> None:
         print_and_log(f"Deleting configurations: {', '.join(list(delete_list))}", "INFO")
         lower_delete_list = lowercase_and_make_unique(delete_list)
 
@@ -320,7 +320,7 @@ class ConfigListManager:
         for config in delete_list:
             self._delete_single_config(config)
 
-    def _delete_single_config(self, config):
+    def _delete_single_config(self, config) -> None:
         try:
             self.file_manager.delete(config, is_component=False)
         except MaxAttemptsExceededException:
@@ -337,7 +337,7 @@ class ConfigListManager:
         self._remove_config_from_dependencies(config)
 
     @deletion_context
-    def delete_components(self, delete_list):
+    def delete_components(self, delete_list) -> None:
         """
         Deletes all components in supplied list
 
@@ -374,7 +374,7 @@ class ConfigListManager:
         for component in lower_delete_list:
             self._delete_single_component(component)
 
-    def _delete_single_component(self, component):
+    def _delete_single_component(self, component) -> None:
         """
         Deletes a single component
 
@@ -413,7 +413,7 @@ class ConfigListManager:
         dependencies = self._comp_dependencies.get(comp_name.lower())
         return [] if dependencies is None else dependencies
 
-    def update_monitors(self):
+    def update_monitors(self) -> None:
         with self._bs.monitor_lock:
             print_and_log("Updating config list monitors")
             # Set the available configs

--- a/BlockServer/core/config_list_manager.py
+++ b/BlockServer/core/config_list_manager.py
@@ -24,7 +24,7 @@ from BlockServer.core.config_list_manager_exceptions import InvalidDeleteExcepti
 from BlockServer.core.constants import DEFAULT_COMPONENT
 from BlockServer.core.file_path_manager import FILEPATH_MANAGER
 from BlockServer.core.inactive_config_holder import InactiveConfigHolder
-from BlockServer.core.macros import MACROS
+from server_common.helpers import MACROS
 from server_common.channel_access import ChannelAccess, verify_manager_mode
 from server_common.common_exceptions import MaxAttemptsExceededException
 from server_common.pv_names import BlockserverPVNames

--- a/BlockServer/core/macros.py
+++ b/BlockServer/core/macros.py
@@ -14,23 +14,6 @@
 # https://www.eclipse.org/org/documents/epl-v10.php or
 # http://opensource.org/licenses/eclipse-1.0.php
 
-import os
-
-
-def _get_env_var(name):
-    try:
-        return os.environ[name]
-    except:
-        return ""
-
-
-MACROS = {
-    "$(MYPVPREFIX)": _get_env_var("MYPVPREFIX"),
-    "$(EPICS_KIT_ROOT)": _get_env_var("EPICS_KIT_ROOT"),
-    "$(ICPCONFIGROOT)": _get_env_var("ICPCONFIGROOT"),
-    "$(ICPVARDIR)": _get_env_var("ICPVARDIR"),
-}
 
 BLOCK_PREFIX = "CS:SB:"
-CONTROL_SYSTEM_PREFIX = MACROS["$(MYPVPREFIX)"] + "CS:"
 PVPREFIX_MACRO = "$(MYPVPREFIX)"

--- a/BlockServer/devices/devices_manager.py
+++ b/BlockServer/devices/devices_manager.py
@@ -87,7 +87,7 @@ class DevicesManager(OnTheFlyPvInterface):
                 self.update_monitors()
             except IOError as err:
                 print_and_log(
-                    f"Could not save device screens: {err} " f"The PV data will not be updated.",
+                    f"Could not save device screens: {err} The PV data will not be updated.",
                     "MINOR",
                 )
 

--- a/BlockServer/devices/devices_manager.py
+++ b/BlockServer/devices/devices_manager.py
@@ -91,7 +91,7 @@ class DevicesManager(OnTheFlyPvInterface):
                     "MINOR",
                 )
 
-    def handle_pv_read(self, _) -> None:
+    def handle_pv_read(self, _: str) -> None:
         """
         Nothing to do as it is all handled by monitors
         """
@@ -125,7 +125,8 @@ class DevicesManager(OnTheFlyPvInterface):
         except (MaxAttemptsExceededException, IOError):
             self._data = self.get_blank_devices()
             print_and_log(
-                "Unable to load devices file. Please check the file is not in use by another process. "
+                "Unable to load devices file. "
+                "Please check the file is not in use by another process. "
                 "The PV data will default to a blank set of devices.",
                 "MINOR",
             )
@@ -181,7 +182,8 @@ class DevicesManager(OnTheFlyPvInterface):
             self._file_io.save_devices_file(self.get_devices_filename(), xml_data_as_bytes)
         except MaxAttemptsExceededException:
             raise IOError(
-                "Unable to save devices file. Please check the file is not in use by another process."
+                "Unable to save devices file. "
+                "Please check the file is not in use by another process."
             )
 
         # Update PVs
@@ -191,7 +193,8 @@ class DevicesManager(OnTheFlyPvInterface):
     def get_devices_schema(self) -> bytes:
         """Gets the XSD data for the devices screens.
 
-        Note: Only reads file once, if the file changes then the BlockServer will need to be restarted
+        Note: Only reads file once, if the file changes then the BlockServer
+        will need to be restarted
 
         Returns:
             str : The XML for the devices screens schema

--- a/BlockServer/devices/devices_manager.py
+++ b/BlockServer/devices/devices_manager.py
@@ -48,7 +48,7 @@ class DevicesManager(OnTheFlyPvInterface):
         block_server: "BlockServer",
         schema_folder: str,
         file_io: DevicesFileIO = DevicesFileIO(),
-    ):
+    ) -> None:
         """Constructor.
 
         Args:
@@ -68,13 +68,13 @@ class DevicesManager(OnTheFlyPvInterface):
         self._load_current()
         self.update_monitors()
 
-    def _create_standard_pvs(self):
+    def _create_standard_pvs(self) -> None:
         """Creates new PVs holding information relevant to the device screens."""
         self._bs.add_string_pv_to_db(GET_SCREENS, 16000)
         self._bs.add_string_pv_to_db(SET_SCREENS, 16000)
         self._bs.add_string_pv_to_db(GET_SCHEMA, 16000)
 
-    def handle_pv_write(self, pv: str, data: str):
+    def handle_pv_write(self, pv: str, data: str) -> None:
         """Handles the request to write device screen PVs.
 
         Args:
@@ -91,14 +91,14 @@ class DevicesManager(OnTheFlyPvInterface):
                     "MINOR",
                 )
 
-    def handle_pv_read(self, _):
+    def handle_pv_read(self, _) -> None:
         """
         Nothing to do as it is all handled by monitors
         """
 
         pass
 
-    def update_monitors(self):
+    def update_monitors(self) -> None:
         """Writes new device screens data to PVs"""
         with self._bs.monitor_lock:
             print_and_log("Updating devices monitors")
@@ -108,7 +108,7 @@ class DevicesManager(OnTheFlyPvInterface):
             self._bs.setParam(GET_SCREENS, compress_and_hex(self._data.decode("utf-8")))
             self._bs.updatePVs()
 
-    def on_config_change(self, full_init=False):
+    def on_config_change(self, full_init=False) -> None:
         """
         Devices don't need to change with config
 
@@ -117,7 +117,7 @@ class DevicesManager(OnTheFlyPvInterface):
         """
         pass
 
-    def _load_current(self):
+    def _load_current(self) -> None:
         """Gets the devices XML for the current instrument"""
         # Read the data from file
         try:
@@ -149,7 +149,7 @@ class DevicesManager(OnTheFlyPvInterface):
 
         return os.path.join(FILEPATH_MANAGER.devices_dir, SCREENS_FILE)
 
-    def update(self, xml_data: bytes, message: str = None):
+    def update(self, xml_data: bytes, message: str = None) -> None:
         """Updates the current device screens with new data.
 
         Args:
@@ -160,7 +160,7 @@ class DevicesManager(OnTheFlyPvInterface):
         self._data = xml_data
         self.update_monitors()
 
-    def save_devices_xml(self, xml_data: str):
+    def save_devices_xml(self, xml_data: str) -> None:
         """Saves the xml in the current "screens.xml" config file.
 
         Args:

--- a/BlockServer/epics/gateway.py
+++ b/BlockServer/epics/gateway.py
@@ -19,8 +19,8 @@ import re
 import time
 from shutil import copyfile
 
-from server_common.helpers import CONTROL_SYSTEM_PREFIX
 from server_common.channel_access import ChannelAccess
+from server_common.helpers import CONTROL_SYSTEM_PREFIX
 from server_common.utilities import print_and_log
 
 ALIAS_HEADER = """\
@@ -65,7 +65,7 @@ def build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv, include_com
 
         # Pattern match is for picking up any extras like :RBV or .EGU
         lines.append(
-            f'{full_block_pv}\\([.:].*\\)    ALIAS    {underlying_pv.replace(pv_suffix, "")}\\1'
+            f"{full_block_pv}\\([.:].*\\)    ALIAS    {underlying_pv.replace(pv_suffix, '')}\\1"
         )
         lines.append(f"{full_block_pv}[.]VAL    ALIAS    {underlying_pv}")
     else:

--- a/BlockServer/epics/gateway.py
+++ b/BlockServer/epics/gateway.py
@@ -38,10 +38,12 @@ ALIAS_FOOTER = r"""
 {0}CS:SB:[^:]*:[ADR]C:.*                     DENY
 ## ignore any request not related to local blocks or gateway itself
 !{0}CS:\(SB\|GATEWAY\):.*                    DENY
-"""
+"""  # noqa: E501
 
 
-def build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv, include_comments=True):
+def build_block_alias_lines(
+    full_block_pv: str, pv_suffix: str, underlying_pv: str, include_comments: bool = True
+) -> list[str]:
     lines = list()
     if underlying_pv.endswith(":SP"):
         # The block points at a setpoint
@@ -59,8 +61,8 @@ def build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv, include_com
         # The block points at a readback value (most likely for a motor)
         if include_comments:
             lines.append(
-                f"## The block points at a {pv_suffix} field, so it needs entries for both reading the field "
-                f"and for the rest"
+                f"## The block points at a {pv_suffix} field, so it needs entries for"
+                f" both reading the field and for the rest"
             )
 
         # Pattern match is for picking up any extras like :RBV or .EGU
@@ -82,24 +84,28 @@ def build_block_alias_lines(full_block_pv, pv_suffix, underlying_pv, include_com
 
 
 class Gateway:
-    """A class for interacting with the EPICS gateway that creates the aliases used for implementing blocks"""
+    """A class for interacting with the EPICS gateway that creates the aliases used
+    for implementing blocks"""
 
     def __init__(
         self,
-        gateway_prefix,
-        instrument_prefix,
-        pvlist_file,
-        block_prefix,
-        control_sys_prefix=CONTROL_SYSTEM_PREFIX,
+        gateway_prefix: str,
+        instrument_prefix: str,
+        pvlist_file: str,
+        block_prefix: str,
+        control_sys_prefix: str = CONTROL_SYSTEM_PREFIX,
     ) -> None:
         """Constructor.
 
         Args:
-            gateway_prefix (string): The full prefix for the gateway, including the instrument prefix etc.
+            gateway_prefix (string): The full prefix for the gateway, including the
+            instrument prefix etc.
             instrument_prefix (string): Prefix for instrument PVs
             pvlist_file (string): Where to write the gateway file
-            block_prefix (string): The prefix for information about a block, including the instrument_prefix etc.
-            control_sys_prefix (string): The prefix for the control system, including the instrument_prefix etc.
+            block_prefix (string): The prefix for information about a block, including
+             the instrument_prefix etc.
+            control_sys_prefix (string): The prefix for the control system, including
+             the instrument_prefix etc.
         """
         self._gateway_prefix = gateway_prefix
         self._block_prefix = block_prefix
@@ -107,7 +113,7 @@ class Gateway:
         self._inst_prefix = instrument_prefix
         self._control_sys_prefix = control_sys_prefix
 
-    def exists(self):
+    def exists(self) -> bool:
         """Checks the gateway exists by querying one of the PVs.
 
         Returns:
@@ -118,7 +124,8 @@ class Gateway:
     def _reload(self) -> None:
         print_and_log("Reloading gateway")
         try:
-            # Have to wait after put as the gateway does not do completion callbacks (it is not an IOC)
+            # Have to wait after put as the gateway does not do completion callbacks
+            # (it is not an IOC)
             ChannelAccess.caput(self._gateway_prefix + "newAsFlag", 1)
 
             while ChannelAccess.caget(self._gateway_prefix + "newAsFlag") == 1:
@@ -140,7 +147,7 @@ class Gateway:
             # Add a blank line at the end!
             f.write("\n")
 
-    def generate_alias(self, block_name, underlying_pv, local):
+    def generate_alias(self, block_name: str, underlying_pv: str, local: bool) -> list[str]:
         print_and_log(f"Creating block: {block_name} for {underlying_pv}")
 
         underlying_pv = underlying_pv.replace(".VAL", "")
@@ -168,14 +175,15 @@ class Gateway:
         lines.append("")  # New line to seperate out each block
         return lines
 
-    def set_new_aliases(self, blocks, configures_block_gateway, config_dir) -> None:
+    def set_new_aliases(self, blocks, configures_block_gateway: bool, config_dir: str) -> None:
         """Creates the aliases for the blocks and restarts the gateway.
 
         Args:
             blocks (OrderedDict): The blocks that belong to the configuration
-            configures_block_gateway (bool): If true indicates that the config contains a gwblock.pvlist to configure
-                the block gateway with.
-            config_dir (str): The directory the configuration we are loading the blocks for lives in.
+            configures_block_gateway (bool): If true indicates that the config contains a
+             gwblock.pvlist to configure the block gateway with.
+            config_dir (str): The directory the configuration we are loading the
+             blocks for lives in.
         """
         pvlist_file = os.path.join(config_dir, "gwblock.pvlist")
         if configures_block_gateway and os.path.exists(pvlist_file):

--- a/BlockServer/epics/gateway.py
+++ b/BlockServer/epics/gateway.py
@@ -19,7 +19,7 @@ import re
 import time
 from shutil import copyfile
 
-from BlockServer.core.macros import CONTROL_SYSTEM_PREFIX
+from server_common.helpers import CONTROL_SYSTEM_PREFIX
 from server_common.channel_access import ChannelAccess
 from server_common.utilities import print_and_log
 

--- a/BlockServer/epics/gateway.py
+++ b/BlockServer/epics/gateway.py
@@ -91,7 +91,7 @@ class Gateway:
         pvlist_file,
         block_prefix,
         control_sys_prefix=CONTROL_SYSTEM_PREFIX,
-    ):
+    ) -> None:
         """Constructor.
 
         Args:
@@ -115,7 +115,7 @@ class Gateway:
         """
         return ChannelAccess.caget(self._gateway_prefix + "pvtotal") is not None
 
-    def _reload(self):
+    def _reload(self) -> None:
         print_and_log("Reloading gateway")
         try:
             # Have to wait after put as the gateway does not do completion callbacks (it is not an IOC)
@@ -127,7 +127,7 @@ class Gateway:
         except Exception as err:
             print_and_log(f"Problem with reloading the gateway {err}")
 
-    def _generate_alias_file(self, blocks=None):
+    def _generate_alias_file(self, blocks=None) -> None:
         # Generate blocks.pvlist for gateway
         with open(self._pvlist_file, "w") as f:
             header = ALIAS_HEADER.format(self._inst_prefix)
@@ -168,7 +168,7 @@ class Gateway:
         lines.append("")  # New line to seperate out each block
         return lines
 
-    def set_new_aliases(self, blocks, configures_block_gateway, config_dir):
+    def set_new_aliases(self, blocks, configures_block_gateway, config_dir) -> None:
         """Creates the aliases for the blocks and restarts the gateway.
 
         Args:

--- a/BlockServer/fileIO/file_manager.py
+++ b/BlockServer/fileIO/file_manager.py
@@ -296,7 +296,7 @@ class ConfigurationFileManager:
             f.write(data)
             return
 
-    def get_files_in_directory(self, path):
+    def get_files_in_directory(self, path:str)->list[str]:
         """Gets a list of the files in the specified folder
 
         Args:

--- a/BlockServer/test_modules/test_active_config_holder.py
+++ b/BlockServer/test_modules/test_active_config_holder.py
@@ -30,7 +30,7 @@ from BlockServer.core.active_config_holder import (
     _blocks_changed_in_config,
     _compare_ioc_properties,
 )
-from BlockServer.core.macros import MACROS
+from server_common.helpers import MACROS
 from BlockServer.mocks.mock_file_manager import MockConfigurationFileManager
 from BlockServer.mocks.mock_ioc_control import MockIocControl
 from BlockServer.test_modules.helpers import modify_active

--- a/BlockServer/test_modules/test_active_config_holder.py
+++ b/BlockServer/test_modules/test_active_config_holder.py
@@ -30,11 +30,11 @@ from BlockServer.core.active_config_holder import (
     _blocks_changed_in_config,
     _compare_ioc_properties,
 )
-from server_common.helpers import MACROS
 from BlockServer.mocks.mock_file_manager import MockConfigurationFileManager
 from BlockServer.mocks.mock_ioc_control import MockIocControl
 from BlockServer.test_modules.helpers import modify_active
 from server_common.constants import IS_LINUX
+from server_common.helpers import MACROS
 
 CONFIG_PATH = "./test_configs/"
 BASE_PATH = "./example_base/"

--- a/BlockServer/test_modules/test_component_switcher.py
+++ b/BlockServer/test_modules/test_component_switcher.py
@@ -100,14 +100,14 @@ class TestComponentSwitcher(unittest.TestCase):
         self.assertEqual(MockChannelAccess.MONITORS[0][0], "first")
         self.assertEqual(MockChannelAccess.MONITORS[1][0], "second")
 
-    @mock.patch.dict("BlockServer.core.macros.MACROS", {PVPREFIX_MACRO: "some_prefix:"})
+    @mock.patch.dict("server_common.helpers.MACROS", {PVPREFIX_MACRO: "some_prefix:"})
     def test_GIVEN_local_pv_monitored_THEN_monitored_pv_has_local_prefix_appended(self):
         self.file_manager.config = [{"pv": "first", "is_local": True, "value_to_component_map": {}}]
 
         self.component_switcher.create_monitors()
         self.assertEqual(MockChannelAccess.MONITORS[0][0], "some_prefix:first")
 
-    @mock.patch.dict("BlockServer.core.macros.MACROS", {PVPREFIX_MACRO: "some_prefix:"})
+    @mock.patch.dict("server_common.helpers.MACROS", {PVPREFIX_MACRO: "some_prefix:"})
     def test_GIVEN_non_local_pv_monitored_THEN_monitored_pv_does_not_have_local_prefix_appended(
         self,
     ):

--- a/BlockServer/test_modules/test_config_holder.py
+++ b/BlockServer/test_modules/test_config_holder.py
@@ -22,8 +22,8 @@ from BlockServer.config.configuration import Configuration
 from BlockServer.core.config_holder import ConfigHolder
 from BlockServer.core.constants import DEFAULT_COMPONENT
 from BlockServer.core.inactive_config_holder import InactiveConfigHolder
-from server_common.helpers import MACROS
 from BlockServer.mocks.mock_file_manager import MockConfigurationFileManager
+from server_common.helpers import MACROS
 
 CONFIG_PATH = "./test_configs/"
 BASE_PATH = "./example_base/"

--- a/BlockServer/test_modules/test_config_holder.py
+++ b/BlockServer/test_modules/test_config_holder.py
@@ -22,7 +22,7 @@ from BlockServer.config.configuration import Configuration
 from BlockServer.core.config_holder import ConfigHolder
 from BlockServer.core.constants import DEFAULT_COMPONENT
 from BlockServer.core.inactive_config_holder import InactiveConfigHolder
-from BlockServer.core.macros import MACROS
+from server_common.helpers import MACROS
 from BlockServer.mocks.mock_file_manager import MockConfigurationFileManager
 
 CONFIG_PATH = "./test_configs/"

--- a/BlockServer/test_modules/test_config_list_manager.py
+++ b/BlockServer/test_modules/test_config_list_manager.py
@@ -22,7 +22,7 @@ from BlockServer.core.active_config_holder import ActiveConfigHolder
 from BlockServer.core.config_list_manager import ConfigListManager, InvalidDeleteException
 from BlockServer.core.constants import DEFAULT_COMPONENT
 from BlockServer.core.inactive_config_holder import InactiveConfigHolder
-from BlockServer.core.macros import MACROS
+from server_common.helpers import MACROS
 from BlockServer.epics.archiver_manager import ArchiverManager
 from BlockServer.mocks.mock_archiver_wrapper import MockArchiverWrapper
 from BlockServer.mocks.mock_block_server import MockBlockServer

--- a/BlockServer/test_modules/test_config_list_manager.py
+++ b/BlockServer/test_modules/test_config_list_manager.py
@@ -28,7 +28,7 @@ from BlockServer.mocks.mock_block_server import MockBlockServer
 from BlockServer.mocks.mock_channel_access import MockChannelAccess
 from BlockServer.mocks.mock_file_manager import MockConfigurationFileManager
 from BlockServer.mocks.mock_ioc_control import MockIocControl
-from server_common.channel_access import ManagerModeRequiredException
+from server_common.channel_access import ManagerModeRequiredError
 from server_common.helpers import MACROS
 from server_common.pv_names import prepend_blockserver
 from server_common.utilities import create_pv_name
@@ -629,7 +629,7 @@ class TestInactiveConfigsSequence(unittest.TestCase):
 
         self.clm._config_metas["test_config1"].isProtected = True
 
-        with self.assertRaises(ManagerModeRequiredException):
+        with self.assertRaises(ManagerModeRequiredError):
             self.clm.delete_configs(["TEST_CONFIG1"])
 
     def test_GIVEN_manager_mode_active_WHEN_protected_component_deleted_THEN_successful(self):
@@ -649,5 +649,5 @@ class TestInactiveConfigsSequence(unittest.TestCase):
 
         self.clm._component_metas["test_component1"].isProtected = True
 
-        with self.assertRaises(ManagerModeRequiredException):
+        with self.assertRaises(ManagerModeRequiredError):
             self.clm.delete_components(["TEST_COMPONENT1"])

--- a/BlockServer/test_modules/test_config_list_manager.py
+++ b/BlockServer/test_modules/test_config_list_manager.py
@@ -22,7 +22,6 @@ from BlockServer.core.active_config_holder import ActiveConfigHolder
 from BlockServer.core.config_list_manager import ConfigListManager, InvalidDeleteException
 from BlockServer.core.constants import DEFAULT_COMPONENT
 from BlockServer.core.inactive_config_holder import InactiveConfigHolder
-from server_common.helpers import MACROS
 from BlockServer.epics.archiver_manager import ArchiverManager
 from BlockServer.mocks.mock_archiver_wrapper import MockArchiverWrapper
 from BlockServer.mocks.mock_block_server import MockBlockServer
@@ -30,6 +29,7 @@ from BlockServer.mocks.mock_channel_access import MockChannelAccess
 from BlockServer.mocks.mock_file_manager import MockConfigurationFileManager
 from BlockServer.mocks.mock_ioc_control import MockIocControl
 from server_common.channel_access import ManagerModeRequiredException
+from server_common.helpers import MACROS
 from server_common.pv_names import prepend_blockserver
 from server_common.utilities import create_pv_name
 

--- a/BlockServer/test_modules/test_configuration.py
+++ b/BlockServer/test_modules/test_configuration.py
@@ -16,11 +16,11 @@
 import unittest
 
 from BlockServer.config.configuration import Configuration
-from server_common.helpers import MACROS
 from BlockServer.mocks.mock_configuration import (
     MockConfigurationFileManager,
     MockConfigurationJsonConverter,
 )
+from server_common.helpers import MACROS
 
 # Args are : name, pv, group, local and visible
 NEW_BLOCK_ARGS = {

--- a/BlockServer/test_modules/test_configuration.py
+++ b/BlockServer/test_modules/test_configuration.py
@@ -103,7 +103,7 @@ class TestConfigurationSequence(unittest.TestCase):
         # assert
         try:
             cf.add_ioc(ioc_name)
-        except:
+        except:  # noqa: E722
             self.fail("Adding the same ioc twice raised Exception unexpectedly!")
 
     def test_get_blocks_names_returns_empty_list_when_no_blocks(self):

--- a/BlockServer/test_modules/test_configuration.py
+++ b/BlockServer/test_modules/test_configuration.py
@@ -16,7 +16,7 @@
 import unittest
 
 from BlockServer.config.configuration import Configuration
-from BlockServer.core.macros import MACROS
+from server_common.helpers import MACROS
 from BlockServer.mocks.mock_configuration import (
     MockConfigurationFileManager,
     MockConfigurationJsonConverter,

--- a/BlockServer/test_modules/test_configuration_xml.py
+++ b/BlockServer/test_modules/test_configuration_xml.py
@@ -25,7 +25,7 @@ from BlockServer.config.group import Group
 from BlockServer.config.ioc import IOC
 from BlockServer.config.metadata import MetaData
 from BlockServer.config.xml_converter import ConfigurationXmlConverter
-from BlockServer.core.macros import MACROS
+from server_common.helpers import MACROS
 
 BLOCKS_XML = """
 <?xml version="1.0" ?>

--- a/BlockServer/test_modules/test_configuration_xml.py
+++ b/BlockServer/test_modules/test_configuration_xml.py
@@ -197,12 +197,12 @@ def make_groups():
 
 def make_iocs():
     iocs = OrderedDict()
-    SIM_LEVELS = ["recsim", "devsim"]
+    sim_levels = ["recsim", "devsim"]
     for i in range(1, 3):
         iocs["TESTIOC" + str(i)] = IOC("TESTIOC" + str(i))
         iocs["TESTIOC" + str(i)].autostart = True
         iocs["TESTIOC" + str(i)].restart = False
-        iocs["TESTIOC" + str(i)].simlevel = SIM_LEVELS[i - 1]
+        iocs["TESTIOC" + str(i)].simlevel = sim_levels[i - 1]
         iocs["TESTIOC" + str(i)].macros["TESTIOC1MACRO"] = {"value": i}
         iocs["TESTIOC" + str(i)].macros["TESTIOC2MACRO"] = {"value": i}
         iocs["TESTIOC" + str(i)].pvs["TESTIOC1PV"] = {"value": i}

--- a/BlockServer/test_modules/test_schema_checker.py
+++ b/BlockServer/test_modules/test_schema_checker.py
@@ -22,12 +22,12 @@ from BlockServer.config.configuration import Configuration
 from BlockServer.config.xml_converter import ConfigurationXmlConverter
 from BlockServer.core.file_path_manager import FILEPATH_MANAGER
 from BlockServer.core.inactive_config_holder import InactiveConfigHolder
-from server_common.helpers import MACROS
 from BlockServer.fileIO.schema_checker import (
     ConfigurationInvalidUnderSchema,
     ConfigurationSchemaChecker,
 )
 from BlockServer.mocks.mock_file_manager import MockConfigurationFileManager
+from server_common.helpers import MACROS
 
 TEST_DIRECTORY = os.path.abspath("test_configs")
 SCRIPT_DIRECTORY = os.path.abspath("test_scripts")

--- a/BlockServer/test_modules/test_schema_checker.py
+++ b/BlockServer/test_modules/test_schema_checker.py
@@ -123,7 +123,7 @@ class TestSchemaChecker(unittest.TestCase):
             ConfigurationSchemaChecker.check_xml_data_matches_schema(
                 os.path.join(self.schema_dir, "blocks.xsd"), xml
             )
-        except:
+        except:  # noqa: E722
             self.fail()
 
     def test_blocks_xml_does_not_match_schema_raises(self):
@@ -202,7 +202,7 @@ class TestSchemaChecker(unittest.TestCase):
             ConfigurationSchemaChecker.check_xml_data_matches_schema(
                 os.path.join(self.schema_dir, "meta.xsd"), xml
             )
-        except:
+        except:  # noqa: E722
             self.fail()
 
     def test_meta_xml_does_not_match_schema_raises(self):
@@ -230,7 +230,7 @@ class TestSchemaChecker(unittest.TestCase):
             ConfigurationSchemaChecker.check_xml_data_matches_schema(
                 os.path.join(self.schema_dir, "components.xsd"), xml
             )
-        except:
+        except:  # noqa: E722
             self.fail()
 
     def test_components_xml_does_not_match_schema_raises(self):

--- a/BlockServer/test_modules/test_schema_checker.py
+++ b/BlockServer/test_modules/test_schema_checker.py
@@ -22,7 +22,7 @@ from BlockServer.config.configuration import Configuration
 from BlockServer.config.xml_converter import ConfigurationXmlConverter
 from BlockServer.core.file_path_manager import FILEPATH_MANAGER
 from BlockServer.core.inactive_config_holder import InactiveConfigHolder
-from BlockServer.core.macros import MACROS
+from server_common.helpers import MACROS
 from BlockServer.fileIO.schema_checker import (
     ConfigurationInvalidUnderSchema,
     ConfigurationSchemaChecker,

--- a/DatabaseServer/test_modules/test_database_server.py
+++ b/DatabaseServer/test_modules/test_database_server.py
@@ -28,7 +28,7 @@ import unittest
 
 from DatabaseServer.database_server import DatabaseServer
 from DatabaseServer.mocks.mock_exp_data import MockExpData
-from DatabaseServer.mocks.mock_procserv_utils import MockProcServWrapper
+from server_common.mocks.mock_procserv_utils import MockProcServWrapper
 from server_common.constants import IS_LINUX
 from server_common.ioc_data import IOCData
 from server_common.loggers.logger import Logger

--- a/DatabaseServer/test_modules/test_database_server.py
+++ b/DatabaseServer/test_modules/test_database_server.py
@@ -28,12 +28,12 @@ import unittest
 
 from DatabaseServer.database_server import DatabaseServer
 from DatabaseServer.mocks.mock_exp_data import MockExpData
-from server_common.mocks.mock_procserv_utils import MockProcServWrapper
 from server_common.constants import IS_LINUX
 from server_common.ioc_data import IOCData
 from server_common.loggers.logger import Logger
 from server_common.mocks.mock_ca_server import MockCAServer
 from server_common.mocks.mock_ioc_data_source import IOCS, MockIocDataSource
+from server_common.mocks.mock_procserv_utils import MockProcServWrapper
 from server_common.pv_names import DatabasePVNames
 from server_common.test_modules.test_ioc_data import (
     FACILITY_PV_NAMES,

--- a/block_server.py
+++ b/block_server.py
@@ -41,7 +41,8 @@ from BlockServer.core.config_list_manager import ConfigListManager
 from BlockServer.core.file_path_manager import FILEPATH_MANAGER
 from BlockServer.core.inactive_config_holder import InactiveConfigHolder
 from BlockServer.core.ioc_control import IocControl
-from BlockServer.core.macros import BLOCK_PREFIX, CONTROL_SYSTEM_PREFIX, MACROS, PVPREFIX_MACRO
+from BlockServer.core.macros import BLOCK_PREFIX, PVPREFIX_MACRO
+from server_common.helpers import MACROS, CONTROL_SYSTEM_PREFIX
 from BlockServer.devices.devices_manager import DevicesManager
 from BlockServer.epics.archiver_manager import ArchiverManager
 from BlockServer.epics.gateway import Gateway

--- a/block_server.py
+++ b/block_server.py
@@ -117,7 +117,7 @@ initial_dbs = {
 class BlockServer(Driver):
     """The class for handling all the static PV access and monitors etc."""
 
-    def __init__(self, ca_server):
+    def __init__(self, ca_server) -> None:
         """Constructor.
 
         Args:
@@ -215,7 +215,7 @@ class BlockServer(Driver):
         )
         self._component_switcher.create_monitors()
 
-    def initialise_configserver(self, facility):
+    def initialise_configserver(self, facility) -> None:
         """Initialises the ActiveConfigHolder.
 
         Args:
@@ -384,7 +384,7 @@ class BlockServer(Driver):
             self.setParam(reason, value)
         return status
 
-    def load_last_config(self):
+    def load_last_config(self) -> None:
         """Loads the last configuration used.
 
         The information is saved in a text file.
@@ -397,7 +397,7 @@ class BlockServer(Driver):
             print_and_log("Loaded last configuration: %s" % last)
         self._initialise_config()
 
-    def _set_curr_config(self, details):
+    def _set_curr_config(self, details) -> None:
         """Sets the current configuration details to that defined in the JSON, saves to disk,
         then re-initialises the current configuration.
 
@@ -419,7 +419,7 @@ class BlockServer(Driver):
 
         self.save_config(details)
 
-    def _initialise_config(self, full_init=False):
+    def _initialise_config(self, full_init=False) -> None:
         """Responsible for initialising the configuration.
         Sets all the monitors, initialises the gateway, etc.
 
@@ -476,7 +476,7 @@ class BlockServer(Driver):
         self.server.set_config(convert_to_json(self._active_configserver.get_config_details()))
         self.write_queue.put((self.set_config_block_values, (), "LOADING_BLOCK_SETS"))
 
-    def _start_config_iocs(self, iocs_to_start, iocs_to_restart):
+    def _start_config_iocs(self, iocs_to_start, iocs_to_restart) -> None:
         # Start the IOCs, if they are available and if they are flagged for autostart
         # Note: autostart means the IOC is started when the config is loaded,
         # restart means the IOC should automatically restart if it stops for some reason (e.g. it crashes)
@@ -511,7 +511,7 @@ class BlockServer(Driver):
             ]
         )
 
-    def load_config(self, config, full_init=True):
+    def load_config(self, config, full_init=True) -> None:
         """Load a configuration.
 
         Args:
@@ -527,7 +527,7 @@ class BlockServer(Driver):
             print_and_log(f"Exception while loading configuration '{config}': {err}", "MAJOR")
             traceback.print_exc()
 
-    def reload_current_config(self):
+    def reload_current_config(self) -> None:
         """Reload the current configuration."""
         try:
             print_and_log("Reloading current configuration")
@@ -539,7 +539,7 @@ class BlockServer(Driver):
             )
             traceback.print_exc()
 
-    def save_config(self, json_data, as_comp=False):
+    def save_config(self, json_data, as_comp=False) -> None:
         """Save a configuration.
 
         Args:
@@ -622,7 +622,7 @@ class BlockServer(Driver):
     def _get_timestamp(self):
         return datetime.datetime.strftime(datetime.datetime.now(), "%Y-%m-%d %H:%M:%S")
 
-    def update_blocks_monitors(self):
+    def update_blocks_monitors(self) -> None:
         """Updates the PV monitors for the blocks and groups, so the clients can see any changes."""
         with self.monitor_lock:
             block_names = convert_to_json(self._active_configserver.get_blocknames())
@@ -635,7 +635,7 @@ class BlockServer(Driver):
 
             self.updatePVs()
 
-    def update_server_status(self, status=""):
+    def update_server_status(self, status="") -> None:
         """Updates the monitor for the server status, so the clients can see any changes.
 
         Args:
@@ -649,7 +649,7 @@ class BlockServer(Driver):
                 )
                 self.updatePVs()
 
-    def update_get_details_monitors(self):
+    def update_get_details_monitors(self) -> None:
         """Updates the monitor for the active configuration, so the clients can see any changes."""
         with self.monitor_lock:
             config_details_json = convert_to_json(self._active_configserver.get_config_details())
@@ -658,7 +658,7 @@ class BlockServer(Driver):
             )
             self.updatePVs()
 
-    def update_wd_details_monitors(self):
+    def update_wd_details_monitors(self) -> None:
         """Updates the monitor for the active configuration, so the web dashboard can see any changes."""
         with self.monitor_lock:
             config_details_json = convert_to_json(
@@ -671,7 +671,7 @@ class BlockServer(Driver):
             self.setParam(BlockserverPVNames.WD_CONF_DETAILS, compress_and_hex(config_details_json))
             self.updatePVs()
 
-    def update_curr_config_name_monitors(self):
+    def update_curr_config_name_monitors(self) -> None:
         """Updates the monitor for the active configuration name, so the clients can see any changes."""
         with self.monitor_lock:
             self.setParam(
@@ -680,7 +680,7 @@ class BlockServer(Driver):
             self.setParam(BlockserverPVNames.CURR_CONFIG_NAME_SEVR, CURR_CONFIG_NAME_SEVR_VALUE)
             self.updatePVs()
 
-    def consume_write_queue(self):
+    def consume_write_queue(self) -> None:
         """Actions any requests on the write queue.
 
         Queue items are tuples with three values:
@@ -713,7 +713,7 @@ class BlockServer(Driver):
         temp_config = InactiveConfigHolder(MACROS, ConfigurationFileManager())
         return temp_config.get_config_details()
 
-    def start_iocs(self, iocs):
+    def start_iocs(self, iocs) -> None:
         # If the IOC is in the config and auto-restart is set to true then
         # reapply the auto-restart setting after starting.
         # This is because stopping an IOC via procServ turns auto-restart off.
@@ -739,7 +739,7 @@ class BlockServer(Driver):
         return name in manager.pvs[self.port]
 
     # Code for handling block-sets
-    def set_config_block_values(self):
+    def set_config_block_values(self) -> None:
         blocks = {
             block_details
             for block_details in self._active_configserver.get_block_details().values()
@@ -765,7 +765,7 @@ class BlockServer(Driver):
             else:
                 ChannelAccess.caput(pv, block_details.set_block_val)
 
-    def delete_pv_from_db(self, name):
+    def delete_pv_from_db(self, name) -> None:
         if name in manager.pvs[self.port]:
             print_and_log(f"Removing PV {name}")
             fullname = manager.pvs[self.port][name].name
@@ -773,7 +773,7 @@ class BlockServer(Driver):
             del manager.pvf[fullname]
             del self.pvDB[name]
 
-    def add_string_pv_to_db(self, name, count=1000):
+    def add_string_pv_to_db(self, name, count=1000) -> None:
         # Check name not already in PVDB and that a PV does not already exist
         if name not in manager.pvs[self.port]:
             try:

--- a/block_server.py
+++ b/block_server.py
@@ -42,7 +42,6 @@ from BlockServer.core.file_path_manager import FILEPATH_MANAGER
 from BlockServer.core.inactive_config_holder import InactiveConfigHolder
 from BlockServer.core.ioc_control import IocControl
 from BlockServer.core.macros import BLOCK_PREFIX, PVPREFIX_MACRO
-from server_common.helpers import MACROS, CONTROL_SYSTEM_PREFIX
 from BlockServer.devices.devices_manager import DevicesManager
 from BlockServer.epics.archiver_manager import ArchiverManager
 from BlockServer.epics.gateway import Gateway
@@ -61,6 +60,7 @@ from ConfigVersionControl.version_control_exceptions import (
     VersionControlException,
 )
 from server_common.channel_access import ChannelAccess
+from server_common.helpers import CONTROL_SYSTEM_PREFIX, MACROS
 from server_common.pv_names import BlockserverPVNames
 from server_common.utilities import (
     char_waveform,

--- a/server_common/channel_access.py
+++ b/server_common/channel_access.py
@@ -35,7 +35,7 @@ except ImportError:
         The system is unable to connect to a PV for some reason.
         """
 
-        def __init__(self, pv_name, err):
+        def __init__(self, pv_name, err) -> None:
             super(UnableToConnectToPVException, self).__init__(
                 "Unable to connect to PV {0}: {1}".format(pv_name, err)
             )
@@ -45,7 +45,7 @@ except ImportError:
         PV exists but its value is unavailable to read.
         """
 
-        def __init__(self, pv_name):
+        def __init__(self, pv_name) -> None:
             super(ReadAccessException, self).__init__(
                 "Read access denied for PV {}".format(pv_name)
             )
@@ -125,7 +125,7 @@ class ChannelAccess(object):
     thread_pool = _create_caput_pool()
 
     @staticmethod
-    def wait_for_tasks():
+    def wait_for_tasks() -> None:
         """
         Wait for all requested tasks to complete, i.e. all caputs.
 
@@ -184,7 +184,7 @@ class ChannelAccess(object):
             # linux build to fail to load the entire class.
             set_pv_value = CaChannelWrapper.set_pv_value
 
-        def _put_value():
+        def _put_value() -> None:
             set_pv_value(name, value, wait, safe_not_quick=safe_not_quick)
 
         if wait:
@@ -197,7 +197,7 @@ class ChannelAccess(object):
             return ChannelAccess.thread_pool.submit(_put_value)
 
     @staticmethod
-    def caput_retry_on_fail(pv_name, value, retry_count=5, safe_not_quick=True):
+    def caput_retry_on_fail(pv_name, value, retry_count=5, safe_not_quick=True) -> None:
         """
         Write to a pv and check the value is set, retry if not; raise if run out of retries
         Args:
@@ -240,7 +240,7 @@ class ChannelAccess(object):
         return CaChannelWrapper.pv_exists(name, timeout)
 
     @staticmethod
-    def add_monitor(name, call_back_function):
+    def add_monitor(name, call_back_function) -> None:
         """
         Add a callback to a pv which responds on a monitor (i.e. value change). This currently only tested for
         numbers.
@@ -253,7 +253,7 @@ class ChannelAccess(object):
         CaChannelWrapper.add_monitor(name, call_back_function)
 
     @staticmethod
-    def poll():
+    def poll() -> None:
         """
         Flush the send buffer and execute any outstanding background activity for all connected pvs.
         NB Connected pv is one which is in the cache
@@ -261,7 +261,7 @@ class ChannelAccess(object):
         CaChannelWrapper.poll()
 
     @staticmethod
-    def clear_monitor(name):
+    def clear_monitor(name) -> None:
         """
         Clears the monitor on a pv if it exists
         """
@@ -276,13 +276,13 @@ class ManagerModeRequiredException(Exception):
     Exception to be thrown if manager mode was required, but not enabled, for an operation.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(ManagerModeRequiredException, self).__init__(*args, **kwargs)
 
 
 def verify_manager_mode(
     channel_access=ChannelAccess(), message="Operation must be performed in manager mode"
-):
+) -> None:
     """
     Verifies that manager mode is active, throwing an error if it was not active.
 

--- a/server_common/channel_access.py
+++ b/server_common/channel_access.py
@@ -309,9 +309,7 @@ def verify_manager_mode(
         )
     except Exception as e:
         raise ManagerModeRequiredException(
-            "Manager mode is required, but an unknown exception occurred " "(caused by: {})".format(
-                e
-            )
+            "Manager mode is required, but an unknown exception occurred (caused by: {})".format(e)
         )
 
     if not is_manager:

--- a/server_common/channel_access.py
+++ b/server_common/channel_access.py
@@ -17,7 +17,7 @@ from concurrent.futures import ThreadPoolExecutor
 # along with this program; if not, you can obtain a copy from
 # https://www.eclipse.org/org/documents/epl-v10.php or
 # http://opensource.org/licenses/eclipse-1.0.php
-from BlockServer.core.macros import MACROS
+from server_common.helpers import MACROS
 from server_common.utilities import print_and_log
 
 # Number of threads to serve caputs

--- a/server_common/helpers.py
+++ b/server_common/helpers.py
@@ -45,3 +45,19 @@ def get_macro_values():
 
 
 motor_in_set_mode = g.adv.motor_in_set_mode
+
+
+def _get_env_var(name):
+    try:
+        return os.environ[name]
+    except:
+        return ""
+
+
+MACROS = {
+    "$(MYPVPREFIX)": _get_env_var("MYPVPREFIX"),
+    "$(EPICS_KIT_ROOT)": _get_env_var("EPICS_KIT_ROOT"),
+    "$(ICPCONFIGROOT)": _get_env_var("ICPCONFIGROOT"),
+    "$(ICPVARDIR)": _get_env_var("ICPVARDIR"),
+}
+CONTROL_SYSTEM_PREFIX = MACROS["$(MYPVPREFIX)"] + "CS:"

--- a/server_common/helpers.py
+++ b/server_common/helpers.py
@@ -9,7 +9,7 @@ from server_common.ioc_data_source import IocDataSource
 from server_common.utilities import SEVERITY, print_and_log
 
 
-def register_ioc_start(ioc_name, pv_database=None, prefix=None):
+def register_ioc_start(ioc_name, pv_database=None, prefix=None) -> None:
     """
     A helper function to register the start of an ioc.
     Args:

--- a/server_common/helpers.py
+++ b/server_common/helpers.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from typing import Dict
 
 from genie_python import genie as g
 from genie_python.mysql_abstraction_layer import SQLAbstraction
@@ -9,7 +10,11 @@ from server_common.ioc_data_source import IocDataSource
 from server_common.utilities import SEVERITY, print_and_log
 
 
-def register_ioc_start(ioc_name, pv_database=None, prefix=None) -> None:
+def register_ioc_start(
+    ioc_name: str,
+    pv_database: Dict[str, Dict[str, str]] = None,
+    prefix: str | None = None,
+) -> None:
     """
     A helper function to register the start of an ioc.
     Args:
@@ -28,11 +33,12 @@ def register_ioc_start(ioc_name, pv_database=None, prefix=None) -> None:
         ioc_data_source.insert_ioc_start(ioc_name, os.getpid(), exepath, pv_database, prefix)
     except Exception as e:
         print_and_log(
-            "Error registering ioc start: {}: {}".format(e.__class__.__name__, e), SEVERITY.MAJOR
+            "Error registering ioc start: {}: {}".format(e.__class__.__name__, e),
+            SEVERITY.MAJOR,
         )
 
 
-def get_macro_values():
+def get_macro_values() -> Dict[str, str]:
     """
     Parse macro environment JSON into dict. To make this work use the icpconfigGetMacros program.
 
@@ -47,7 +53,7 @@ def get_macro_values():
 motor_in_set_mode = g.adv.motor_in_set_mode
 
 
-def _get_env_var(name):
+def _get_env_var(name: str) -> str:
     try:
         return os.environ[name]
     except:

--- a/server_common/mocks/mock_procserv_utils.py
+++ b/server_common/mocks/mock_procserv_utils.py
@@ -1,20 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-# This file is part of the ISIS IBEX application.
-# Copyright (C) 2012-2016 Science & Technology Facilities Council.
-# All rights reserved.
-#
-# This program is distributed in the hope that it will be useful.
-# This program and the accompanying materials are made available under the
-# terms of the Eclipse Public License v1.0 which accompanies this distribution.
-# EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM
-# AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
-# OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
-#
-# You should have received a copy of the Eclipse Public License v1.0
-# along with this program; if not, you can obtain a copy from
-# https://www.eclipse.org/org/documents/epl-v10.php or
-# http://opensource.org/licenses/eclipse-1.0.php
+from __future__ import division, absolute_import, print_function, unicode_literals
 
 
 class MockProcServWrapper(object):

--- a/server_common/mocks/mock_procserv_utils.py
+++ b/server_common/mocks/mock_procserv_utils.py
@@ -1,4 +1,4 @@
-from __future__ import division, absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 
 class MockProcServWrapper(object):

--- a/server_common/test_modules/test_ioc_data.py
+++ b/server_common/test_modules/test_ioc_data.py
@@ -16,7 +16,7 @@
 
 import unittest
 
-from DatabaseServer.mocks.mock_procserv_utils import MockProcServWrapper
+from server_common.mocks.mock_procserv_utils import MockProcServWrapper
 from server_common.ioc_data import IOCData
 from server_common.mocks.mock_ioc_data_source import (
     BL_PVS,

--- a/server_common/test_modules/test_ioc_data.py
+++ b/server_common/test_modules/test_ioc_data.py
@@ -16,7 +16,6 @@
 
 import unittest
 
-from server_common.mocks.mock_procserv_utils import MockProcServWrapper
 from server_common.ioc_data import IOCData
 from server_common.mocks.mock_ioc_data_source import (
     BL_PVS,
@@ -28,6 +27,7 @@ from server_common.mocks.mock_ioc_data_source import (
     USER_PVS,
     MockIocDataSource,
 )
+from server_common.mocks.mock_procserv_utils import MockProcServWrapper
 
 
 class TestIocDataSequence(unittest.TestCase):


### PR DESCRIPTION
### Description of work

Closes #418 

This removes where `server_common` depends on things like the blockserver, dbserver - it should only be the other way around. 

### To test

unit tests pass, blockserver and dbserver still work

### Acceptance criteria

see "to test"

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
