### PR TITLE
Update set_instrument_list.py

### DIFF
--- a/scripts/set_instrument_list.py
+++ b/scripts/set_instrument_list.py
@@ -191,6 +191,7 @@ if __name__ == "__main__":
         inst_dictionary("MERLIN", groups=[EXCITATIONS], target_station=TS1),
         inst_dictionary("RIKENFE", groups=[MUONS], is_scheduled=False, target_station=MUON_TARGET),
         inst_dictionary("SELAB", groups=[SUPPORT], is_scheduled=False, target_station=MISC),
+        inst_dictionary("SELAB2", groups=[SUPPORT], is_scheduled=False, target_station=MISC),
         inst_dictionary("EMMA-A", groups=[SUPPORT], is_scheduled=False, target_station=TS1),
         inst_dictionary("EMMA-B", groups=[SUPPORT], is_scheduled=False, target_station=TS1),
         inst_dictionary("SANDALS", groups=[DISORDERED], target_station=TS1),


### PR DESCRIPTION
add selab2 to inst list. 

Deploy server testing phase fails on SELAB2, I believe this is why. If it needs sorting elsewhere, please let me know - I have limited knowledge of this area. 

### Description of work

*Add your own description here*

### To test

*Which ticket does this PR fix?*

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Has the author taken into account the multi-threaded nature of the code?
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
