### PR TITLE
Forward inst PVs

### DIFF
--- a/BlockServerToKafka/block_server_monitor.py
+++ b/BlockServerToKafka/block_server_monitor.py
@@ -97,7 +97,7 @@ class BlockServerMonitor:
 
         pvs = [self.block_name_to_pv_name(blk) for blk in blocks]
         if pvs != self.last_pvs:
-            print_and_log(f"Configuration changed to: {pvs}")
+            print_and_log(f"Blocks configuration changed to: {pvs}")
             self.producer.remove_config(self.last_pvs)
             self.producer.add_config(pvs)
             self.last_pvs = pvs

--- a/BlockServerToKafka/inst_pvs.py
+++ b/BlockServerToKafka/inst_pvs.py
@@ -1,0 +1,36 @@
+import threading
+
+from genie_python.mysql_abstraction_layer import SQLAbstraction
+from server_common.utilities import print_and_log
+
+from BlockServerToKafka.kafka_producer import ProducerWrapper
+
+
+class InstPVs(object):
+    def __init__(self, producer: ProducerWrapper) -> None:
+        self._pvs = []
+        self._sql = SQLAbstraction(
+            dbid="iocdb", user="report", password="$report", host="localhost"
+        )
+        self.producer = producer
+
+    def schedule(self) -> None:
+        def action() -> None:
+            self._work()
+            self.schedule()
+
+        job = threading.Timer(30.0, action)
+        job.start()
+
+    def _work(self) -> None:
+        pvs = self._sql.query('SELECT pvname FROM iocdb.pvinfo WHERE infoname="archive";')
+        if pvs is None:
+            return
+
+        pvs = [pv[0] for pv in pvs]
+
+        if set(self._pvs) != set(pvs):
+            print_and_log(f"Inst configuration changed to: {pvs}")
+            self.producer.remove_config(self._pvs)
+            self.producer.add_config(pvs)
+            self._pvs = pvs

--- a/BlockServerToKafka/inst_pvs.py
+++ b/BlockServerToKafka/inst_pvs.py
@@ -1,3 +1,4 @@
+import typing
 from threading import Timer
 
 from genie_python.mysql_abstraction_layer import SQLAbstraction
@@ -10,7 +11,7 @@ class InstPVs(object):
     def __init__(
         self, producer: ProducerWrapper, sql_abstraction: SQLAbstraction | None = None
     ) -> None:
-        self._pvs = []
+        self._pvs: list[str] = []
         self._sql = (
             SQLAbstraction(dbid="iocdb", user="report", password="$report", host="localhost")
             if sql_abstraction is None
@@ -31,7 +32,7 @@ class InstPVs(object):
         if pvs is None:
             return
 
-        pvs = [pv[0] for pv in pvs]
+        pvs = typing.cast(list[str], [pv[0] for pv in pvs])
 
         if set(self._pvs) != set(pvs):
             print_and_log(f"Inst configuration changed to: {pvs}")

--- a/BlockServerToKafka/inst_pvs.py
+++ b/BlockServerToKafka/inst_pvs.py
@@ -6,6 +6,8 @@ from server_common.utilities import print_and_log
 
 from BlockServerToKafka.kafka_producer import ProducerWrapper
 
+UPDATE_FREQUENCY_S = 30.0
+
 
 class InstPVs(object):
     def __init__(
@@ -24,7 +26,7 @@ class InstPVs(object):
             self.update_pvs_from_mysql()
             self.schedule()
 
-        job = Timer(30.0, action)
+        job = Timer(UPDATE_FREQUENCY_S, action)
         job.start()
 
     def update_pvs_from_mysql(self) -> None:

--- a/BlockServerToKafka/main.py
+++ b/BlockServerToKafka/main.py
@@ -23,6 +23,7 @@ from os import environ
 from time import sleep
 
 from BlockServerToKafka.block_server_monitor import BlockServerMonitor
+from BlockServerToKafka.inst_pvs import InstPVs
 from BlockServerToKafka.kafka_producer import ProducerWrapper
 
 if __name__ == "__main__":
@@ -72,6 +73,7 @@ if __name__ == "__main__":
     KAFKA_BROKER = args.broker
     PREFIX = args.pvprefix
     block_producer = ProducerWrapper(KAFKA_BROKER, KAFKA_CONFIG, KAFKA_DATA)
+    inst_producer = ProducerWrapper(KAFKA_BROKER, KAFKA_CONFIG, KAFKA_DATA)
     monitor = BlockServerMonitor(f"{PREFIX}CS:BLOCKSERVER:BLOCKNAMES", PREFIX, block_producer)
     runlog_producer = ProducerWrapper(KAFKA_BROKER, KAFKA_CONFIG, KAFKA_RUNLOG)
 
@@ -92,6 +94,8 @@ if __name__ == "__main__":
             # todo how should we do run_status/icp_event/is_running/is_waiting?
         ]
     )
+
+    InstPVs(inst_producer).schedule()
 
     while True:
         sleep(0.1)

--- a/BlockServerToKafka/test_modules/test_inst_pvs.py
+++ b/BlockServerToKafka/test_modules/test_inst_pvs.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from BlockServerToKafka.inst_pvs import InstPVs
+
+
+class TestInstPVs(unittest.TestCase):
+    def test_calling_start_schedules_timer(self):
+        with patch("BlockServerToKafka.inst_pvs.Timer") as timer:
+            InstPVs(MagicMock(), MagicMock()).schedule()
+
+        timer.assert_called_once()
+        timer.return_value.start.assert_called_once()
+
+    def test_update_pvs_from_mysql(self):
+        mock_sql = MagicMock()
+        mock_sql.query.return_value = [("pv1",), ("pv2",), ("pv3",)]
+
+        mock_producer = MagicMock()
+
+        inst_pvs = InstPVs(mock_producer, mock_sql)
+        inst_pvs.update_pvs_from_mysql()
+
+        mock_producer.remove_config.assert_called_once_with([])
+        mock_producer.add_config.assert_called_once_with(["pv1", "pv2", "pv3"])
+
+        # Check that more calls where SQL query returns the same thing
+        # don't cause extra updates
+        inst_pvs.update_pvs_from_mysql()
+        assert mock_producer.remove_config.call_count == 1
+        assert mock_producer.add_config.call_count == 1
+
+        # If SQL call does return something different then should update
+        mock_sql.query.return_value = [("new_pv1",), ("new_pv2",)]
+        inst_pvs.update_pvs_from_mysql()
+        mock_producer.remove_config.assert_called_with(["pv1", "pv2", "pv3"])
+        mock_producer.add_config.assert_called_with(["new_pv1", "new_pv2"])

--- a/BlockServerToKafka/test_modules/test_inst_pvs.py
+++ b/BlockServerToKafka/test_modules/test_inst_pvs.py
@@ -14,7 +14,7 @@ class TestInstPVs(unittest.TestCase):
 
     def test_update_pvs_from_mysql(self):
         mock_sql = MagicMock()
-        mock_sql.query.return_value = [("pv1",), ("pv2",), ("pv3",)]
+        mock_sql.query.return_value = [("pv1", "VAL"), ("pv2", "VAL RBV"), ("pv3", "5.0 VAL")]
 
         mock_producer = MagicMock()
 
@@ -22,16 +22,21 @@ class TestInstPVs(unittest.TestCase):
         inst_pvs.update_pvs_from_mysql()
 
         mock_producer.remove_config.assert_called_once_with([])
-        mock_producer.add_config.assert_called_once_with(["pv1", "pv2", "pv3"])
+        self.assertCountEqual(
+            mock_producer.add_config.call_args.args[0], ["pv1.VAL", "pv2.VAL", "pv2.RBV", "pv3.VAL"]
+        )
 
         # Check that more calls where SQL query returns the same thing
         # don't cause extra updates
         inst_pvs.update_pvs_from_mysql()
-        assert mock_producer.remove_config.call_count == 1
-        assert mock_producer.add_config.call_count == 1
+        self.assertEqual(mock_producer.remove_config.call_count, 1)
+        self.assertEqual(mock_producer.add_config.call_count, 1)
 
         # If SQL call does return something different then should update
-        mock_sql.query.return_value = [("new_pv1",), ("new_pv2",)]
+        mock_sql.query.return_value = [("new_pv1", "VAL"), ("pv2", "VAL")]
         inst_pvs.update_pvs_from_mysql()
-        mock_producer.remove_config.assert_called_with(["pv1", "pv2", "pv3"])
-        mock_producer.add_config.assert_called_with(["new_pv1", "new_pv2"])
+
+        self.assertCountEqual(
+            mock_producer.remove_config.call_args.args[0], ["pv1.VAL", "pv2.RBV", "pv3.VAL"]
+        )
+        self.assertCountEqual(mock_producer.add_config.call_args.args[0], ["new_pv1.VAL"])


### PR DESCRIPTION
### Description of work

Forward the PVs that the inst archiver would have stored, in addition to blocks.

This isn't quite fully equivalent - it doesn't handle archive specifications like `info(archive, "VAL RBV 5.0")` - it always just stores `VAL` on the base PV.

### To test

*Which ticket does this PR fix?*

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
