### PR TITLE
if on HIFI use supermusr redpanda cluster, else use livedata

### DIFF
--- a/start_bs_to_kafka_cmd.bat
+++ b/start_bs_to_kafka_cmd.bat
@@ -9,5 +9,13 @@ set EPICS_CAS_INTF_ADDR_LIST=127.0.0.1
 set EPICS_CAS_BEACON_ADDR_LIST=127.255.255.255
 
 set PYTHONUNBUFFERED=TRUE
+
+
+if "%INSTRUMENT%" == "NDXHIFI" (
+    set "BROKER=130.246.55.29:9092"
+) else (
+    set "BROKER=livedata.isis.cclrc.ac.uk:31092"
+)
+
 @echo %DATE% %TIME% starting BS to Kafka 
-%PYTHON3W% %MYDIRCD%\BlockServerToKafka\main.py -d %INSTRUMENT%_sampleEnv -c forwarder_config -b livedata.isis.cclrc.ac.uk:31092 -p %MYPVPREFIX%
+%PYTHON3W% %MYDIRCD%\BlockServerToKafka\main.py -d %INSTRUMENT%_sampleEnv -c %INSTRUMENT%_forwarderConfig -b %BROKER% -p %MYPVPREFIX%

--- a/start_bs_to_kafka_cmd.bat
+++ b/start_bs_to_kafka_cmd.bat
@@ -11,7 +11,7 @@ set EPICS_CAS_BEACON_ADDR_LIST=127.255.255.255
 set PYTHONUNBUFFERED=TRUE
 
 
-if "%INSTRUMENT%" == "NDXHIFI" (
+if "%INSTRUMENT%" == "HIFI" (
     set "BROKER=130.246.55.29:9092"
 ) else (
     set "BROKER=livedata.isis.cclrc.ac.uk:31092"


### PR DESCRIPTION
### Description of work

This is currently patched on HIFI but we'll lose the change on next deploy, so this needs to be merged before release so we don't have to patch it again.

### To test

Check batch logic looks correct. 

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
