### PR TITLE
Increase start timeout

### DIFF
--- a/BlockServer/core/ioc_control.py
+++ b/BlockServer/core/ioc_control.py
@@ -195,8 +195,11 @@ class IocControl:
         except Exception as err:
             print_and_log(f"Could not get auto-restart setting for IOC {ioc}: {err}", "MAJOR")
 
-    def waitfor_running(self, ioc: str, timeout: int = 5) -> None:
+    def waitfor_running(self, ioc: str, timeout: int = 15) -> None:
         """Waits for the IOC to start running.
+           we may need to wait for procServ to lauch, asyn to connect and PSCTR
+           to report which can take up to 15 seconds - however once procServ is
+           running it will be much quicker
 
         Args:
             ioc (string): The name of the IOC
@@ -207,5 +210,5 @@ class IocControl:
             while self.ioc_restart_pending(ioc) or self.get_ioc_status(ioc) != "RUNNING":
                 sleep(0.5)
                 if time() - start >= timeout:
-                    print_and_log(f"Gave up waiting for IOC {ioc} to be running", "MAJOR")
+                    print_and_log(f"Gave up waiting for IOC {ioc} to be running after {timeout} seconds", "MAJOR")
                     return


### PR DESCRIPTION
### Description of work

Increase startup timeout to avoid error messages like
```
MAJOR: Gave up waiting for IOC GALIL_01 to be running
INFO: Auto-restart for IOC GALIL_01 unchanged as IOC is not running
```

this is due to delayed launch of procServ, 5 seconds is not long enough to wait.  

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
